### PR TITLE
Name-clash avoidance: the adapter owns its default and what BY_ADAPTER means

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -144,13 +144,32 @@ old one.
 ### Name-clash avoidance (`NameClashAvoidanceSupport`)
 
 One adapter-scoped property decides how a workflow module's identifiers are kept
-apart from another module's: `name-clash-avoidance` = `BY_ADAPTER` (default,
-VanillaBP 1's behavior — the BPMS' own isolation, e.g. a tenant named after the
-module) | `USE_PREFIX` (no tenant; VanillaBP prefixes the identifiers, separator
-`__`) | `NONE`. The core owns both the resolution (most-specific-wins across
-workflow > workflow module > adapter) and the composition of the strings
+apart from another module's: `name-clash-avoidance` = `BY_ADAPTER` (VanillaBP 1's
+behavior — the BPMS' own isolation, e.g. a tenant named after the module) |
+`USE_PREFIX` (no tenant; VanillaBP prefixes the identifiers, separator `__`) |
+`NONE`. The core owns both the resolution (most-specific-wins across workflow >
+workflow module > adapter) and the composition of the strings
 (`NameClashAvoidanceService implements NameClashAvoidanceSupport`, handed to every
-adapter as a platform bean). An adapter only decides WHERE to apply the result:
+adapter as a platform bean).
+
+Without any configuration the ADAPTER's default applies
+(`AdapterDeploymentService#defaultNameClashAvoidance`, `BY_ADAPTER` unless
+overridden): a BPMS which isolates out of the box keeps version 1's behavior, while
+Camunda 8 defaults to `NONE` because a cluster started from the stock image has
+multi-tenancy switched off and rejects a deploy command carrying a tenant id, so an
+application configuring nothing would not even boot. The platform integrations
+therefore hand the adapters' deployment services to the service as a lazily resolved
+supplier (adapters receive the service themselves, so they cannot be injected).
+
+Since `NONE` protects nothing, the core has the ADAPTER report it once per workflow
+module and adapter id while the mode is resolved, i.e. at startup
+(`AdapterDeploymentService#warnAboutUnscopedIdentifiers`). What can be used instead
+is BPMS knowledge: Camunda 8 offers prefixing, a tenant per module on a
+multi-tenancy cluster or a cluster per module, Camunda 7 offers prefixing, a tenant
+per module or an engine per module (`data-source-name`, `table-prefix`). The default
+implementation names what every BPMS can offer.
+
+An adapter only decides WHERE to apply the result:
 
 - in `prepareBpmn`, on its own model type — only the adapter knows it. Note the
   pipeline calls `prepareBpmn` once per PROCESS while all processes of a file share

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -154,12 +154,29 @@ adapter as a platform bean).
 
 Without any configuration the ADAPTER's default applies
 (`AdapterDeploymentService#defaultNameClashAvoidance`, `BY_ADAPTER` unless
-overridden): a BPMS which isolates out of the box keeps version 1's behavior, while
-Camunda 8 defaults to `NONE` because a cluster started from the stock image has
-multi-tenancy switched off and rejects a deploy command carrying a tenant id, so an
-application configuring nothing would not even boot. The platform integrations
-therefore hand the adapters' deployment services to the service as a lazily resolved
-supplier (adapters receive the service themselves, so they cannot be injected).
+overridden). Both Camunda adapters override it with `NONE`: a Camunda 8 cluster
+started from the stock image has multi-tenancy switched off and rejects a deploy
+command carrying a tenant id, and Camunda 7 offers more than one mechanism (a tenant,
+prefixes, an engine per module), so neither presumes one. The platform integrations
+hand the adapters' deployment services to the service as a lazily resolved supplier
+(adapters receive the service themselves, so they cannot be injected).
+
+`BY_ADAPTER` means "the BPMS' own isolation", and what that IS the core does not know
+(a tenant, a namespace, a database of its own). It therefore computes none of it: the
+adapters derive the tenant themselves from the resolved mode (`Camunda8Scoping` and
+`Camunda7Scoping`, duplicated on purpose - the rule is one line and the concept is
+theirs). The core answers `modeFor` and nothing else.
+
+The same split holds for validating: an adapter which carries configuration only
+BY_ADAPTER could honor hands the PROPERTY KEY to `validateNoneNameClashStrategy`, and
+the core answers whether BY_ADAPTER applies anywhere for that adapter - if it does
+not, the boot fails naming the property, the modes which do apply and the two ways to
+reconcile them. Both Camunda adapters pass their `tenant-id` this way.
+
+And for asking the BPMS itself: Camunda 8 looks the tenant up in the cluster before
+deploying (a cluster without multi-tenancy, or an unknown tenant, becomes a message
+naming the property to change), while Camunda 7 has nothing to ask - a tenant id is an
+attribute of the deployment there and the engine creates nothing.
 
 Since `NONE` protects nothing, the core has the ADAPTER report it once per workflow
 module and adapter id while the mode is resolved, i.e. at startup

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
@@ -21,8 +21,8 @@ public class AdapterProperties {
    * workflow modules (see
    * {@link io.vanillabp.integration.adapter.spi.NameClashAvoidance}). Adapter-scoped
    * and therefore resolvable per workflow module and workflow; <code>null</code>
-   * means "not configured at this level" (the default is
-   * {@link io.vanillabp.integration.adapter.spi.NameClashAvoidance#BY_ADAPTER}).
+   * means "not configured at this level" (the adapter's own default applies then, see
+   * {@link io.vanillabp.integration.adapter.spi.AdapterDeploymentService#defaultNameClashAvoidance()}).
    */
   private io.vanillabp.integration.adapter.spi.NameClashAvoidance nameClashAvoidance;
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/scoping/NameClashAvoidanceService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/scoping/NameClashAvoidanceService.java
@@ -3,10 +3,16 @@ package io.vanillabp.integration.adapter.migration.scoping;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.NameClashAvoidance;
 import io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport;
 
@@ -21,8 +27,16 @@ import io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport;
  * across workflow &gt; workflow module &gt; adapter
  * ({@link MigrationAdapterProperties#resolveForAdapter}) - which is what allows two
  * adapter ids to carry DIFFERENT modes for the same workflow module, the basis of
- * the migration path documented on {@link NameClashAvoidance}. The default is
- * {@link NameClashAvoidance#BY_ADAPTER}, VanillaBP 1's behavior.
+ * the migration path documented on {@link NameClashAvoidance}. Without any
+ * configuration the ADAPTER's default applies
+ * ({@link AdapterDeploymentService#defaultNameClashAvoidance()}):
+ * {@link NameClashAvoidance#BY_ADAPTER} - VanillaBP 1's behavior - for a BPMS which
+ * isolates out of the box, {@link NameClashAvoidance#NONE} for one which has to be
+ * set up for it first (Camunda 8 rejects tenant ids unless multi-tenancy is enabled).
+ * A resolved {@link NameClashAvoidance#NONE} is therefore reported once per workflow
+ * module and adapter by the adapter's own WARN
+ * ({@link AdapterDeploymentService#warnAboutUnscopedIdentifiers(String, boolean)}) -
+ * it protects nothing, and only the adapter knows what its BPMS offers instead.
  *
  * <h2>Composition and its inverse</h2>
  *
@@ -36,10 +50,48 @@ public class NameClashAvoidanceService implements NameClashAvoidanceSupport {
 
   private final MigrationAdapterProperties properties;
 
+  /**
+   * The adapters' deployment services, resolved LAZILY: every adapter receives this
+   * service, so it has to be constructible before any adapter exists. The result is
+   * cached once it is non-empty (an empty resolution means the adapter beans were
+   * not created yet).
+   */
+  private final Supplier<Collection<AdapterDeploymentService<?, ?>>> deploymentServices;
+
+  private volatile Map<String, AdapterDeploymentService<?, ?>> deploymentServicesByAdapterId;
+
+  /**
+   * The (workflow module, adapter) pairs already reported as unscoped - the mode is
+   * resolved on every runtime boundary, the WARN belongs to startup.
+   */
+  private final Set<String> unscopedReported = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Without the adapters' deployment services every adapter's default is
+   * {@link NameClashAvoidance#BY_ADAPTER} and no adapter can report an unscoped
+   * workflow module - for tests and for platforms not passing them.
+   *
+   * @param properties The VanillaBP configuration
+   */
   public NameClashAvoidanceService(
       final MigrationAdapterProperties properties) {
 
+    this(properties, List::of);
+
+  }
+
+  /**
+   * @param properties The VanillaBP configuration
+   * @param deploymentServices The adapters' deployment services, asked for their
+   *          default mode and for reporting a workflow module whose identifiers are
+   *          not scoped. Invoked on first use, never during construction.
+   */
+  public NameClashAvoidanceService(
+      final MigrationAdapterProperties properties,
+      final Supplier<Collection<AdapterDeploymentService<?, ?>>> deploymentServices) {
+
     this.properties = properties;
+    this.deploymentServices = deploymentServices;
 
   }
 
@@ -49,18 +101,92 @@ public class NameClashAvoidanceService implements NameClashAvoidanceSupport {
       final String bpmnProcessId,
       final String adapterId) {
 
-    if (properties == null) {
-      return NameClashAvoidance.BY_ADAPTER;
-    }
-    final var configured = properties.resolveForAdapter(
-        workflowModuleId,
-        bpmnProcessId,
-        null,
-        adapterId,
-        AdapterProperties::getNameClashAvoidance);
-    return configured != null
+    final var configured = properties != null
+        ? properties.resolveForAdapter(
+            workflowModuleId,
+            bpmnProcessId,
+            null,
+            adapterId,
+            AdapterProperties::getNameClashAvoidance)
+        : null;
+    final var mode = configured != null
         ? configured
+        : defaultModeFor(adapterId);
+    if (mode == NameClashAvoidance.NONE) {
+      reportUnscopedIdentifiers(adapterId, workflowModuleId, configured == null);
+    }
+    return mode;
+
+  }
+
+  /**
+   * The mode applying to the given adapter without any configuration - the adapter's
+   * own default, {@link NameClashAvoidance#BY_ADAPTER} for an adapter which is
+   * unknown here (see {@link #deploymentServices}).
+   */
+  private NameClashAvoidance defaultModeFor(
+      final String adapterId) {
+
+    final var deploymentService = deploymentServiceOf(adapterId);
+    final var adapterDefault = deploymentService != null
+        ? deploymentService.defaultNameClashAvoidance()
+        : null;
+    return adapterDefault != null
+        ? adapterDefault
         : NameClashAvoidance.BY_ADAPTER;
+
+  }
+
+  /**
+   * Lets the adapter report the workflow module as unscoped, once per workflow module
+   * and adapter id. Resolving a mode without a workflow module (e.g. while comparing
+   * two adapter instances) reports nothing - the per-module resolutions of the
+   * deployment do.
+   */
+  private void reportUnscopedIdentifiers(
+      final String adapterId,
+      final String workflowModuleId,
+      final boolean fromDefault) {
+
+    if ((workflowModuleId == null) || (adapterId == null)) {
+      return;
+    }
+    final var deploymentService = deploymentServiceOf(adapterId);
+    if (deploymentService == null) {
+      return;
+    }
+    if (!unscopedReported.add("%s@%s".formatted(workflowModuleId, adapterId))) {
+      return;
+    }
+    deploymentService.warnAboutUnscopedIdentifiers(workflowModuleId, fromDefault);
+
+  }
+
+  private AdapterDeploymentService<?, ?> deploymentServiceOf(
+      final String adapterId) {
+
+    var byAdapterId = deploymentServicesByAdapterId;
+    if (byAdapterId == null) {
+      synchronized (this) {
+        byAdapterId = deploymentServicesByAdapterId;
+        if (byAdapterId == null) {
+          final var collected = new LinkedHashMap<String, AdapterDeploymentService<?, ?>>();
+          final var resolved = deploymentServices.get();
+          if (resolved != null) {
+            resolved
+                .stream()
+                .filter(java.util.Objects::nonNull)
+                .forEach(service -> collected.putIfAbsent(service.getAdapterId(), service));
+          }
+          byAdapterId = collected;
+          if (!collected.isEmpty()) {
+            // an empty result means the adapters were not created yet - ask again
+            deploymentServicesByAdapterId = collected;
+          }
+        }
+      }
+    }
+    return byAdapterId.get(adapterId);
 
   }
 
@@ -347,14 +473,15 @@ public class NameClashAvoidanceService implements NameClashAvoidanceSupport {
   }
 
   /**
-   * Whether the adapter has NO mode configured at all - the default
-   * ({@link NameClashAvoidance#BY_ADAPTER}) then applies, which an adapter without
-   * native isolation cannot serve either.
+   * Whether the adapter has NO mode configured at all AND defaults to
+   * {@link NameClashAvoidance#BY_ADAPTER} - which an adapter without native isolation
+   * cannot serve either. An adapter defaulting to another mode is unaffected.
    */
   private Collection<String> unconfiguredLevels(
       final String adapterId) {
 
-    if ((properties == null) || (valueOfAdapterLevel(adapterId) != null)) {
+    if ((properties == null) || (valueOfAdapterLevel(adapterId) != null) || (defaultModeFor(
+        adapterId) != NameClashAvoidance.BY_ADAPTER)) {
       return java.util.List.of();
     }
     return java.util.List.of("vanillabp.adapters.%s (nothing configured, the default applies)".formatted(adapterId));

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/scoping/NameClashAvoidanceService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/scoping/NameClashAvoidanceService.java
@@ -305,20 +305,96 @@ public class NameClashAvoidanceService implements NameClashAvoidanceSupport {
   }
 
   @Override
-  public String tenantIdFor(
-      final String workflowModuleId,
-      final String bpmnProcessId,
+  public void validateNoneNameClashStrategy(
       final String adapterId,
-      final String configuredTenantId) {
+      final String byAdapterOnlyPropertyKey) {
 
-    if (modeFor(workflowModuleId, bpmnProcessId, adapterId) != NameClashAvoidance.BY_ADAPTER) {
-      // NONE: no tenant at all; USE_PREFIX: the prefix IS the isolation - using a
-      // tenant on top would defeat the purpose (BPMS are licensed per tenant)
-      return null;
+    if ((byAdapterOnlyPropertyKey == null) || byAdapterOnlyPropertyKey.isBlank()) {
+      return;
     }
-    return (configuredTenantId != null) && !configuredTenantId.isBlank()
-        ? configuredTenantId
-        : workflowModuleId;
+    if (appliesByAdapterAnywhere(adapterId)) {
+      return;
+    }
+    throw new IllegalStateException(
+        """
+            The property '%s' is configured, but nothing can use it: it takes effect only \
+            where the name-clash-avoidance mode is 'by-adapter' - the BPMS' own isolation - \
+            and the mode applying to adapter '%s' is %s. The two contradict each other, so \
+            choose the one you mean:
+              - remove '%s' if the workflow modules are not meant to be kept apart by the BPMS itself, or
+              - vanillabp.adapters.%s.name-clash-avoidance: by-adapter   # let the BPMS keep them apart
+            The mode may also be set per workflow module \
+            (vanillabp.workflow-modules.<module>.adapters.%s.name-clash-avoidance), which is \
+            enough to put the property to use for that module."""
+            .formatted(
+                byAdapterOnlyPropertyKey,
+                adapterId,
+                modesApplying(adapterId),
+                byAdapterOnlyPropertyKey,
+                adapterId,
+                adapterId));
+
+  }
+
+  /**
+   * Whether {@link NameClashAvoidance#BY_ADAPTER} applies anywhere for the given
+   * adapter, i.e. whether any workflow module is kept apart by the BPMS itself:
+   * configured at some level, or the adapter's default while at least one level leaves
+   * the mode unconfigured.
+   */
+  private boolean appliesByAdapterAnywhere(
+      final String adapterId) {
+
+    if (properties == null) {
+      return true; // nothing is known about the configuration, so nothing is claimed
+    }
+    if (!levelsConfiguring(adapterId, NameClashAvoidance.BY_ADAPTER).isEmpty()) {
+      return true;
+    }
+    if (valueOfAdapterLevel(adapterId) != null) {
+      return false; // configured, and it is not BY_ADAPTER (that was checked above)
+    }
+    if (defaultModeFor(adapterId) != NameClashAvoidance.BY_ADAPTER) {
+      return false;
+    }
+    // the adapter's default applies wherever no level overrides it
+    final var modules = properties.getWorkflowModules();
+    return modules.isEmpty() || modules
+        .values()
+        .stream()
+        .anyMatch(module -> valueOf(module.getAdapters(), adapterId) == null);
+
+  }
+
+  /**
+   * The modes applying to the given adapter, for messages: the values configured at any
+   * level plus the adapter's default where nothing is configured.
+   */
+  private String modesApplying(
+      final String adapterId) {
+
+    final var modes = new java.util.TreeSet<String>();
+    for (final var mode : NameClashAvoidance.values()) {
+      if (!levelsConfiguring(adapterId, mode).isEmpty()) {
+        modes.add(nameOf(mode));
+      }
+    }
+    if ((properties == null) || (valueOfAdapterLevel(adapterId) == null)) {
+      modes.add(nameOf(defaultModeFor(adapterId)));
+    }
+    return modes
+        .stream()
+        .collect(Collectors.joining("' and '", "'", "'"));
+
+  }
+
+  private static String nameOf(
+      final NameClashAvoidance mode) {
+
+    return mode
+        .name()
+        .toLowerCase()
+        .replace('_', '-');
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/scoping/NameClashAvoidanceServiceTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/scoping/NameClashAvoidanceServiceTest.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
 import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
@@ -18,6 +19,7 @@ import io.vanillabp.integration.adapter.migration.config.MigrationAdapterPropert
 import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
 import io.vanillabp.integration.adapter.migration.scoping.NameClashAvoidanceService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.NameClashAvoidance;
 import io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport;
 import io.vanillabp.integration.test.utils.SuppressOutputExtension;
@@ -40,7 +42,7 @@ public class NameClashAvoidanceServiceTest {
    * Properties with a mode at the adapter level and, optionally, overrides per
    * workflow module and workflow.
    */
-  private static NameClashAvoidanceService serviceWith(
+  private static MigrationAdapterProperties propertiesWith(
       final NameClashAvoidance adapterLevel,
       final NameClashAvoidance moduleLevel,
       final NameClashAvoidance workflowLevel,
@@ -68,7 +70,18 @@ public class NameClashAvoidanceServiceTest {
         .workflowModules(Map.of(MODULE, module))
         .build();
     properties.validateAndLink();
-    return new NameClashAvoidanceService(properties);
+    return properties;
+
+  }
+
+  private static NameClashAvoidanceService serviceWith(
+      final NameClashAvoidance adapterLevel,
+      final NameClashAvoidance moduleLevel,
+      final NameClashAvoidance workflowLevel,
+      final Boolean prefixTaskDefinitionsPerProcess) {
+
+    return new NameClashAvoidanceService(
+        propertiesWith(adapterLevel, moduleLevel, workflowLevel, prefixTaskDefinitionsPerProcess));
 
   }
 
@@ -76,6 +89,43 @@ public class NameClashAvoidanceServiceTest {
       final NameClashAvoidance adapterLevel) {
 
     return serviceWith(adapterLevel, null, null, null);
+
+  }
+
+  /**
+   * An adapter of the id {@link #ADAPTER} declaring the given default mode
+   * (<code>null</code> for an adapter which declares none).
+   */
+  @SuppressWarnings("unchecked")
+  private static AdapterDeploymentService<Object, Object> adapterDeclaring(
+      final NameClashAvoidance defaultMode) {
+
+    final AdapterDeploymentService<Object, Object> deploymentService = Mockito
+        .mock(AdapterDeploymentService.class);
+    Mockito
+        .lenient()
+        .when(deploymentService.getAdapterId())
+        .thenReturn(ADAPTER);
+    Mockito
+        .lenient()
+        .when(deploymentService.defaultNameClashAvoidance())
+        .thenReturn(defaultMode);
+    return deploymentService;
+
+  }
+
+  /**
+   * A service knowing the adapter's deployment service - the shape both platform
+   * integrations wire up (the adapter is asked for its default mode and reports a
+   * workflow module whose identifiers are not scoped).
+   */
+  private static NameClashAvoidanceService serviceWith(
+      final NameClashAvoidance adapterLevel,
+      final AdapterDeploymentService<Object, Object> deploymentService) {
+
+    return new NameClashAvoidanceService(
+        propertiesWith(adapterLevel, null, null,
+            null), () -> List.<AdapterDeploymentService<?, ?>>of(deploymentService));
 
   }
 
@@ -258,6 +308,80 @@ public class NameClashAvoidanceServiceTest {
     // ... and a module using a supported mode passes even though another one does not
     serviceWith(NameClashAvoidance.BY_ADAPTER, NameClashAvoidance.USE_PREFIX, null, null)
         .validateNativeIsolationSupported(ADAPTER, MODULE, "the Process-Engine-API");
+
+  }
+
+  @Test
+  @DisplayName("Without configuration the ADAPTER's own default applies")
+  public void adapterDefaultApplies() {
+
+    // an adapter whose BPMS has to be set up for isolation first (Camunda 8)
+    assertEquals(
+        NameClashAvoidance.NONE,
+        serviceWith(null, adapterDeclaring(NameClashAvoidance.NONE)).modeFor(MODULE, PROCESS, ADAPTER));
+    // ... which a configured mode still overrules
+    assertEquals(
+        NameClashAvoidance.USE_PREFIX,
+        serviceWith(NameClashAvoidance.USE_PREFIX, adapterDeclaring(NameClashAvoidance.NONE))
+            .modeFor(MODULE, PROCESS, ADAPTER));
+    // an adapter declaring no default keeps version 1's behavior ...
+    assertEquals(
+        NameClashAvoidance.BY_ADAPTER,
+        serviceWith(null, adapterDeclaring(null)).modeFor(MODULE, PROCESS, ADAPTER));
+    // ... as does an adapter unknown to the service (tests, platforms not wiring them)
+    assertEquals(NameClashAvoidance.BY_ADAPTER, serviceWith(null).modeFor(MODULE, PROCESS, ADAPTER));
+
+  }
+
+  @Test
+  @DisplayName("NONE is reported by the ADAPTER, once per workflow module and adapter id")
+  public void noneIsReportedByTheAdapter() {
+
+    final var byDefault = adapterDeclaring(NameClashAvoidance.NONE);
+    final var testee = serviceWith(null, byDefault);
+
+    // the mode is resolved again at every boundary, the WARN belongs to startup
+    testee.modeFor(MODULE, PROCESS, ADAPTER);
+    testee.modeFor(MODULE, PROCESS, ADAPTER);
+    Mockito
+        .verify(byDefault, Mockito.times(1))
+        .warnAboutUnscopedIdentifiers(MODULE, true);
+
+    // every workflow module is reported on its own ...
+    testee.modeFor("other-module", null, ADAPTER);
+    Mockito
+        .verify(byDefault, Mockito.times(1))
+        .warnAboutUnscopedIdentifiers("other-module", true);
+    // ... while resolving the mode without one reports nothing (e.g. comparing two
+    // adapter instances) - the per-module resolutions of the deployment do
+    testee.modeFor(null, null, ADAPTER);
+    Mockito
+        .verify(byDefault, Mockito.never())
+        .warnAboutUnscopedIdentifiers(Mockito.isNull(), Mockito.anyBoolean());
+
+    // a CONFIGURED 'none' is reported as well, but as a deliberate choice
+    final var configured = adapterDeclaring(NameClashAvoidance.BY_ADAPTER);
+    serviceWith(NameClashAvoidance.NONE, configured).modeFor(MODULE, PROCESS, ADAPTER);
+    Mockito
+        .verify(configured)
+        .warnAboutUnscopedIdentifiers(MODULE, false);
+
+    // the other modes protect the identifiers, so there is nothing to report
+    final var prefixing = adapterDeclaring(NameClashAvoidance.NONE);
+    serviceWith(NameClashAvoidance.USE_PREFIX, prefixing).modeFor(MODULE, PROCESS, ADAPTER);
+    Mockito
+        .verify(prefixing, Mockito.never())
+        .warnAboutUnscopedIdentifiers(Mockito.anyString(), Mockito.anyBoolean());
+
+  }
+
+  @Test
+  @DisplayName("An adapter without native isolation defaulting to NONE is not asked to choose")
+  public void unconfiguredLevelsHonorTheAdapterDefault() {
+
+    // nothing configured, so BY_ADAPTER never applies - no boot failure to raise
+    serviceWith(null, adapterDeclaring(NameClashAvoidance.NONE))
+        .validateNativeIsolationSupported(ADAPTER, null, "the Process-Engine-API");
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/scoping/NameClashAvoidanceServiceTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/scoping/NameClashAvoidanceServiceTest.java
@@ -136,11 +136,8 @@ public class NameClashAvoidanceServiceTest {
     final var testee = serviceWith(null);
 
     assertEquals(NameClashAvoidance.BY_ADAPTER, testee.modeFor(MODULE, PROCESS, ADAPTER));
-    // the tenant of BY_ADAPTER is the workflow module id ...
-    assertEquals(MODULE, testee.tenantIdFor(MODULE, PROCESS, ADAPTER, null));
-    // ... unless the adapter configured a name
-    assertEquals("banking", testee.tenantIdFor(MODULE, PROCESS, ADAPTER, "banking"));
-    // and nothing is prefixed
+    // nothing is prefixed - what BY_ADAPTER means for a BPMS (a tenant, a namespace)
+    // is the adapter's business
     assertEquals(PROCESS, testee.scopedProcessId(MODULE, PROCESS, ADAPTER));
 
   }
@@ -170,7 +167,7 @@ public class NameClashAvoidanceServiceTest {
   }
 
   @Test
-  @DisplayName("NONE scopes nothing and uses no tenant")
+  @DisplayName("NONE scopes nothing")
   public void noneScopesNothing() {
 
     final var testee = serviceWith(NameClashAvoidance.NONE);
@@ -178,13 +175,11 @@ public class NameClashAvoidanceServiceTest {
     assertEquals(PROCESS, testee.scopedProcessId(MODULE, PROCESS, ADAPTER));
     assertEquals("PaymentReceived", testee.scopedIdentifier(MODULE, "PaymentReceived", ADAPTER));
     assertEquals("scoreApplicant", testee.scopedTaskDefinition(MODULE, PROCESS, "scoreApplicant", ADAPTER));
-    assertNull(testee.tenantIdFor(MODULE, PROCESS, ADAPTER, null));
-    assertNull(testee.tenantIdFor(MODULE, PROCESS, ADAPTER, "banking"), "an explicit tenant does not revive tenants");
 
   }
 
   @Test
-  @DisplayName("USE_PREFIX composes module (and process for task definitions) - and uses no tenant")
+  @DisplayName("USE_PREFIX composes module (and process for task definitions)")
   public void prefixComposesIdentifiers() {
 
     final var testee = serviceWith(NameClashAvoidance.USE_PREFIX);
@@ -196,7 +191,6 @@ public class NameClashAvoidanceServiceTest {
         "loan-approval__RiskAssessment__scoreApplicant",
         testee.scopedTaskDefinition(MODULE, PROCESS, "scoreApplicant", ADAPTER),
         "task definitions are scoped per process by default");
-    assertNull(testee.tenantIdFor(MODULE, PROCESS, ADAPTER, "banking"), "the prefix IS the isolation - no tenant");
     // null identifiers stay null (an adapter may pass an absent value)
     assertNull(testee.scopedIdentifier(MODULE, null, ADAPTER));
     assertNull(testee.scopedTaskDefinition(MODULE, PROCESS, null, ADAPTER));
@@ -376,6 +370,43 @@ public class NameClashAvoidanceServiceTest {
   }
 
   @Test
+  @DisplayName("Configuration only BY_ADAPTER could use fails the boot naming both ways out")
+  public void byAdapterOnlyConfigurationWithoutByAdapterIsRejected() {
+
+    // what the setting IS stays with the adapter - here the Camunda tenant
+    final var tenantKey = "vanillabp.adapters.c8.tenant-id";
+
+    // the adapter defaults to NONE and nothing is configured, so the BPMS isolates nothing
+    final var exception = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> serviceWith(null, adapterDeclaring(NameClashAvoidance.NONE))
+            .validateNoneNameClashStrategy(ADAPTER, tenantKey));
+    final var message = exception.getMessage();
+    assertTrue(message.contains(tenantKey), () -> message);
+    assertTrue(message.contains("'none'"), () -> message);
+    assertTrue(message.contains("name-clash-avoidance: by-adapter"), () -> message);
+
+    // prefixing does not use the BPMS' own isolation either
+    assertThrowsExactly(
+        IllegalStateException.class,
+        () -> serviceWith(NameClashAvoidance.USE_PREFIX).validateNoneNameClashStrategy(ADAPTER, tenantKey));
+
+    // configured at the adapter level ...
+    serviceWith(NameClashAvoidance.BY_ADAPTER).validateNoneNameClashStrategy(ADAPTER, tenantKey);
+    // ... or for a single workflow module: the property is put to use there
+    serviceWith(NameClashAvoidance.NONE, NameClashAvoidance.BY_ADAPTER, null, null)
+        .validateNoneNameClashStrategy(ADAPTER, tenantKey);
+    // ... or by the adapter's default while no level overrides it
+    serviceWith(null, adapterDeclaring(NameClashAvoidance.BY_ADAPTER))
+        .validateNoneNameClashStrategy(ADAPTER, tenantKey);
+
+    // the adapter passes nothing, so there is nothing to contradict
+    serviceWith(NameClashAvoidance.NONE).validateNoneNameClashStrategy(ADAPTER, null);
+    serviceWith(NameClashAvoidance.NONE).validateNoneNameClashStrategy(ADAPTER, "  ");
+
+  }
+
+  @Test
   @DisplayName("An adapter without native isolation defaulting to NONE is not asked to choose")
   public void unconfiguredLevelsHonorTheAdapterDefault() {
 
@@ -393,7 +424,6 @@ public class NameClashAvoidanceServiceTest {
 
     assertEquals(NameClashAvoidance.BY_ADAPTER, testee.modeFor(MODULE, PROCESS, ADAPTER));
     assertEquals(PROCESS, testee.scopedProcessId(MODULE, PROCESS, ADAPTER));
-    assertEquals(MODULE, testee.tenantIdFor(MODULE, PROCESS, ADAPTER, null));
 
   }
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/AdapterDeploymentService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/AdapterDeploymentService.java
@@ -114,4 +114,75 @@ public interface AdapterDeploymentService<BPMN, PC> extends ExtensionWiringServi
 
   }
 
+  /**
+   * The {@link NameClashAvoidance} mode which applies to this adapter as long as the
+   * application configures none at any level. {@link NameClashAvoidance#BY_ADAPTER}
+   * - version 1's behavior - unless the adapter's BPMS makes another mode the better
+   * starting point: the Camunda 8 adapter defaults to
+   * {@link NameClashAvoidance#NONE} because a cluster started from the stock image
+   * has multi-tenancy switched off and rejects tenant ids, so an application
+   * configuring nothing would not even boot.
+   * <p>
+   * Whichever mode an adapter picks, the core keeps the choice visible:
+   * {@link NameClashAvoidance#NONE} is reported at startup by
+   * {@link #warnAboutUnscopedIdentifiers(String, boolean)}.
+   *
+   * @return The mode applying without configuration, never <code>null</code>
+   */
+  default NameClashAvoidance defaultNameClashAvoidance() {
+
+    return NameClashAvoidance.BY_ADAPTER;
+
+  }
+
+  /**
+   * Reports that a workflow module reaches this adapter's BPMS with
+   * {@link NameClashAvoidance#NONE}, so nothing keeps its identifiers apart from
+   * those of the other workflow modules. Called by the core once per workflow module
+   * and adapter id as soon as the mode is resolved (i.e. while deploying, at
+   * startup), no matter whether the mode was configured or is the adapter's
+   * {@link #defaultNameClashAvoidance() default}.
+   * <p>
+   * The message belongs to the ADAPTER because the alternatives do: Camunda 8 can
+   * prefix, use tenants (on a cluster with multi-tenancy enabled) or give a workflow
+   * module a cluster of its own, whereas Camunda 7 can prefix, use tenants or run a
+   * separate engine per module (<code>data-source-name</code>,
+   * <code>table-prefix</code>). The default names what every BPMS can offer -
+   * adapters override it to name their own options.
+   *
+   * @param workflowModuleId The workflow module whose identifiers are not scoped
+   * @param fromDefault Whether the mode is this adapter's default (nothing is
+   *          configured) rather than a configured value
+   */
+  default void warnAboutUnscopedIdentifiers(
+      final String workflowModuleId,
+      final boolean fromDefault) {
+
+    org.slf4j.LoggerFactory
+        .getLogger(getClass())
+        .warn(
+            """
+                Workflow module '{}' is deployed to adapter '{}' with name-clash-avoidance 'none'{}, \
+                so its BPMN process ids, message names and task definitions reach the BPMS as they \
+                are. Nothing protects them: a second workflow module using the same identifier \
+                addresses the same processes and tasks, and neither VanillaBP nor the BPMS can tell. \
+                Keep 'none' only as long as your identifiers are unique across ALL workflow modules \
+                of this application, otherwise choose:
+                  vanillabp.adapters.{}.name-clash-avoidance: use-prefix   # VanillaBP prefixes the identifiers with the workflow module id
+                  vanillabp.adapters.{}.name-clash-avoidance: by-adapter   # the BPMS' own isolation mechanism
+                The same key may be set per workflow module \
+                (vanillabp.workflow-modules.{}.adapters.{}.name-clash-avoidance). The mode is not a \
+                runtime switch - changing it once workflows are running is a BPMS migration.""",
+            workflowModuleId,
+            getAdapterId(),
+            fromDefault
+                ? " (nothing is configured, so the adapter's default applies)"
+                : "",
+            getAdapterId(),
+            getAdapterId(),
+            workflowModuleId,
+            getAdapterId());
+
+  }
+
 }

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidance.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidance.java
@@ -23,7 +23,12 @@ public enum NameClashAvoidance {
   /**
    * Nothing is scoped - the application guarantees that its identifiers are unique
    * across all of its workflow modules. The least surprising choice for an
-   * application consisting of exactly one workflow module.
+   * application consisting of exactly one workflow module, and the default of
+   * adapters whose BPMS cannot isolate without being set up for it (Camunda 8).
+   * <p>
+   * Since this mode protects nothing, every adapter reports it at startup per
+   * workflow module and names its own alternatives
+   * ({@link AdapterDeploymentService#warnAboutUnscopedIdentifiers(String, boolean)}).
    */
   NONE,
 
@@ -31,7 +36,8 @@ public enum NameClashAvoidance {
    * The BPMS' own isolation mechanism is used - for Camunda 7 and Camunda 8 a
    * TENANT named after the workflow module (the name is overridable by the
    * adapter's <code>tenant-id</code>). This is what VanillaBP 1 did, which is why
-   * it is the default.
+   * it is the default of every adapter whose BPMS isolates out of the box
+   * ({@link AdapterDeploymentService#defaultNameClashAvoidance()}).
    * <p>
    * An adapter whose BPMS has no such mechanism rejects this mode at startup with a
    * guiding message instead of silently deploying everything into one scope.

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidanceSupport.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidanceSupport.java
@@ -146,26 +146,31 @@ public interface NameClashAvoidanceSupport {
       String adapterId);
 
   /**
-   * The tenant a workflow module is deployed to under
-   * {@link NameClashAvoidance#BY_ADAPTER} - the workflow module ID unless the
-   * adapter configured an explicit name.
+   * Fails with a guiding message if the adapter carries configuration which only
+   * {@link NameClashAvoidance#BY_ADAPTER} could honor, although BY_ADAPTER applies at
+   * no level of this adapter: the BPMS' own isolation is never asked for, so the
+   * setting has no effect and the two contradict each other. Either the setting is
+   * meant and the mode has to say so, or the mode is meant and the setting is dead
+   * configuration - silently ignoring it is the one outcome nobody asked for.
    * <p>
-   * Adapters of a BPMS WITHOUT tenants must not call this; they reject
-   * {@link NameClashAvoidance#BY_ADAPTER} at startup instead (see
-   * {@link #validateNativeIsolationSupported}).
+   * WHICH setting that is belongs to the ADAPTER, because the isolation mechanism does
+   * (a tenant, a namespace, a database of its own - the core knows none of them). The
+   * adapter decides that something is configured and hands over the property key it
+   * would have to ignore; the core answers which modes apply and how to reconcile them.
+   * Called while deploying (i.e. at startup), before anything reaches the BPMS.
    *
-   * @param workflowModuleId The workflow module ID
-   * @param bpmnProcessId The BPMN process ID or <code>null</code>
    * @param adapterId The adapter ID
-   * @param configuredTenantId The tenant name configured for the adapter or
-   *          <code>null</code>
-   * @return The tenant ID, or <code>null</code> if the mode does not use one
+   * @param byAdapterOnlyPropertyKey The full property key of the configured setting
+   *          which only BY_ADAPTER could use, e.g.
+   *          <code>vanillabp.adapters.myengine.tenant-id</code> - the message tells the
+   *          developer to remove exactly this one. <code>null</code>/blank checks
+   *          nothing
+   * @throws IllegalStateException Naming that property, the modes which apply and both
+   *           ways out
    */
-  String tenantIdFor(
-      String workflowModuleId,
-      String bpmnProcessId,
+  void validateNoneNameClashStrategy(
       String adapterId,
-      String configuredTenantId);
+      String byAdapterOnlyPropertyKey);
 
   /**
    * Fails with a guiding message if the mode resolved for the given workflow module

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidanceSupport.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/NameClashAvoidanceSupport.java
@@ -36,8 +36,8 @@ public interface NameClashAvoidanceSupport {
   /**
    * The mode configured for the given workflow module (and, if given, workflow) of
    * the given adapter - the most specific configured value wins (workflow >
-   * workflow module > adapter), the default is
-   * {@link NameClashAvoidance#BY_ADAPTER}.
+   * workflow module > adapter). Without any configuration the adapter's own default
+   * applies ({@link AdapterDeploymentService#defaultNameClashAvoidance()}).
    *
    * @param workflowModuleId The workflow module ID
    * @param bpmnProcessId The BPMN process ID or <code>null</code> to resolve the

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/WorkflowTaskRegistryProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/WorkflowTaskRegistryProducer.java
@@ -51,16 +51,40 @@ public class WorkflowTaskRegistryProducer {
   /**
    * The core-owned name-clash-avoidance model (story 35): resolves the mode per
    * workflow module/workflow and adapter and composes the identifiers a BPMS sees.
+   * <p>
+   * The adapters' deployment services are looked up LAZILY (they receive this bean, so
+   * they cannot be injected here): the mode applying without configuration is the
+   * adapter's own, and an unscoped workflow module is reported by the adapter itself.
+   * Both bean shapes of the platform contract are accepted - element beans and beans
+   * of type <code>List&lt;AdapterDeploymentService&lt;Object, Object&gt;&gt;</code>
+   * (one instance per configured adapter id), see
+   * {@link io.vanillabp.integration.runtime.deployment.VanillaBpDeploymentRunner}.
    *
    * @param properties The VanillaBP configuration
+   * @param deploymentServices The adapters' deployment services as element beans
+   * @param deploymentServiceLists The adapters' deployment services as per-adapter-id
+   *          lists
    * @return The name-clash-avoidance support
    */
   @jakarta.enterprise.inject.Produces
   @jakarta.inject.Singleton
   public io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport nameClashAvoidanceSupport(
-      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
+      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties,
+      @jakarta.enterprise.inject.Any final jakarta.enterprise.inject.Instance<io.vanillabp.integration.adapter.spi.AdapterDeploymentService<?, ?>> deploymentServices,
+      @jakarta.enterprise.inject.Any final jakarta.enterprise.inject.Instance<java.util.List<io.vanillabp.integration.adapter.spi.AdapterDeploymentService<Object, Object>>> deploymentServiceLists) {
 
-    return new io.vanillabp.integration.adapter.migration.scoping.NameClashAvoidanceService(properties);
+    return new io.vanillabp.integration.adapter.migration.scoping.NameClashAvoidanceService(
+        properties, () -> java.util.stream.Stream
+            .concat(
+                deploymentServices.stream(),
+                deploymentServiceLists
+                    .stream()
+                    .filter(java.util.Objects::nonNull)
+                    .flatMap(java.util.List::stream))
+            .filter(
+                java.util.Objects::nonNull).<io.vanillabp.integration.adapter.spi.AdapterDeploymentService<?, ?>>map(
+                    service -> service)
+            .toList());
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -241,16 +241,25 @@ public class SpringBootMigrationAdapterAutoConfiguration {
    * workflow module/workflow and adapter and composes the identifiers a BPMS sees.
    * One instance per application - BPMS adapters receive it and apply it to their
    * model and their commands.
+   * <p>
+   * The adapters' deployment services are streamed LAZILY (they receive this bean, so
+   * they cannot be injected here): the mode applying without configuration is the
+   * adapter's own, and an unscoped workflow module is reported by the adapter itself.
    *
    * @param properties The VanillaBP configuration
+   * @param deploymentServices The adapters' deployment services, resolved on first use
    * @return The name-clash-avoidance support
    */
   @Bean
   @ConditionalOnMissingBean
   public io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport vanillaBpNameClashAvoidanceSupport(
-      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
+      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties,
+      final org.springframework.beans.factory.ObjectProvider<io.vanillabp.integration.adapter.spi.AdapterDeploymentService<?, ?>> deploymentServices) {
 
-    return new io.vanillabp.integration.adapter.migration.scoping.NameClashAvoidanceService(properties);
+    return new io.vanillabp.integration.adapter.migration.scoping.NameClashAvoidanceService(
+        properties, () -> deploymentServices
+            .stream()
+            .toList());
 
   }
 


### PR DESCRIPTION
Two changes to the name-clash-avoidance model, both of them about who knows what.

**The default belongs to the adapter.** `AdapterDeploymentService#defaultNameClashAvoidance`
answers what applies when an application configures nothing, `BY_ADAPTER` unless an
adapter overrides it. Both Camunda adapters override it with `NONE`: a Camunda 8 cluster
started from the stock image has multi-tenancy switched off and rejects a deploy command
carrying a tenant id, and Camunda 7 can keep modules apart in more ways than one. Since
`NONE` protects nothing, the core has the ADAPTER report it once per workflow module and
adapter id while the mode is resolved, because what can be used instead is BPMS knowledge
(`warnAboutUnscopedIdentifiers`).

**What BY_ADAPTER IS stays out of the core.** `tenantIdFor` is gone from the SPI; the
adapters derive the tenant from the resolved mode themselves. An adapter carrying
configuration only BY_ADAPTER could honor hands over the property key, and
`validateNoneNameClashStrategy` answers whether BY_ADAPTER applies anywhere for that
adapter. If it does not, the boot fails naming the property, the modes which do apply and
the two ways to reconcile them, instead of deploying while silently ignoring configuration.

The platform integrations hand the adapters' deployment services to the scoping service as
a lazily resolved supplier, since adapters receive that service themselves.

Closes G2 of the blueprints' GAPS.md together with the adapter changes.

Tested: `./mvnw install` green, Spring Boot and Quarkus integration tests included.