### PR TITLE
Stories 41-48 + 52: BPMS-initiated starts, signals, workflow end, aggregateChanged, process versions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -11,10 +11,13 @@ nothing existing changes behavior.
 
 - **New in `spi-for-java` 1.2.0:** `aggregateChanged(aggregate)` writes the values
   shared with the BPMS at the workflow's global scope, `aggregateChanged(aggregate,
-  taskId)` writes them in the scope of that task instance - which is what
-  multi-instance needs. The task-scoped overload does NOT additionally write the
-  global scope: a local value shadows the global one there anyway, and writing both
-  would change what the sibling instances see.
+  taskId)` writes them in the scope that task RUNS in - the process, an embedded
+  subprocess, or the one iteration of a multi-instance embedded subprocess. NOT the
+  task's own scope: engines create one where the model asks for it (a boundary event,
+  an instance of a multi-instance activity), values written there serve that activity
+  alone and vanish with it. The task-scoped overload does not additionally write the
+  global scope either: an inner value shadows the global one there anyway, and writing
+  both would change what the other iterations see.
 - **What travels is the sync model of story 28** (`@SyncWithBPMS`), the same values a
   task completion pushes. The method names no variables.
 - **New adapter SPI methods** `MigratableProcessService#aggregateChangedPhaseOne` /
@@ -26,18 +29,30 @@ nothing existing changes behavior.
   could only drop a push, never save one. The adapter is elected at dispatch time by
   probing, like message correlation.
 - **Camunda 7** writes inside the caller's transaction: `setVariables` at the process
-  instance, `setVariablesLocal` at the parked execution of a task. This is what makes
-  **conditional events** usable at all there - the engine looks at their conditions
-  when a variable of their scope changes. Where an application shares nothing (this
+  instance, `setVariablesLocal` at the execution of the scope a task runs in (found by
+  walking the execution tree, skipping an activity's own scope and the multi-instance
+  body). This is what makes **conditional events** usable at all there - the engine
+  looks at their conditions when a variable of their scope or of a parent scope
+  changes, so an event subprocess with a conditional start event reacts. Where an application shares nothing (this
   adapter's opt-in default), a technical variable `vanillabpAggregateChanged` is
   written so the change happens.
 - **Camunda 8** sends `SetVariables` after the commit, for the process instance
-  respectively the element instance of the task. It **needs secondary storage**: the
+  respectively the element instance of the scope the task runs in (the API reports
+  children of a scope but no parents, so the adapter walks down from the process
+  instance to find it). It **needs secondary storage**: the
   cluster has no business key, so only the query API translates an aggregate ID into
   the keys the command takes. Without it the adapter fails with a guiding message.
   Conditional events do not exist in Camunda 8 - that stays true.
 - **Process-Engine-API:** not supported (gap 18). The API modifies the payload of a
   TASK, never that of a running instance, so both phases throw with a guiding message.
+- **Also fixed:** the Camunda 7 EL resolver returned the task's activity behavior for
+  ANY name evaluated while an execution sat at a wired task - including the condition of
+  a conditional event reading the workflow aggregate, which failed with "condition
+  expression returns non-Boolean". A name which IS a task definition still means the
+  task; otherwise an attribute of the workflow aggregate wins. The new adapter-SPI
+  method `WorkflowTaskInvoker#workflowAggregateHasProperty` answers that from the
+  aggregate CLASS, without loading an aggregate. Adapters implementing the SPI have to
+  implement it.
 - **Fixed on the way:** the Camunda 8 adapter searched process instances by the
   aggregate-ID variable WITHOUT quoting the value. Variable values are stored as JSON,
   so a String value never matched and every probe of a cluster WITH secondary storage

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,33 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Telling the application that a workflow ended (2026-08-13)
+
+Story 43 - `@WorkflowEnded` exists now. Additive; nothing existing changes behavior,
+and a model without such a method is deployed exactly as before.
+
+- **New in `spi-for-java` 1.2.0:** the annotation `@WorkflowEnded` and the value
+  record `WorkflowEnd` (kind, time, end event id). The method takes the workflow
+  aggregate and optionally a `WorkflowEnd`, returns void, and VanillaBP saves the
+  aggregate afterwards.
+- **New adapter SPI** `io.vanillabp.integration.adapter.spi.workflowend`:
+  `WorkflowEndedInvoker` (implemented by the same core bean as the other two
+  invokers) with `workflowEndedHandlerExists` - adapters ask it while wiring, so a
+  listener is attached ONLY where a method exists - and `workflowEnded`.
+- **Camunda 7:** an END execution listener at the process scope, inside the engine's
+  transaction. It distinguishes `COMPLETED` from `TERMINATED` by the execution's
+  delete reason and reports the end event reached.
+- **Camunda 8:** an `end` execution listener on the process element plus a worker for
+  its job. The cluster runs end listeners of completed instances only, so this
+  adapter reports `COMPLETED` and never `TERMINATED`, and it does not report which
+  end event was reached. A model of a process with such a method is redeployed with
+  the listener and therefore produces a new process version.
+- **Process-Engine-API:** not supported (gap 17). A method for a process running
+  there yields a WARN naming it - deliberately not a boot failure, since the workflow
+  itself runs normally and only the notification is missing.
+- The notification is at-least-once, and an aggregate deleted meanwhile is logged and
+  skipped instead of failing the BPMS' transaction.
+
 ## Broadcasting BPMN signals (2026-08-12)
 
 Story 42 - `ProcessService.sendSignal(String)` exists now. Additive; nothing existing

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,47 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Phase-two operations become a registry (2026-08-12)
+
+Story 45 - the closed enum `PhaseTwoOperation` becomes an open registry, so
+extensions can use the outbox for crash-safe after-commit work of their own and new
+core operations no longer edit a shared enum plus a `switch`.
+
+- **`PhaseTwoOperation` is no longer an enum** but a record of a persisted NAME and
+  its idempotency-key derivation. The seven core operations stay constants of that
+  class under UNCHANGED names and UNCHANGED key rules (`START_WORKFLOW`,
+  `COMPLETE_TASK`, `CANCEL_TASK`, `COMPLETE_USER_TASK`, `CANCEL_USER_TASK`,
+  `CORRELATE_MESSAGE`, `START_WORKFLOW_BY_MESSAGE`), pinned by a test now that the
+  compiler no longer guarantees them. Entries written by an earlier build keep
+  dispatching and deduplicating.
+- **`PhaseTwoCall` carries the operation by name** (`String operation()`) and the
+  derived idempotency key as a component. Build calls with
+  `PhaseTwoCall.of(operation, ...)` when scheduling and with
+  `PhaseTwoCall.forDispatch(name, ...)` when a store rebuilds one from a persisted
+  entry - the canonical constructor changed, so custom stores or extensions
+  constructing calls directly have to switch to the factories.
+- **Breaking for custom `PhaseTwoOutbox` stores** in exactly two places: persist
+  `call.operation()` instead of `call.operation().name()`, and stop resolving the
+  persisted name (no more `PhaseTwoOperation.valueOf`) - hand it to the router as a
+  String. Nothing else about the store contract changed; stores still never
+  interpret operations.
+- **Unknown operations are the router's business now.** An entry whose operation is
+  not registered fails with a guiding message naming the operation and listing the
+  registered ones; the entry stays in the store and its retry/blocking behavior is
+  unchanged. This covers the new case of an extension having been removed from the
+  application.
+- **New: extensions register their own operations.** `PhaseTwoOperation`
+  `.extensionOperation(name, key)` enforces a namespace (`my-extension:NOTIFY`), and
+  `PhaseTwoOperationRegistry.register(operation, dispatch)` adds it. The registry is
+  a bean on both platforms (Spring Boot `vanillaBpPhaseTwoOperationRegistry`,
+  Quarkus a `@Singleton` producer). An extension operation is dispatched to its own
+  handler, without the aggregate-to-adapter election of the core operations.
+- **No schema change.** The persisted encoding is still the operation's name; the
+  namespaced names of extensions are longer, but the column widths of the shipped
+  stores already accommodate them (the Quarkus JDBC store's `OPERATION` column is
+  `VARCHAR(255)`, MongoDB is schemaless, gruelbox serializes the name into its
+  invocation). Applications running a SNAPSHOT need no migration.
+
 ## Name-clash avoidance: tenants, prefixes - and a Camunda 8 fix (2026-08-07)
 
 Story 35 - how a workflow module's identifiers are kept apart from those of other

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,34 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Broadcasting BPMN signals (2026-08-12)
+
+Story 42 - `ProcessService.sendSignal(String)` exists now. Additive; nothing existing
+changes behavior.
+
+- **New in `spi-for-java` 1.2.0:** `sendSignal(String signalName)` as a default method
+  throwing until an adapter implements it. Broadcast only - there is deliberately no
+  overload limiting a signal to one workflow, because Camunda 8 cannot do that and an
+  API which quietly means something else per BPMS is worse than none.
+- **New adapter SPI methods** `MigratableProcessService#sendSignalPhaseOne` /
+  `#sendSignalPhaseTwo`, both `default` and both throwing a guiding
+  `UnsupportedOperationException` - an adapter whose BPMS has no signals says so
+  instead of swallowing a broadcast.
+- **New core operation `SEND_SIGNAL`** in the operation registry (story 45), WITHOUT
+  an idempotency key: a signal has nothing to deduplicate by, so a redelivered outbox
+  entry broadcasts again. The broadcasting adapter IS persisted with the entry,
+  because a broadcast goes to every BPMS the workflow module was deployed to and each
+  of them gets its own entry.
+- **`PhaseTwoCall.workflowAggregateId()` may be `null`** from now on: an operation
+  which is not about one workflow carries no aggregate ID. Custom outbox stores have
+  to tolerate that (the shipped ones do - the JDBC store's `AGGREGATE_ID` column was
+  nullable already).
+- **Camunda 7** broadcasts inside the caller's transaction, **Camunda 8** after the
+  commit, and the **Process-Engine-API** uses its `SignalApi` after the commit (that
+  API exists, so this needed no gap entry).
+- A broadcast reaches the DEPLOYMENT UNION of the workflow module, not only the
+  first-priority adapter of the calling process service.
+
 ## Workflows the BPMS starts itself (2026-08-12)
 
 Story 41 - a timer, signal or conditional start event produces a workflow without a

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,28 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Camunda 8: workflows were never found on clusters with secondary storage (2026-08-13)
+
+Story 52 - a defect fix. Nothing to change in your code or configuration.
+
+The adapter searched process instances by the aggregate-ID variable and passed the ID as
+a plain string. Camunda 8 compares a variable against its stored JSON, so a String value
+has to carry its quotes: the filter matched nothing, `awarenessOfWorkflow` answered
+`UNKNOWN_TO_BPMS` for every workflow, and everything electing its BPMS by probing failed
+with a guiding `WorkflowNotFoundException` - `completeTask`, `cancelTask`, the user-task
+operations, `correlateMessage`, `aggregateChanged`, the viewer and the START re-dispatch
+mitigation. On a cluster without secondary storage none of this showed, because the search
+throws there and the adapter answers optimistically `ACTIVE`.
+
+Which is also why it survived: the adapter's Docker tests all ran on such a cluster, so
+what they exercised was the fallback and never the query. `Camunda8SecondaryStorageIT`
+brings its own Elasticsearch now and correlates a message with a workflow located by
+probing; it fails with the old filter, carrying the exception the field reported.
+
+The encoding lives in one place (`Camunda8VariableFilters`), used by the process service
+and the viewer. It quotes unconditionally because VanillaBP writes the ID as a string
+whatever type the aggregate's ID attribute has - a unit test pins the two halves together.
+
 ## Telling the BPMS that the aggregate changed (2026-08-13)
 
 Story 44 - `ProcessService.aggregateChanged` exists now, in two overloads. Additive;

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,35 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Workflows the BPMS starts itself (2026-08-12)
+
+Story 41 - a timer, signal or conditional start event produces a workflow without a
+workflow aggregate, which VanillaBP now builds. Additive: nothing existing changes
+behavior.
+
+- **New in `spi-for-java` 1.2.0:** the annotation `@WorkflowStartedByBpms` and the
+  value record `BpmsStartTrigger`. Both are OPTIONAL - without them VanillaBP builds
+  the aggregate on its own (see the wiki page "Starting workflows").
+- **New adapter SPI** `io.vanillabp.integration.adapter.spi.workflowstart`:
+  `BpmsInitiatedStartInvoker` (implemented by the core, offered to adapters like
+  `WorkflowTaskInvoker` - the same bean implements both), plus
+  `BpmsInitiatedStartSpec`, `BpmsInitiatedStartContext` and
+  `BpmsInitiatedStartResult`. An adapter which does not implement it keeps working;
+  processes with such start events simply cannot run on it.
+- **Camunda 7:** an execution listener on the start event builds the aggregate inside
+  the engine's transaction and sets the instance's business key from it.
+- **Camunda 8:** an execution listener is added to the start event while deploying
+  (event type `end` - the cluster rejects `start` listeners there), and its job
+  completion writes the aggregate-ID variable plus the shared aggregate values. A
+  model deployed by an earlier VanillaBP 2 build is redeployed with that listener, so
+  it produces a new process version.
+- **Process-Engine-API:** deploying a process with such a start event now fails with a
+  guiding message (gap 16) - the API never reports a start the application did not
+  ask for.
+- The workflow-aggregate class needs a constructor without arguments to be built by
+  VanillaBP. Where it has none, a `@WorkflowStartedByBpms` method returning the
+  aggregate does the job; the failure message says both.
+
 ## Phase-two operations become a registry (2026-08-12)
 
 Story 45 - the closed enum `PhaseTwoOperation` becomes an open registry, so

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,46 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Telling the BPMS that the aggregate changed (2026-08-13)
+
+Story 44 - `ProcessService.aggregateChanged` exists now, in two overloads. Additive;
+nothing existing changes behavior.
+
+- **New in `spi-for-java` 1.2.0:** `aggregateChanged(aggregate)` writes the values
+  shared with the BPMS at the workflow's global scope, `aggregateChanged(aggregate,
+  taskId)` writes them in the scope of that task instance - which is what
+  multi-instance needs. The task-scoped overload does NOT additionally write the
+  global scope: a local value shadows the global one there anyway, and writing both
+  would change what the sibling instances see.
+- **What travels is the sync model of story 28** (`@SyncWithBPMS`), the same values a
+  task completion pushes. The method names no variables.
+- **New adapter SPI methods** `MigratableProcessService#aggregateChangedPhaseOne` /
+  `#aggregateChangedPhaseTwo`, both `default` and both throwing a guiding
+  `UnsupportedOperationException`.
+- **New core operation `AGGREGATE_CHANGED`** in the operation registry (story 45),
+  WITHOUT an idempotency key: the values are read from the aggregate when the entry is
+  dispatched, so a redelivered entry writes the then-current state. Deduplicating
+  could only drop a push, never save one. The adapter is elected at dispatch time by
+  probing, like message correlation.
+- **Camunda 7** writes inside the caller's transaction: `setVariables` at the process
+  instance, `setVariablesLocal` at the parked execution of a task. This is what makes
+  **conditional events** usable at all there - the engine looks at their conditions
+  when a variable of their scope changes. Where an application shares nothing (this
+  adapter's opt-in default), a technical variable `vanillabpAggregateChanged` is
+  written so the change happens.
+- **Camunda 8** sends `SetVariables` after the commit, for the process instance
+  respectively the element instance of the task. It **needs secondary storage**: the
+  cluster has no business key, so only the query API translates an aggregate ID into
+  the keys the command takes. Without it the adapter fails with a guiding message.
+  Conditional events do not exist in Camunda 8 - that stays true.
+- **Process-Engine-API:** not supported (gap 18). The API modifies the payload of a
+  TASK, never that of a running instance, so both phases throw with a guiding message.
+- **Fixed on the way:** the Camunda 8 adapter searched process instances by the
+  aggregate-ID variable WITHOUT quoting the value. Variable values are stored as JSON,
+  so a String value never matched and every probe of a cluster WITH secondary storage
+  answered "unknown workflow". Affects `awarenessOfWorkflow`,
+  `awarenessOfWorkflowForRedispatch` and the new push.
+
 ## Telling the application that a workflow ended (2026-08-13)
 
 Story 43 - `@WorkflowEnded` exists now. Additive; nothing existing changes behavior,

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,49 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## `version` decides which method serves a task (2026-08-13)
+
+Story 48 - the `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and
+`@WorkflowEnded` is evaluated now. It exists since VanillaBP 1 and was never implemented
+there, so every method served every version; VanillaBP 2 parsed the ranges but no adapter
+reported a version, which came to the same. Applications not using the attribute are
+unaffected.
+
+The version meant is the version of the deployed process DEFINITION as the BPMS counts it
+(Camunda 7 and Camunda 8 count integers upwards per BPMN process id), not a version an
+application invents. A boundary may also name a version TAG of the model
+(`camunda:versionTag`, `zeebe:versionTag`).
+
+Three things flip for an application which already carries the attribute:
+
+- Disjoint ranges really are disjoint now. A version served by NO method fails the
+  delivery with a message naming that version, where before the first method ran.
+- Two methods wired to one BPMN element with OVERLAPPING ranges fail the boot, naming both
+  methods. The duplicate check compared `matchesVersion(null)`, which is `true` for every
+  specification, so it never fired; and the workflow-task registry compared newly scanned
+  handlers only against the already registered ones, so two methods of the SAME class were
+  never compared at all.
+- A non-numeric specification is a version TAG now instead of a boot failure. `version =
+  "latest"` used to fail with "unsupported version specification" and is a tag named
+  `latest` today. `>=3` and `<=3` are supported as documented in version 1's README (they
+  were never implemented either).
+
+New in the adapter SPI (`io.vanillabp.integration.adapter.spi.version`):
+`ProcessVersionCatalog` with `DeployedProcessVersion` and the ready-made
+`CachingProcessVersionCatalog`, plus two default methods on `WorkflowTaskInvoker`:
+`registerProcessVersions(...)` during `wireBpmn` and `resolveProcessVersions(module)` at
+the end of `deployResources`. Both are optional: an adapter which registers nothing keeps
+working, and only specifications naming a version tag need a catalog at all. Adapters
+outside this repository do not have to change.
+
+What it costs: nothing for specifications made of numbers - they are compared to the
+version the adapter reports with the task. A specification naming a tag makes VanillaBP ask
+the BPMS once per process while the application starts (after the deployment, so a tag
+deployed by this very start is included) and again only for a version it has never seen,
+which is what a rolling deployment produces while another node is ahead. Camunda 7 answers
+from its definition query, Camunda 8 needs its query API (secondary storage) for tags, and
+the Process-Engine-API can only report the tag of the current task (GAPS 19).
+
 ## Camunda 8: workflows were never found on clusters with secondary storage (2026-08-13)
 
 Story 52 - a defect fix. Nothing to change in your code or configuration.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,7 +30,12 @@ changes behavior.
   commit, and the **Process-Engine-API** uses its `SignalApi` after the commit (that
   API exists, so this needed no gap entry).
 - A broadcast reaches the DEPLOYMENT UNION of the workflow module, not only the
-  first-priority adapter of the calling process service.
+  first-priority adapter of the calling process service. Its SCOPE is that workflow
+  module: every adapter broadcasts through its own client with its own tenant, and
+  the signal name carries the module's prefix where the module prefixes identifiers.
+  A signal meant for several workflow modules is sent through the `ProcessService` of
+  each of them - with the mode `none` nothing separates the modules in the BPMS
+  anyway, which is the price of that mode.
 
 ## Workflows the BPMS starts itself (2026-08-12)
 

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -407,6 +407,11 @@ applications may define their own `PhaseTwoOutbox` bean instead):
 A signal is the one BPMS operation which is not about a workflow, so it is the one
 place where neither election nor aggregate applies:
 
+- The scope is the WORKFLOW MODULE of the calling process service: each adapter
+  broadcasts through ITS own client with ITS tenant, and the signal name is scoped
+  like every other identifier of the module (prefixed in `use-prefix`). Crossing
+  module boundaries is deliberately left to the application - a module is a scope,
+  and which modules a signal is meant for is a business question.
 - `MigrationProcessService.sendSignal(name)` fans out over the DEPLOYMENT UNION of the
   workflow module (`getDeploymentAdaptersFor`, story 27), not over the prioritized
   adapters of the calling process service. During a migration the subscriptions are

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -312,7 +312,7 @@ An operation is not a hardcoded case in the router but an entry of the
 
 VanillaBP's own operations (`START_WORKFLOW`, `COMPLETE_TASK`, `CANCEL_TASK`,
 `COMPLETE_USER_TASK`, `CANCEL_USER_TASK`, `CORRELATE_MESSAGE`,
-`START_WORKFLOW_BY_MESSAGE`) are constants of `PhaseTwoOperation`, registered by the
+`START_WORKFLOW_BY_MESSAGE`, `SEND_SIGNAL`, `AGGREGATE_CHANGED`) are constants of `PhaseTwoOperation`, registered by the
 `PhaseTwoRouter` while it is built. Their dispatch is the process-service routing
 described above. Their names and key rules are pinned by a test, because since they
 stopped being enum constants nothing else guarantees them.
@@ -442,6 +442,34 @@ place where neither election nor aggregate applies:
   idempotency key: nothing about a signal can be deduplicated.
 - The call carries no aggregate ID, which is why `PhaseTwoCall` allows it to be
   absent. The router's `SEND_SIGNAL` dispatch therefore does not convert one.
+
+### Pushing a changed aggregate (`aggregateChanged`)
+
+`MigrationProcessService.aggregateChanged(aggregate, taskId)` is `correlateMessage` with
+another verb: save the aggregate, locate the BPMS by probing `awarenessOfWorkflow`, write
+in phase one for an embedded BPMS and schedule an `AGGREGATE_CHANGED` outbox entry for a
+remote one. A completed workflow is a warned no-op, an unknown one a
+`WorkflowNotFoundException` naming that the aggregate WAS saved.
+
+Two decisions are worth knowing:
+
+- **No idempotency key.** The values are read from the aggregate when the entry is
+  DISPATCHED, so a redelivered entry writes the then-current state. A key could only ever
+  drop a push, never save one.
+- **The task id decides the scope and nothing else.** Without one the values belong to the
+  workflow's global scope, with one to that task instance - and a task-scoped push must NOT
+  additionally write the global scope, or the sibling instances of a multi-instance
+  activity would see what another instance pushed. The adapters enforce that, the core only
+  transports the id (in `ARG_TASK_ID`).
+
+There is no ordering guarantee between outbox entries: the dispatchers select by due time
+(`NEXT_ATTEMPT_AT <= now`) without an `ORDER BY`, so a push and a task completion scheduled
+in the same transaction may reach a remote BPMS in the other order. That is documented
+rather than fixed - inventing an order here would promise something the stores do not
+implement, and an application which needs one can keep the calls in separate transactions.
+
+WHAT is pushed stays the sync model's business (story 28). This operation adds no second
+way of choosing values, which is what keeps the aggregate the single source of truth.
 
 ### Workflows the BPMS starts itself (`BpmsInitiatedStartInvoker`)
 

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -402,6 +402,48 @@ applications may define their own `PhaseTwoOutbox` bean instead):
 | Spring Boot | MongoDB                  | own implementation using `MongoTemplate` (`spring-boot-integration`)                     |
 | Quarkus     | JDBC datasource (Agroal) | own JDBC/JTA-based implementation (`quarkus-integration`; gruelbox does not support JTA) |
 
+### Workflows the BPMS starts itself (`BpmsInitiatedStartInvoker`)
+
+A timer, signal or conditional start event produces a workflow nobody asked for - and
+therefore a workflow without a workflow aggregate, which is the one thing every other
+mechanism needs: tasks are routed by the aggregate's ID, expressions read its
+attributes. The core builds it, adapters only report and write back.
+
+Adapters use the SPI (`io.vanillabp.integration.adapter.spi.workflowstart`) twice:
+
+- `validateBpmsInitiatedStarts(module, process, specs)` during `wireBpmn`, with the
+  start events of the deployed process the BPMS fires on its own. The core registers
+  them and reports an application method serving a process (or a start event) which
+  has none. Signal names are reported PLAIN - scoping stays invisible above the BPMS
+  boundary (story 35). Throwing honors the `deployment-failure` policy.
+- `startWorkflowByBpms(module, process, context)` when the BPMS reports such a start.
+  The context carries values only: start event id, kind, trigger time, the BPMS' own
+  identity of the start, the variables the model set, and whether the aggregate has to
+  be built in the CALLER's transaction (embedded BPMS) or in a new one (remote BPMS).
+
+What the core does, in one transaction: derive the ID, reuse an aggregate already
+carrying it (a repeated notification builds nothing twice), otherwise instantiate the
+class, write the ID and the variables into it, run the optional
+`@WorkflowStartedByBpms` method and save. The result carries the aggregate's ID, the
+name of its ID attribute and the variables the adapter writes back - the ID variable
+plus the values shared per `@SyncWithBPMS` where the adapter asks for them
+(`AggregateSyncMode`).
+
+The ID rules live in `BpmsInitiatedStartId`: what the BPMS identifies the start by
+wins (a remote BPMS' instance key, stable across redeliveries), then a timer's trigger
+time, then a generated ID - and where none of them fits the ID attribute's type,
+nothing is assigned and the persistence layer generates one while saving.
+
+The `@WorkflowStartedByBpms` methods are scanned by `BpmsInitiatedStartScanner` and
+held by `BpmsInitiatedStarts`, to which `WorkflowTaskRegistry` delegates the second
+adapter-facing interface. Both scanners walk the same classes and share the value
+conversion; folding them into ONE pluggable handler contract is the subject of the
+extension-enablement story.
+
+An adapter whose BPMS cannot report such a start implements none of this and fails the
+deployment of such a process with a guiding message instead - a workflow which could
+never obtain an aggregate is better refused than deployed.
+
 ### Viewer/history API (read path)
 
 `ProcessService#getProcessDefinitions`, `#getBpmnXml` and `#getWorkflowHistory` are

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -457,10 +457,11 @@ Two decisions are worth knowing:
   DISPATCHED, so a redelivered entry writes the then-current state. A key could only ever
   drop a push, never save one.
 - **The task id decides the scope and nothing else.** Without one the values belong to the
-  workflow's global scope, with one to that task instance - and a task-scoped push must NOT
-  additionally write the global scope, or the sibling instances of a multi-instance
-  activity would see what another instance pushed. The adapters enforce that, the core only
-  transports the id (in `ARG_TASK_ID`).
+  workflow's global scope, with one to the scope that task RUNS in (process, embedded
+  subprocess, or one iteration of a multi-instance embedded subprocess) - never the task's
+  own scope, and never additionally the global one, or the other iterations would see what
+  one of them pushed. Which execution or element instance that is, is the adapter's
+  business; the core only transports the id (in `ARG_TASK_ID`).
 
 There is no ordering guarantee between outbox entries: the dispatchers select by due time
 (`NEXT_ATTEMPT_AT <= now`) without an `ORDER BY`, so a push and a task completion scheduled

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -298,6 +298,56 @@ completing tasks, ...) will instead probe the prioritized adapters at dispatch t
 (their calls carry no adapter ID); each such operation gets its own typed
 `schedule*` default method in `PhaseTwoOutbox` building the `PhaseTwoCall`.
 
+#### Which operations exist: the operation registry
+
+An operation is not a hardcoded case in the router but an entry of the
+`PhaseTwoOperationRegistry` (business SPI), consisting of three things:
+
+- its **name**, which the store persists and which is therefore a contract: never
+  rename an operation, never change what an existing name means,
+- its **idempotency-key derivation** (`PhaseTwoOperation.IdempotencyKey`, a function
+  of the `PhaseTwoCall`), which is just as persisted as the name, and
+- its **dispatch** (`PhaseTwoOperationDispatch`), which is not persisted at all: it
+  is registered at startup by whoever owns the operation.
+
+VanillaBP's own operations (`START_WORKFLOW`, `COMPLETE_TASK`, `CANCEL_TASK`,
+`COMPLETE_USER_TASK`, `CANCEL_USER_TASK`, `CORRELATE_MESSAGE`,
+`START_WORKFLOW_BY_MESSAGE`) are constants of `PhaseTwoOperation`, registered by the
+`PhaseTwoRouter` while it is built. Their dispatch is the process-service routing
+described above. Their names and key rules are pinned by a test, because since they
+stopped being enum constants nothing else guarantees them.
+
+An **extension** contributes operations of its own, which is why the registry exists.
+It builds them with `PhaseTwoOperation.extensionOperation(name, key)`, which enforces
+a namespace (`my-extension:MY_OPERATION`), and registers them together with its own
+dispatch:
+
+```java
+registry.register(
+    PhaseTwoOperation.extensionOperation(
+        "my-extension:NOTIFY",
+        call -> Optional.of(call.workflowAggregateId() + "|" + call.args().get("event"))),
+    (call, previouslyAttempted) -> notify(call));
+```
+
+The registry is offered as a bean by both platform integrations (Spring Boot:
+`vanillaBpPhaseTwoOperationRegistry`; Quarkus: a `@Singleton` producer). Scheduling
+works as for core operations: build the call with
+`PhaseTwoCall.of(operation, ...)` and hand it to the `PhaseTwoOutbox`, inside the
+business transaction. Dispatch then goes straight to the extension's handler: the
+aggregate-ID-to-adapter election of the core operations does not apply, and no
+process service has to be registered for the call's BPMN process.
+
+Rules the registry enforces at registration time, each with a guiding message: an
+operation is registered exactly once, an extension name is namespaced, and the core's
+names are reserved. At dispatch time an unregistered name is an error naming the
+operation and listing the registered ones. The entry stays in the store (like a
+stale adapter ID of a START entry), so an extension temporarily missing from the
+application does not silently lose its scheduled work.
+
+Stores never look into the registry: they persist name, args and key and stay
+operation-agnostic.
+
 The core does not implement (or depend on) any outbox itself — it only defines the
 `PhaseTwoOutbox` contract (stores implement exactly one method,
 `schedule(PhaseTwoCall)`):

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -402,6 +402,24 @@ applications may define their own `PhaseTwoOutbox` bean instead):
 | Spring Boot | MongoDB                  | own implementation using `MongoTemplate` (`spring-boot-integration`)                     |
 | Quarkus     | JDBC datasource (Agroal) | own JDBC/JTA-based implementation (`quarkus-integration`; gruelbox does not support JTA) |
 
+### Telling the application that a workflow ended (`WorkflowEndedInvoker`)
+
+The counterpart of the BPMS-initiated start, and the one handler kind whose whole
+point is that nothing depends on it:
+
+- Adapters ask `workflowEndedHandlerExists(module, process)` while wiring and attach
+  their listener only where the answer is yes. A model must not pay for a
+  notification the application did not ask for, which is why the question exists at
+  all instead of a plain "always attach".
+- `workflowEnded(module, process, context)` loads the aggregate, calls the method and
+  saves it, in the caller's transaction (embedded BPMS) or a new one (remote BPMS).
+- A missing aggregate is NOT an error: an application may delete the aggregate of a
+  workflow which ended, and a redelivered notification would find nothing either.
+  Both cases are logged and skipped.
+- What the context reports about the KIND of end is the adapter's honest answer, not
+  a normalized fiction: Camunda 7 tells a cancellation from a regular end by the
+  execution's delete reason, Camunda 8 never sees a cancelled instance's end.
+
 ### Broadcasting signals
 
 A signal is the one BPMS operation which is not about a workflow, so it is the one

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -402,6 +402,24 @@ applications may define their own `PhaseTwoOutbox` bean instead):
 | Spring Boot | MongoDB                  | own implementation using `MongoTemplate` (`spring-boot-integration`)                     |
 | Quarkus     | JDBC datasource (Agroal) | own JDBC/JTA-based implementation (`quarkus-integration`; gruelbox does not support JTA) |
 
+### Broadcasting signals
+
+A signal is the one BPMS operation which is not about a workflow, so it is the one
+place where neither election nor aggregate applies:
+
+- `MigrationProcessService.sendSignal(name)` fans out over the DEPLOYMENT UNION of the
+  workflow module (`getDeploymentAdaptersFor`, story 27), not over the prioritized
+  adapters of the calling process service. During a migration the subscriptions are
+  spread across the BPMS, and a partial broadcast is worse than none.
+- Every adapter is asked before the first failure is reported: a broadcast which
+  stopped at the first unreachable BPMS would leave the others waiting.
+- Embedded adapters broadcast in `sendSignalPhaseOne` (inside the caller's
+  transaction), remote ones get one `SEND_SIGNAL` outbox entry EACH, carrying their
+  adapter id - dispatch goes to exactly that adapter, without probing. There is no
+  idempotency key: nothing about a signal can be deduplicated.
+- The call carries no aggregate ID, which is why `PhaseTwoCall` allows it to be
+  absent. The router's `SEND_SIGNAL` dispatch therefore does not convert one.
+
 ### Workflows the BPMS starts itself (`BpmsInitiatedStartInvoker`)
 
 A timer, signal or conditional start event produces a workflow nobody asked for - and

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -250,6 +250,34 @@ and that adapter does not process workflows). A failure of the first-priority ad
 always fails the boot, regardless of the policy, because new workflows could not be
 started otherwise.
 
+#### Process versions (`version` attribute)
+
+The `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and
+`@WorkflowEnded` is evaluated by `VersionRange` (parsed once at registration) and
+`ProcessVersions` (package `workflowtask`), shared by all three handler kinds:
+
+- a boundary is a version identifier as the BPMS counts it, or a version TAG of the
+  model. A specification consisting of numbers is compared to the version the adapter
+  reports in its invocation context, so it costs nothing;
+- as soon as a TAG is involved, both sides are placed in the deployment order through
+  the adapter SPI `ProcessVersionCatalog` (package `spi.version`), which an adapter
+  hands over per process during `wireBpmn`
+  (`WorkflowTaskInvoker.registerProcessVersions`). `CachingProcessVersionCatalog`
+  implements the bookkeeping every adapter would write otherwise: the versions its
+  deploy command reported, the BPMS query for a version it has never seen (a rolling
+  deployment where another node is ahead) and a floor between two such queries;
+- `WorkflowTaskInvoker.resolveProcessVersions(module)`, called by adapters at the end
+  of `deployResources`, resolves the tags the application names while the application
+  STARTS - the deployment has happened, so a tag deployed by this very start is
+  included. A tag no BPMS knows is a WARN, never a boot failure: the tagged version may
+  arrive later, and the other methods have to keep serving.
+
+Two methods wired to the same BPMN element are ambiguous exactly when their ranges
+OVERLAP (`VersionRange.overlaps`, interval math). A range naming a tag cannot be placed
+before a BPMS was asked, so the check runs twice: at registration for everything
+decidable without a BPMS, and again during `resolveProcessVersions`. Both times it fails
+the boot naming both methods.
+
 ### Two-phase workflow start (`PhaseTwoOutbox` SPI)
 
 Starting a workflow must be atomic with the local database transaction that persists

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoCall.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoCall.java
@@ -14,24 +14,36 @@ import java.util.Optional;
  * ID type happens exactly once, at dispatch time, by the core's router using a
  * converter registered by the platform integration.
  *
- * @param operation The operation to execute
+ * The operation is carried by NAME: stores persist it, and the core's router
+ * resolves it in the {@link PhaseTwoOperationRegistry} at dispatch time. Build
+ * calls through {@link #of} (scheduling side - derives the idempotency key from
+ * the operation) or {@link #forDispatch} (a store rebuilding a call from a
+ * persisted entry).
+ *
+ * @param operation The NAME of the operation to execute (see
+ *        {@link PhaseTwoOperation#name()})
  * @param workflowModuleId The ID of the workflow module the workflow belongs to
  * @param bpmnProcessId The BPMN process ID of the workflow
  * @param workflowAggregateId The workflow-aggregate ID in serialized (String) form
  * @param adapterId The ID of the elected BPMS adapter - set for
  *        {@link PhaseTwoOperation#START_WORKFLOW} (the adapter elected in phase one
- *        is persisted and used in phase two), <code>null</code> for future probing
+ *        is persisted and used in phase two), <code>null</code> for probing
  *        operations which determine the adapter at dispatch time
  * @param args Additional operation-specific arguments (empty for
  *        {@link PhaseTwoOperation#START_WORKFLOW})
+ * @param idempotencyKey The key deduplicating this call, derived by the operation
+ *        when the call was built - {@link Optional#empty()} for operations which
+ *        must not be deduplicated and for calls rebuilt by a store at dispatch
+ *        time (where the key was persisted and is no longer needed)
  */
 public record PhaseTwoCall(
-                           PhaseTwoOperation operation,
+                           String operation,
                            String workflowModuleId,
                            String bpmnProcessId,
                            String workflowAggregateId,
                            String adapterId,
-                           Map<String, String> args) {
+                           Map<String, String> args,
+                           Optional<String> idempotencyKey) {
 
   /**
    * The {@link #args()} key carrying the task ID of
@@ -68,18 +80,64 @@ public record PhaseTwoCall(
     Objects.requireNonNull(bpmnProcessId, "bpmnProcessId must not be null");
     Objects.requireNonNull(workflowAggregateId, "workflowAggregateId must not be null");
     args = args == null ? Map.of() : Map.copyOf(args);
+    idempotencyKey = idempotencyKey == null ? Optional.empty() : idempotencyKey;
   }
 
   /**
-   * The idempotency key of this call, derived per operation - see the derivation
-   * rules documented on {@link PhaseTwoOperation}.
+   * Builds a call to be scheduled, deriving its idempotency key from the given
+   * operation (see the derivation rules documented on {@link PhaseTwoOperation}).
    *
-   * @return The idempotency key or {@link Optional#empty()} if the operation must
-   *         not be deduplicated
+   * @param operation The operation to execute
+   * @param workflowModuleId The ID of the workflow module the workflow belongs to
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param workflowAggregateId The workflow-aggregate ID in serialized form
+   * @param adapterId The ID of the elected BPMS adapter or <code>null</code>
+   * @param args Additional operation-specific arguments (may be
+   *        <code>null</code>)
+   * @return The call, ready to be handed to {@link PhaseTwoOutbox#schedule}
    */
-  public Optional<String> idempotencyKey() {
+  public static PhaseTwoCall of(
+      final PhaseTwoOperation operation,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String adapterId,
+      final Map<String, String> args) {
 
-    return operation.idempotencyKey(this);
+    // the key is derived from the call itself, so the call is built twice: once
+    // to derive from, once carrying the result
+    final var withoutKey = new PhaseTwoCall(
+        operation.name(), workflowModuleId, bpmnProcessId, workflowAggregateId, adapterId, args, Optional.empty());
+    return new PhaseTwoCall(
+        withoutKey.operation(), withoutKey.workflowModuleId(), withoutKey.bpmnProcessId(), withoutKey
+            .workflowAggregateId(), withoutKey
+                .adapterId(), withoutKey.args(), operation.idempotencyKey().derive(withoutKey));
+
+  }
+
+  /**
+   * Rebuilds a call from a persisted outbox entry. The idempotency key is not
+   * part of it: the store persisted it when the entry was written and nothing
+   * downstream of the store reads it again.
+   *
+   * @param operation The persisted operation NAME
+   * @param workflowModuleId The ID of the workflow module the workflow belongs to
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param workflowAggregateId The workflow-aggregate ID in serialized form
+   * @param adapterId The persisted adapter ID or <code>null</code>
+   * @param args The persisted arguments (may be <code>null</code>)
+   * @return The call, ready to be handed to the core's router
+   */
+  public static PhaseTwoCall forDispatch(
+      final String operation,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String adapterId,
+      final Map<String, String> args) {
+
+    return new PhaseTwoCall(
+        operation, workflowModuleId, bpmnProcessId, workflowAggregateId, adapterId, args, Optional.empty());
 
   }
 

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoCall.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoCall.java
@@ -24,7 +24,8 @@ import java.util.Optional;
  *        {@link PhaseTwoOperation#name()})
  * @param workflowModuleId The ID of the workflow module the workflow belongs to
  * @param bpmnProcessId The BPMN process ID of the workflow
- * @param workflowAggregateId The workflow-aggregate ID in serialized (String) form
+ * @param workflowAggregateId The workflow-aggregate ID in serialized (String) form,
+ *        or <code>null</code> for an operation which is not about one workflow
  * @param adapterId The ID of the elected BPMS adapter - set for
  *        {@link PhaseTwoOperation#START_WORKFLOW} (the adapter elected in phase one
  *        is persisted and used in phase two), <code>null</code> for probing
@@ -74,11 +75,19 @@ public record PhaseTwoCall(
    */
   public static final String ARG_CORRELATION_ID = "correlationId";
 
+  /**
+   * The {@link #args()} key carrying the signal name of
+   * {@link PhaseTwoOperation#SEND_SIGNAL} calls. Part of the persisted contract -
+   * never change the literal.
+   */
+  public static final String ARG_SIGNAL_NAME = "signalName";
+
   public PhaseTwoCall {
     Objects.requireNonNull(operation, "operation must not be null");
     Objects.requireNonNull(workflowModuleId, "workflowModuleId must not be null");
     Objects.requireNonNull(bpmnProcessId, "bpmnProcessId must not be null");
-    Objects.requireNonNull(workflowAggregateId, "workflowAggregateId must not be null");
+    // no requireNonNull: an operation which is not about ONE workflow carries no
+    // aggregate ID (a broadcast signal, story 42)
     args = args == null ? Map.of() : Map.copyOf(args);
     idempotencyKey = idempotencyKey == null ? Optional.empty() : idempotencyKey;
   }

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
@@ -180,6 +180,20 @@ public record PhaseTwoOperation(
       "SEND_SIGNAL", call -> Optional.empty());
 
   /**
+   * Phase two of pushing a changed workflow-aggregate to the BPMS - see
+   * {@code MigratableProcessService#aggregateChangedPhaseTwo}. An optional task ID
+   * travels in {@link PhaseTwoCall#args()} under {@link PhaseTwoCall#ARG_TASK_ID};
+   * without it the values are written at the workflow's global scope. No adapter ID
+   * is persisted - the executing adapter is elected at dispatch time by probing.
+   * <p>
+   * NO idempotency key, and that is not a shortcut: the values are read from the
+   * aggregate when the entry is DISPATCHED, so a redelivered entry writes the
+   * then-current state. Deduplicating could only drop a push, never save one.
+   */
+  public static final PhaseTwoOperation AGGREGATE_CHANGED = new PhaseTwoOperation(
+      "AGGREGATE_CHANGED", call -> Optional.empty());
+
+  /**
    * All operations owned by the VanillaBP core. Their names are reserved: an
    * extension registering one of them is rejected by
    * {@link PhaseTwoOperationRegistry#register(PhaseTwoOperation, PhaseTwoOperationDispatch)}.
@@ -193,7 +207,8 @@ public record PhaseTwoOperation(
           CANCEL_USER_TASK,
           CORRELATE_MESSAGE,
           START_WORKFLOW_BY_MESSAGE,
-          SEND_SIGNAL);
+          SEND_SIGNAL,
+          AGGREGATE_CHANGED);
 
   public PhaseTwoOperation {
     Objects.requireNonNull(name, "name must not be null");

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
@@ -1,18 +1,25 @@
 package io.vanillabp.integration.spi;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
  * The operation a {@link PhaseTwoCall} executes after the local transaction was
- * committed.
+ * committed: a persisted NAME plus the rule deriving the call's idempotency key.
+ * What an operation actually DOES at dispatch time is registered separately (see
+ * {@link PhaseTwoOperationRegistry} and {@link PhaseTwoOperationDispatch}) - the
+ * core registers its operations, extensions register theirs.
  * <p>
- * <strong>Persisted contract:</strong> The enum constant's name as well as the
- * idempotency-key derivation rules below are persisted by {@link PhaseTwoOutbox}
- * implementations. Never rename constants and never change a derivation rule for an
- * existing operation - outbox entries scheduled by a previous version of the
- * application must still dispatch and deduplicate correctly after an upgrade.
+ * <strong>Persisted contract:</strong> The operation's {@link #name()} as well as
+ * the idempotency-key derivation rules below are persisted by
+ * {@link PhaseTwoOutbox} implementations. Never rename an operation and never
+ * change a derivation rule of an existing one - outbox entries scheduled by a
+ * previous version of the application must still dispatch and deduplicate
+ * correctly after an upgrade.
  * <p>
- * <strong>Idempotency-key derivation rules</strong> (parts joined by <code>|</code>):
+ * <strong>Idempotency-key derivation rules of the core operations</strong> (parts
+ * joined by <code>|</code>):
  * <ul>
  * <li>{@link #START_WORKFLOW}:
  * <code>workflowModuleId|bpmnProcessId|workflowAggregateId</code> - a workflow is
@@ -22,6 +29,8 @@ import java.util.Optional;
  * task is completed (or canceled) at most once, but multiple tasks of the same
  * workflow may be completed. The BPMN error code of a cancellation is NOT part of
  * the key (it is carried in {@link PhaseTwoCall#args()}).</li>
+ * <li>{@link #COMPLETE_USER_TASK} / {@link #CANCEL_USER_TASK}: like their
+ * asynchronous-task counterparts.</li>
  * <li>{@link #CORRELATE_MESSAGE}: WITH a correlation id the key is
  * <code>workflowModuleId|bpmnProcessId|workflowAggregateId|messageName|correlationId</code>;
  * WITHOUT one it is {@link Optional#empty()} - no deduplication is possible
@@ -33,24 +42,55 @@ import java.util.Optional;
  * is started at most once per aggregate, regardless of the triggering
  * message.</li>
  * </ul>
+ * <p>
+ * <strong>Operations of extensions</strong> are built by
+ * {@link #extensionOperation(String, IdempotencyKey)}: their name has to be
+ * namespaced (<code>my-extension:MY_OPERATION</code>) so an extension can never
+ * collide with a core operation or with another extension.
+ *
+ * @param name The persisted name of the operation
+ * @param idempotencyKey The rule deriving the idempotency key of a call of this
+ *        operation
  */
-public enum PhaseTwoOperation {
+public record PhaseTwoOperation(
+                                String name,
+                                IdempotencyKey idempotencyKey) {
+
+  /**
+   * Separates an extension's namespace from the operation's own name (e.g.
+   * <code>businesscockpit:PUBLISH_USER_TASK_EVENT</code>). Core operations never
+   * contain it, which is what makes collisions impossible.
+   */
+  public static final String NAMESPACE_SEPARATOR = ":";
+
+  /**
+   * Derives the idempotency key of a {@link PhaseTwoCall} - the rule is part of
+   * the persisted contract of the operation it belongs to.
+   */
+  @FunctionalInterface
+  public interface IdempotencyKey {
+
+    /**
+     * @param call The call to derive the key for
+     * @return The idempotency key or {@link Optional#empty()} if calls of this
+     *         operation must not be deduplicated
+     */
+    Optional<String> derive(
+        PhaseTwoCall call);
+
+  }
 
   /**
    * Phase two of starting a workflow - see
    * {@code MigratableProcessService#startWorkflowPhaseTwo}.
    */
-  START_WORKFLOW {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId()));
-    }
-  },
+  public static final PhaseTwoOperation START_WORKFLOW = new PhaseTwoOperation(
+      "START_WORKFLOW", call -> Optional
+          .of(
+              "%s|%s|%s".formatted(
+                  call.workflowModuleId(),
+                  call.bpmnProcessId(),
+                  call.workflowAggregateId())));
 
   /**
    * Phase two of completing an asynchronous task - see
@@ -59,18 +99,8 @@ public enum PhaseTwoOperation {
    * ID is persisted - the executing adapter is elected at dispatch time by probing
    * the prioritized adapters.
    */
-  COMPLETE_TASK {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId(),
-              call.args().get(PhaseTwoCall.ARG_TASK_ID)));
-    }
-  },
+  public static final PhaseTwoOperation COMPLETE_TASK = new PhaseTwoOperation(
+      "COMPLETE_TASK", PhaseTwoOperation::taskKey);
 
   /**
    * Phase two of canceling an asynchronous task by BPMN error - see
@@ -79,18 +109,8 @@ public enum PhaseTwoOperation {
    * {@link PhaseTwoCall#ARG_TASK_ID} / {@link PhaseTwoCall#ARG_BPMN_ERROR_CODE};
    * only the task ID is part of the idempotency key.
    */
-  CANCEL_TASK {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId(),
-              call.args().get(PhaseTwoCall.ARG_TASK_ID)));
-    }
-  },
+  public static final PhaseTwoOperation CANCEL_TASK = new PhaseTwoOperation(
+      "CANCEL_TASK", PhaseTwoOperation::taskKey);
 
   /**
    * Phase two of completing a USER task - see
@@ -98,36 +118,16 @@ public enum PhaseTwoOperation {
    * {@link #COMPLETE_TASK} (task ID in {@link PhaseTwoCall#ARG_TASK_ID}, no
    * adapter ID persisted).
    */
-  COMPLETE_USER_TASK {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId(),
-              call.args().get(PhaseTwoCall.ARG_TASK_ID)));
-    }
-  },
+  public static final PhaseTwoOperation COMPLETE_USER_TASK = new PhaseTwoOperation(
+      "COMPLETE_USER_TASK", PhaseTwoOperation::taskKey);
 
   /**
    * Phase two of canceling a USER task by BPMN error - see
    * {@code MigratableProcessService#cancelUserTaskPhaseTwo}. Same shape as
    * {@link #CANCEL_TASK}.
    */
-  CANCEL_USER_TASK {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId(),
-              call.args().get(PhaseTwoCall.ARG_TASK_ID)));
-    }
-  },
+  public static final PhaseTwoOperation CANCEL_USER_TASK = new PhaseTwoOperation(
+      "CANCEL_USER_TASK", PhaseTwoOperation::taskKey);
 
   /**
    * Phase two of correlating a message - see
@@ -137,25 +137,23 @@ public enum PhaseTwoOperation {
    * No adapter ID is persisted - the executing adapter is elected at dispatch time
    * by probing the prioritized adapters.
    */
-  CORRELATE_MESSAGE {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      final var correlationId = call.args().get(PhaseTwoCall.ARG_CORRELATION_ID);
-      if (correlationId == null) {
-        // the same message may legitimately be correlated multiple times - no
-        // deduplication possible (documented at-least-once residual)
-        return Optional.empty();
-      }
-      return Optional.of(
-          "%s|%s|%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId(),
-              call.args().get(PhaseTwoCall.ARG_MESSAGE_NAME),
-              correlationId));
-    }
-  },
+  public static final PhaseTwoOperation CORRELATE_MESSAGE = new PhaseTwoOperation(
+      "CORRELATE_MESSAGE", call -> {
+        final var correlationId = call.args().get(PhaseTwoCall.ARG_CORRELATION_ID);
+        if (correlationId == null) {
+          // the same message may legitimately be correlated multiple times - no
+          // deduplication possible (documented at-least-once residual)
+          return Optional.empty();
+        }
+        return Optional
+            .of(
+                "%s|%s|%s|%s|%s".formatted(
+                    call.workflowModuleId(),
+                    call.bpmnProcessId(),
+                    call.workflowAggregateId(),
+                    call.args().get(PhaseTwoCall.ARG_MESSAGE_NAME),
+                    correlationId));
+      });
 
   /**
    * Phase two of starting a workflow BY MESSAGE - see
@@ -164,27 +162,116 @@ public enum PhaseTwoOperation {
    * and the idempotency key equals {@link #START_WORKFLOW}'s (one workflow per
    * aggregate). The message name travels in {@link PhaseTwoCall#args()}.
    */
-  START_WORKFLOW_BY_MESSAGE {
-    @Override
-    public Optional<String> idempotencyKey(
-        final PhaseTwoCall call) {
-      return Optional.of(
-          "%s|%s|%s".formatted(
-              call.workflowModuleId(),
-              call.bpmnProcessId(),
-              call.workflowAggregateId()));
-    }
-  };
+  public static final PhaseTwoOperation START_WORKFLOW_BY_MESSAGE = new PhaseTwoOperation(
+      "START_WORKFLOW_BY_MESSAGE", call -> START_WORKFLOW.idempotencyKey().derive(call));
 
   /**
-   * Derive the idempotency key of the given call according to the rules documented
-   * on this enum.
-   *
-   * @param call The call to derive the key for
-   * @return The idempotency key or {@link Optional#empty()} if the operation must
-   *         not be deduplicated
+   * All operations owned by the VanillaBP core. Their names are reserved: an
+   * extension registering one of them is rejected by
+   * {@link PhaseTwoOperationRegistry#register(PhaseTwoOperation, PhaseTwoOperationDispatch)}.
    */
-  public abstract Optional<String> idempotencyKey(
-      PhaseTwoCall call);
+  public static final List<PhaseTwoOperation> CORE_OPERATIONS = List
+      .of(
+          START_WORKFLOW,
+          COMPLETE_TASK,
+          CANCEL_TASK,
+          COMPLETE_USER_TASK,
+          CANCEL_USER_TASK,
+          CORRELATE_MESSAGE,
+          START_WORKFLOW_BY_MESSAGE);
+
+  public PhaseTwoOperation {
+    Objects.requireNonNull(name, "name must not be null");
+    Objects.requireNonNull(idempotencyKey, "idempotencyKey must not be null");
+    if (name.isBlank()) {
+      throw new IllegalArgumentException("The name of a phase-two operation must not be blank!");
+    }
+  }
+
+  /**
+   * Builds an operation contributed by an extension. The name has to carry the
+   * extension's namespace (<code>my-extension:MY_OPERATION</code>) - see
+   * {@link #NAMESPACE_SEPARATOR}.
+   *
+   * @param name The namespaced name of the operation - persisted, so treat it as
+   *        a contract
+   * @param idempotencyKey The rule deriving the idempotency key of a call, or
+   *        <code>call -&gt; Optional.empty()</code> for operations which must not
+   *        be deduplicated
+   * @return The operation, to be registered together with its dispatch
+   * @throws IllegalArgumentException If the name is not namespaced (guiding
+   *         message)
+   */
+  public static PhaseTwoOperation extensionOperation(
+      final String name,
+      final IdempotencyKey idempotencyKey) {
+
+    final var operation = new PhaseTwoOperation(name, idempotencyKey);
+    validateNamespaced(operation);
+    return operation;
+
+  }
+
+  /**
+   * @param name The name to look up
+   * @return The core operation of that name, if there is one
+   */
+  public static Optional<PhaseTwoOperation> coreOperation(
+      final String name) {
+
+    return CORE_OPERATIONS
+        .stream()
+        .filter(operation -> operation.name().equals(name))
+        .findFirst();
+
+  }
+
+  /**
+   * The names of all core operations, in the order of {@link #CORE_OPERATIONS} -
+   * used for guiding messages.
+   *
+   * @return The core operations' names
+   */
+  public static List<String> coreOperationNames() {
+
+    return CORE_OPERATIONS
+        .stream()
+        .map(PhaseTwoOperation::name)
+        .toList();
+
+  }
+
+  static void validateNamespaced(
+      final PhaseTwoOperation operation) {
+
+    final var separator = operation.name().indexOf(NAMESPACE_SEPARATOR);
+    if ((separator < 1) || (separator == (operation.name().length() - 1))) {
+      throw new IllegalArgumentException(
+          """
+              The phase-two operation '%s' is not namespaced! Operations contributed by an extension \
+              have to be named '<extension>%s<operation>' (e.g. 'my-extension%sMY_OPERATION') so they \
+              can never collide with VanillaBP's core operations (%s) or with another extension's \
+              operations. The name is persisted in the outbox store - choose it once and keep it."""
+              .formatted(
+                  operation.name(),
+                  NAMESPACE_SEPARATOR,
+                  NAMESPACE_SEPARATOR,
+                  String.join(", ", coreOperationNames())));
+    }
+
+  }
+
+  private static Optional<String> taskKey(
+      final PhaseTwoCall call) {
+
+    return Optional
+        .of(
+            "%s|%s|%s|%s".formatted(
+                call.workflowModuleId(),
+                call.bpmnProcessId(),
+                call.workflowAggregateId(),
+                call.args().get(PhaseTwoCall.ARG_TASK_ID)));
+
+  }
 
 }

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperation.java
@@ -37,6 +37,8 @@ import java.util.Optional;
  * because the same message may legitimately be correlated multiple times over an
  * instance's lifetime (an at-least-once dispatch may then double-correlate; see
  * the adapters' documentation).</li>
+ * <li>{@link #SEND_SIGNAL}: {@link Optional#empty()} - a broadcast signal has no
+ * key to deduplicate by.</li>
  * <li>{@link #START_WORKFLOW_BY_MESSAGE}: like {@link #START_WORKFLOW}
  * (<code>workflowModuleId|bpmnProcessId|workflowAggregateId</code>) - a workflow
  * is started at most once per aggregate, regardless of the triggering
@@ -166,6 +168,18 @@ public record PhaseTwoOperation(
       "START_WORKFLOW_BY_MESSAGE", call -> START_WORKFLOW.idempotencyKey().derive(call));
 
   /**
+   * Phase two of broadcasting a BPMN signal - see
+   * {@code MigratableProcessService#sendSignalPhaseTwo}. The signal name travels in
+   * {@link PhaseTwoCall#args()} under {@link PhaseTwoCall#ARG_SIGNAL_NAME}, the
+   * broadcasting adapter IS persisted with the entry (a broadcast goes to every
+   * BPMS the workflow module was deployed to, so each of them gets its own entry).
+   * NO idempotency key: a signal has nothing to deduplicate by, and the same signal
+   * may legitimately be broadcast again and again.
+   */
+  public static final PhaseTwoOperation SEND_SIGNAL = new PhaseTwoOperation(
+      "SEND_SIGNAL", call -> Optional.empty());
+
+  /**
    * All operations owned by the VanillaBP core. Their names are reserved: an
    * extension registering one of them is rejected by
    * {@link PhaseTwoOperationRegistry#register(PhaseTwoOperation, PhaseTwoOperationDispatch)}.
@@ -178,7 +192,8 @@ public record PhaseTwoOperation(
           COMPLETE_USER_TASK,
           CANCEL_USER_TASK,
           CORRELATE_MESSAGE,
-          START_WORKFLOW_BY_MESSAGE);
+          START_WORKFLOW_BY_MESSAGE,
+          SEND_SIGNAL);
 
   public PhaseTwoOperation {
     Objects.requireNonNull(name, "name must not be null");

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperationDispatch.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperationDispatch.java
@@ -1,0 +1,33 @@
+package io.vanillabp.integration.spi;
+
+/**
+ * What a {@link PhaseTwoOperation} does once the local transaction was committed
+ * and the outbox store hands its entry back for execution. Registered together
+ * with the operation in the {@link PhaseTwoOperationRegistry}: the core registers
+ * the dispatch of its own operations (routing into the process service of the
+ * call's workflow module and BPMN process), an extension registers the dispatch
+ * of the operations it contributes.
+ * <p>
+ * The call is delivered exactly as it was scheduled (the store never interprets
+ * it). An exception aborts the dispatch: the outbox store keeps the entry, retries
+ * it with a backoff and blocks it after too many attempts - so throwing is the way
+ * to say &quot;not now&quot;, never a way to say &quot;never&quot;.
+ */
+@FunctionalInterface
+public interface PhaseTwoOperationDispatch {
+
+  /**
+   * Execute the given call.
+   *
+   * @param call The phase-two call as it was scheduled
+   * @param previouslyAttempted Whether the outbox entry was dispatched before (a
+   *        recovered or retried entry). Core start operations use it for the
+   *        re-dispatch mitigation; an extension may use it to distinguish the
+   *        first attempt from a repetition, but must stay correct either way -
+   *        stores which cannot tell pass <code>false</code>
+   */
+  void dispatch(
+      PhaseTwoCall call,
+      boolean previouslyAttempted);
+
+}

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperationRegistry.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOperationRegistry.java
@@ -1,0 +1,165 @@
+package io.vanillabp.integration.spi;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * All phase-two operations known to this application: VanillaBP's core operations
+ * plus the operations extensions contribute. The registry replaces what used to be
+ * a closed enum - an outbox entry persists the operation's NAME, and the name is
+ * resolved here at dispatch time.
+ * <p>
+ * The core registers its operations while the core's phase-two router is built, so
+ * they are available before the first entry can be dispatched. Extensions register
+ * theirs at startup:
+ *
+ * <pre>
+ * registry.register(
+ *     PhaseTwoOperation.extensionOperation("my-extension:NOTIFY", call -&gt; Optional.of(...)),
+ *     (call, previouslyAttempted) -&gt; notify(call));
+ * </pre>
+ *
+ * An extension operation is dispatched to the extension's own
+ * {@link PhaseTwoOperationDispatch} - the aggregate-ID-to-adapter election of the
+ * core operations does not apply to it.
+ * <p>
+ * Outbox stores never touch this registry: they persist the operation's name, its
+ * arguments and its idempotency key and stay operation-agnostic.
+ */
+public final class PhaseTwoOperationRegistry {
+
+  private record Registration(
+                              PhaseTwoOperation operation,
+                              PhaseTwoOperationDispatch dispatch) {
+  }
+
+  private final Map<String, Registration> registrations = new ConcurrentHashMap<>();
+
+  /**
+   * Register one of VanillaBP's core operations - called by the core itself. An
+   * operation which is not a core operation is rejected: extensions use
+   * {@link #register(PhaseTwoOperation, PhaseTwoOperationDispatch)}.
+   *
+   * @param operation The core operation, one of
+   *        {@link PhaseTwoOperation#CORE_OPERATIONS}
+   * @param dispatch What to do with a call of that operation after the commit
+   * @throws IllegalArgumentException If the operation is not a core operation
+   * @throws IllegalStateException If an operation of that name is already
+   *         registered
+   */
+  public void registerCoreOperation(
+      final PhaseTwoOperation operation,
+      final PhaseTwoOperationDispatch dispatch) {
+
+    if (PhaseTwoOperation.coreOperation(operation.name()).isEmpty()) {
+      throw new IllegalArgumentException(
+          """
+              The phase-two operation '%s' is not one of VanillaBP's core operations (%s)! Operations \
+              contributed by an extension are registered by 'register' and have to be namespaced \
+              (e.g. 'my-extension%sMY_OPERATION')."""
+              .formatted(
+                  operation.name(),
+                  String.join(", ", PhaseTwoOperation.coreOperationNames()),
+                  PhaseTwoOperation.NAMESPACE_SEPARATOR));
+    }
+    add(operation, dispatch);
+
+  }
+
+  /**
+   * Register an operation contributed by an extension. Its name has to be
+   * namespaced (see
+   * {@link PhaseTwoOperation#extensionOperation(String, PhaseTwoOperation.IdempotencyKey)}),
+   * which keeps it distinct from VanillaBP's core operations and from the
+   * operations of other extensions.
+   *
+   * @param operation The extension's operation
+   * @param dispatch What to do with a call of that operation after the commit
+   * @throws IllegalArgumentException If the name is a core operation's name or is
+   *         not namespaced (guiding message)
+   * @throws IllegalStateException If an operation of that name is already
+   *         registered
+   */
+  public void register(
+      final PhaseTwoOperation operation,
+      final PhaseTwoOperationDispatch dispatch) {
+
+    if (PhaseTwoOperation.coreOperation(operation.name()).isPresent()) {
+      throw new IllegalArgumentException(
+          """
+              The phase-two operation name '%s' is reserved for VanillaBP's core operations (%s)! An \
+              extension has to namespace its operations (e.g. 'my-extension%s%s') - the name is \
+              persisted in the outbox store, so it has to stay unique across the whole application."""
+              .formatted(
+                  operation.name(),
+                  String.join(", ", PhaseTwoOperation.coreOperationNames()),
+                  PhaseTwoOperation.NAMESPACE_SEPARATOR,
+                  operation.name()));
+    }
+    PhaseTwoOperation.validateNamespaced(operation);
+    add(operation, dispatch);
+
+  }
+
+  /**
+   * @param name The persisted name of an operation
+   * @return The registered operation of that name, if any
+   */
+  public Optional<PhaseTwoOperation> find(
+      final String name) {
+
+    return Optional
+        .ofNullable(registrations.get(name))
+        .map(Registration::operation);
+
+  }
+
+  /**
+   * @param name The persisted name of an operation
+   * @return The dispatch registered for that operation, if any
+   */
+  public Optional<PhaseTwoOperationDispatch> dispatchFor(
+      final String name) {
+
+    return Optional
+        .ofNullable(registrations.get(name))
+        .map(Registration::dispatch);
+
+  }
+
+  /**
+   * The names of all registered operations, sorted - used for guiding messages.
+   *
+   * @return The registered operations' names
+   */
+  public List<String> registeredNames() {
+
+    return registrations
+        .keySet()
+        .stream()
+        .sorted()
+        .toList();
+
+  }
+
+  private void add(
+      final PhaseTwoOperation operation,
+      final PhaseTwoOperationDispatch dispatch) {
+
+    final var previous = registrations
+        .putIfAbsent(operation.name(), new Registration(operation, dispatch));
+    if (previous != null) {
+      throw new IllegalStateException(
+          """
+              The phase-two operation '%s' is registered twice! Every operation is registered exactly \
+              once - by VanillaBP for its core operations, by the contributing extension for its own. \
+              Check whether the extension registers on every startup event it observes, or whether two \
+              extensions claim the same name."""
+              .formatted(operation.name()));
+    }
+
+  }
+
+}

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
@@ -271,6 +271,38 @@ public interface PhaseTwoOutbox {
   }
 
   /**
+   * Schedule phase two of pushing a changed workflow-aggregate to the BPMS. NO
+   * adapter ID is persisted - the adapter is elected at dispatch time by probing.
+   * There is NO idempotency key either: the values are read from the aggregate when
+   * the entry is dispatched, so a repeated dispatch writes the then-current state.
+   *
+   * @param workflowModuleId The ID of the workflow module the workflow belongs to
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param workflowAggregateId The ID of the workflow aggregate
+   * @param taskId The ID of the task whose scope receives the values, or
+   *        <code>null</code> for the workflow's global scope
+   * @return <code>true</code> if scheduled
+   */
+  default boolean scheduleAggregateChanged(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    final var args = new java.util.LinkedHashMap<String, String>();
+    if (taskId != null) {
+      args.put(PhaseTwoCall.ARG_TASK_ID, taskId);
+    }
+    return schedule(
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.AGGREGATE_CHANGED, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, args));
+
+  }
+
+  /**
    * Schedule phase two of broadcasting a BPMN signal. The broadcasting adapter IS
    * persisted with the entry: a broadcast reaches every BPMS the workflow module
    * was deployed to, so one entry per BPMS is scheduled and each is dispatched to

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
@@ -271,6 +271,33 @@ public interface PhaseTwoOutbox {
   }
 
   /**
+   * Schedule phase two of broadcasting a BPMN signal. The broadcasting adapter IS
+   * persisted with the entry: a broadcast reaches every BPMS the workflow module
+   * was deployed to, so one entry per BPMS is scheduled and each is dispatched to
+   * the BPMS it was written for. There is NO idempotency key - a signal has nothing
+   * to deduplicate by, so a redelivered entry broadcasts again.
+   *
+   * @param workflowModuleId The ID of the workflow module the signal belongs to
+   * @param bpmnProcessId The BPMN process ID whose process service was called
+   * @param signalName The PLAIN BPMN signal name
+   * @param adapterId The ID of the BPMS adapter to broadcast to
+   * @return <code>true</code> - a signal is never deduplicated
+   */
+  default boolean scheduleSendSignal(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName,
+      final String adapterId) {
+
+    return schedule(
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.SEND_SIGNAL, workflowModuleId, bpmnProcessId, null, adapterId, java.util.Map
+                    .of(PhaseTwoCall.ARG_SIGNAL_NAME, signalName)));
+
+  }
+
+  /**
    * Schedule phase two of starting a workflow BY MESSAGE. Start semantics: the
    * adapter elected in phase one is persisted and used in phase two, and a
    * workflow is started at most once per aggregate.

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
@@ -13,6 +13,12 @@ package io.vanillabp.integration.spi;
  * happens through the core's <code>PhaseTwoRouter</code> which routes the call to the
  * <code>MigrationProcessService</code> of the workflow module/BPMN process.
  * <p>
+ * An EXTENSION uses the same outbox for after-commit work of its own: it registers
+ * an operation in the {@link PhaseTwoOperationRegistry}, builds its calls with
+ * {@link PhaseTwoCall#of(PhaseTwoOperation, String, String, String, String, java.util.Map)}
+ * and schedules them here - the store treats them like any other entry, and the
+ * router dispatches them to the extension's own handler.
+ * <p>
  * Implementations are provided by the platform integrations (e.g. based on JDBC, JPA
  * or MongoDB) or by the business application itself, since the platform-neutral core
  * must not depend on any particular persistence technology.
@@ -102,9 +108,11 @@ public interface PhaseTwoOutbox {
       final String adapterId) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.START_WORKFLOW, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), adapterId, null));
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.START_WORKFLOW, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                adapterId, null));
 
   }
 
@@ -129,9 +137,11 @@ public interface PhaseTwoOutbox {
       final String taskId) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.COMPLETE_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), null, java.util.Map.of(PhaseTwoCall.ARG_TASK_ID, taskId)));
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.COMPLETE_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, java.util.Map.of(PhaseTwoCall.ARG_TASK_ID, taskId)));
 
   }
 
@@ -155,9 +165,11 @@ public interface PhaseTwoOutbox {
       final String bpmnErrorCode) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.CANCEL_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), null, java.util.Map
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.CANCEL_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, java.util.Map
                     .of(
                         PhaseTwoCall.ARG_TASK_ID, taskId, PhaseTwoCall.ARG_BPMN_ERROR_CODE,
                         bpmnErrorCode)));
@@ -182,9 +194,11 @@ public interface PhaseTwoOutbox {
       final String taskId) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.COMPLETE_USER_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), null, java.util.Map.of(PhaseTwoCall.ARG_TASK_ID, taskId)));
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.COMPLETE_USER_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, java.util.Map.of(PhaseTwoCall.ARG_TASK_ID, taskId)));
 
   }
 
@@ -208,9 +222,11 @@ public interface PhaseTwoOutbox {
       final String bpmnErrorCode) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.CANCEL_USER_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), null, java.util.Map
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.CANCEL_USER_TASK, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, java.util.Map
                     .of(
                         PhaseTwoCall.ARG_TASK_ID, taskId, PhaseTwoCall.ARG_BPMN_ERROR_CODE,
                         bpmnErrorCode)));
@@ -246,9 +262,11 @@ public interface PhaseTwoOutbox {
       args.put(PhaseTwoCall.ARG_CORRELATION_ID, correlationId);
     }
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.CORRELATE_MESSAGE, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), null, args));
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.CORRELATE_MESSAGE, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                null, args));
 
   }
 
@@ -273,9 +291,12 @@ public interface PhaseTwoOutbox {
       final String adapterId) {
 
     return schedule(
-        new PhaseTwoCall(
-            PhaseTwoOperation.START_WORKFLOW_BY_MESSAGE, workflowModuleId, bpmnProcessId, workflowAggregateId
-                .toString(), adapterId, java.util.Map.of(PhaseTwoCall.ARG_MESSAGE_NAME, messageName)));
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.START_WORKFLOW_BY_MESSAGE, workflowModuleId, bpmnProcessId, workflowAggregateId
+                    .toString(),
+                adapterId, java.util.Map
+                    .of(PhaseTwoCall.ARG_MESSAGE_NAME, messageName)));
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -44,6 +44,15 @@ public class MigrationProcessService<A> {
 
   private final List<MigratableProcessService<A>> adapterProcessServices;
 
+  /**
+   * The process services of every adapter the workflow module is DEPLOYED to (the
+   * union of story 27), which is more than the prioritized adapters of this process
+   * whenever another workflow of the module elects a different BPMS. A broadcast
+   * signal goes to all of them: while a migration runs, workflows waiting for the
+   * signal legitimately live in more than one BPMS.
+   */
+  private final List<MigratableProcessService<A>> deploymentAdapterProcessServices;
+
   private final AggregatePersistenceAware<A> aggregatePersistenceSupport;
 
   /**
@@ -136,6 +145,16 @@ public class MigrationProcessService<A> {
                         workflowModuleId,
                         workflowModuleId,
                         bpmnProcessId))))
+        .toList();
+    this.deploymentAdapterProcessServices = properties
+        .getDeploymentAdaptersFor(workflowModuleId)
+        .stream()
+        .map(adapterId -> processServices
+            .stream()
+            .filter(processService -> processService.getAdapterId().equals(adapterId))
+            .findFirst()
+            .orElse(null))
+        .filter(java.util.Objects::nonNull)
         .toList();
     this.phaseTwoOutboxResolver = phaseTwoOutboxResolver;
 
@@ -887,6 +906,96 @@ public class MigrationProcessService<A> {
     }
 
     return attachedAggregate;
+
+  }
+
+  /**
+   * Broadcasts a BPMN signal to every BPMS the workflow module is deployed to.
+   * <p>
+   * A signal is not addressed to a workflow, so nothing is probed and no aggregate
+   * is loaded or saved. Embedded BPMS broadcast inside the caller's transaction
+   * (a rollback takes the broadcast with it), remote BPMS get an outbox entry each
+   * and broadcast after the commit.
+   * <p>
+   * Every deployed BPMS is asked, not only the first-priority one: during a
+   * migration the workflows waiting for the signal are spread across them, and a
+   * broadcast reaching half of them would be worse than none.
+   *
+   * @param signalName The PLAIN BPMN signal name
+   */
+  public void sendSignal(
+      final String signalName) {
+
+    if ((signalName == null) || signalName.isBlank()) {
+      throw new IllegalArgumentException(
+          """
+              No signal name given (BPMN process '%s' of workflow module '%s')! Pass the signal name \
+              as it is modelled - VanillaBP applies the name scoping of the workflow module."""
+              .formatted(bpmnProcessId, workflowModuleId));
+    }
+
+    final var targets = deploymentAdapterProcessServices.isEmpty()
+        ? adapterProcessServices
+        : deploymentAdapterProcessServices;
+
+    RuntimeException failure = null;
+    for (final var adapter : targets) {
+      try {
+        adapter.sendSignalPhaseOne(workflowModuleId, bpmnProcessId, signalName);
+        if (adapter.needsTwoPhaseCommitForStartingWorkflows()) {
+          final var outbox = resolvePhaseTwoOutbox();
+          if (outbox == null) {
+            throw new IllegalStateException(
+                buildNoOutboxMessage(adapter.getAdapterId()));
+          }
+          outbox.scheduleSendSignal(workflowModuleId, bpmnProcessId, signalName, adapter.getAdapterId());
+        }
+      } catch (final RuntimeException e) {
+        // every BPMS is asked before the first failure is reported: a broadcast
+        // which stopped at the first unreachable BPMS would leave the others
+        // waiting, and the outbox retries what was scheduled anyway
+        log.error(
+            "Broadcasting signal '{}' of workflow module '{}' to adapter '{}' failed",
+            signalName,
+            workflowModuleId,
+            adapter.getAdapterId(),
+            e);
+        if (failure == null) {
+          failure = e;
+        }
+      }
+    }
+    if (failure != null) {
+      throw failure;
+    }
+
+  }
+
+  /**
+   * Executes phase two of broadcasting a signal, dispatched by the
+   * {@link PhaseTwoRouter} after the local transaction was committed. The adapter
+   * of the entry is the one the broadcast was scheduled for - there is no
+   * election, a broadcast is not about a workflow.
+   *
+   * @param signalName The PLAIN BPMN signal name
+   * @param adapterId The ID of the adapter to broadcast to
+   */
+  public void sendSignalPhaseTwo(
+      final String signalName,
+      final String adapterId) {
+
+    final var adapter = deploymentAdapterProcessServices
+        .stream()
+        .filter(candidate -> candidate.getAdapterId().equals(adapterId))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            """
+                Cannot broadcast signal '%s' of BPMN process '%s' (workflow module '%s'): the adapter \
+                '%s' the outbox entry was written for is not configured (any more)! Either restore the \
+                adapter's configuration or remove the entry from the outbox store."""
+                .formatted(signalName, bpmnProcessId, workflowModuleId, adapterId)));
+
+    adapter.sendSignalPhaseTwo(workflowModuleId, bpmnProcessId, signalName);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -230,6 +230,55 @@ public class MigrationProcessService<A> {
   }
 
   /**
+   * The type of the workflow aggregate's ID attribute, or <code>null</code> if the
+   * persistence layer does not report one (it then owns the serialized form).
+   *
+   * @return The ID type or <code>null</code>
+   */
+  public Class<?> getAggregateIdType() {
+
+    return aggregateIdType;
+
+  }
+
+  /**
+   * Loads the workflow aggregate by its ID in the aggregate's own ID type - used
+   * where the ID was not serialized in the first place (a workflow the BPMS started
+   * on its own).
+   *
+   * @param workflowAggregateId The ID in the aggregate's ID type
+   * @return The aggregate or <code>null</code> if there is none
+   */
+  public A loadWorkflowAggregateById(
+      final Object workflowAggregateId) {
+
+    return aggregatePersistenceSupport.loadById(workflowAggregateId);
+
+  }
+
+  /**
+   * @param workflowAggregate The aggregate to persist
+   * @return The persisted aggregate (attached, in case of an ORM)
+   */
+  public A saveWorkflowAggregate(
+      final A workflowAggregate) {
+
+    return aggregatePersistenceSupport.save(workflowAggregate);
+
+  }
+
+  /**
+   * @param workflowAggregate The aggregate to investigate
+   * @return Its ID
+   */
+  public Object getWorkflowAggregateId(
+      final A workflowAggregate) {
+
+    return aggregatePersistenceSupport.getAggregateId(workflowAggregate);
+
+  }
+
+  /**
    * Processes a BPMN task: loads the workflow aggregate by the context's serialized
    * ID, invokes the given <code>&#64;WorkflowTask</code> handler and saves the
    * aggregate - all within one transaction run by the given

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -910,6 +910,114 @@ public class MigrationProcessService<A> {
   }
 
   /**
+   * Pushes a changed workflow-aggregate to the BPMS holding its workflow: the
+   * aggregate is saved, the BPMS is located by probing {@code awarenessOfWorkflow},
+   * and the push runs in phase one (embedded) or is scheduled through the outbox
+   * (remote).
+   * <p>
+   * WHICH values travel is the sync model's business ({@code @SyncWithBPMS}), not
+   * this method's. WHERE they land depends on the task ID: <code>null</code> means
+   * the workflow's global scope, a task ID means the scope of that task instance
+   * only - a task-scoped push deliberately leaves the global values as they were.
+   *
+   * @param workflowAggregate The workflow aggregate
+   * @param taskId The ID of the task whose scope receives the values, or
+   *        <code>null</code> for the workflow's global scope
+   * @return The attached workflow aggregate
+   */
+  public A aggregateChanged(
+      final A workflowAggregate,
+      final String taskId) {
+
+    final var attachedAggregate = aggregatePersistenceSupport
+        .save(workflowAggregate);
+    final var aggregateId = aggregatePersistenceSupport
+        .getAggregateId(attachedAggregate);
+
+    final var subject = "workflow of aggregate '%s' (BPMN process '%s' of workflow module '%s')"
+        .formatted(aggregateId, bpmnProcessId, workflowModuleId);
+
+    final var location = workflowLocator.locate(
+        adapterProcessServices,
+        adapter -> adapter.awarenessOfWorkflow(aggregateId),
+        aggregateId,
+        subject);
+
+    switch (location.awareness()) {
+      case COMPLETED -> {
+        // a workflow which ended has no variables worth updating - the aggregate is
+        // saved either way, which is what the caller mainly wanted
+        log.warn(
+            "Ignored pushing the changed aggregate of {} to the BPMS: adapter '{}' reports the "
+                + "workflow as already completed",
+            subject,
+            location.adapter().getAdapterId());
+        return attachedAggregate;
+      }
+      case UNKNOWN_TO_BPMS -> throw new io.vanillabp.spi.process.WorkflowNotFoundException(
+          ("No configured BPMS knows the %s - the changed aggregate cannot be pushed (probed "
+              + "adapters, in prioritized order: %s)! The aggregate itself was saved. Likely "
+              + "causes: the workflow was never started, was started through another system, or "
+              + "already ended long ago.")
+              .formatted(subject, prioritizedAdapters));
+      default -> {
+        // ACTIVE - fall through
+      }
+    }
+
+    final var adapter = location.adapter();
+    adapter.aggregateChangedPhaseOne(
+        workflowModuleId, bpmnProcessId, aggregatePersistenceSupport, attachedAggregate, taskId);
+
+    if (adapter.needsTwoPhaseCommitForStartingWorkflows()) {
+      final var outbox = resolvePhaseTwoOutbox();
+      if (outbox == null) {
+        throw new IllegalStateException(
+            buildNoOutboxMessage(adapter.getAdapterId()));
+      }
+      outbox.scheduleAggregateChanged(workflowModuleId, bpmnProcessId, aggregateId, taskId);
+    }
+
+    return attachedAggregate;
+
+  }
+
+  /**
+   * Executes phase two of pushing a changed workflow-aggregate - dispatch-time
+   * election via probing; a workflow gone by now is a stale entry (logged,
+   * consumed). The values are read from the aggregate as it is now.
+   *
+   * @param workflowAggregateId The ID of the workflow aggregate (original type)
+   * @param taskId The ID of the task whose scope receives the values, or
+   *        <code>null</code> for the workflow's global scope
+   */
+  public void aggregateChangedPhaseTwo(
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    final var subject = "workflow of aggregate '%s' (BPMN process '%s' of workflow module '%s')"
+        .formatted(workflowAggregateId, bpmnProcessId, workflowModuleId);
+
+    final var location = workflowLocator.locate(
+        adapterProcessServices,
+        adapter -> adapter.awarenessOfWorkflow(workflowAggregateId),
+        workflowAggregateId,
+        subject);
+
+    switch (location.awareness()) {
+      case UNKNOWN_TO_BPMS, COMPLETED -> log.warn(
+          "Skipped phase two of pushing the changed aggregate of {}: the workflow is gone (stale "
+              + "outbox entry); the entry is consumed",
+          subject);
+      default -> location
+          .adapter()
+          .aggregateChangedPhaseTwo(
+              workflowModuleId, bpmnProcessId, aggregatePersistenceSupport, workflowAggregateId, taskId);
+    }
+
+  }
+
+  /**
    * Broadcasts a BPMN signal to every BPMS the workflow module is deployed to.
    * <p>
    * A signal is not addressed to a workflow, so nothing is probed and no aggregate

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
@@ -2,8 +2,11 @@ package io.vanillabp.integration.adapter.migration.processservice;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.BiConsumer;
 
 import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
 import io.vanillabp.integration.spi.PhaseTwoOutbox;
 
 /**
@@ -23,6 +26,13 @@ import io.vanillabp.integration.spi.PhaseTwoOutbox;
  * converted back into the aggregate's ID type by the process service itself
  * ({@link MigrationProcessService#convertAggregateId} - the ID type comes from the
  * aggregate's persistence support), so the conversion happens exactly once, here.
+ * <p>
+ * WHICH operations exist is not hardcoded here: the router owns a
+ * {@link PhaseTwoOperationRegistry} and registers the dispatch of VanillaBP's core
+ * operations into it while it is built. An extension registers its own operations
+ * in the same registry (see {@link #getOperations()}) and receives their calls in
+ * its own {@link io.vanillabp.integration.spi.PhaseTwoOperationDispatch} - the
+ * process-service routing below applies to core operations only.
  */
 public final class PhaseTwoRouter {
 
@@ -32,6 +42,38 @@ public final class PhaseTwoRouter {
   }
 
   private final Map<RegistrationKey, MigrationProcessService<?>> registrations = new ConcurrentHashMap<>();
+
+  private final PhaseTwoOperationRegistry operations;
+
+  public PhaseTwoRouter() {
+
+    this(new PhaseTwoOperationRegistry());
+
+  }
+
+  /**
+   * @param operations The registry to register the core operations in and to
+   *        resolve dispatched operations from
+   */
+  public PhaseTwoRouter(
+      final PhaseTwoOperationRegistry operations) {
+
+    this.operations = operations;
+    registerCoreOperations();
+
+  }
+
+  /**
+   * The registry of phase-two operations - extensions register their own
+   * operations here (the platform integrations offer it as a bean).
+   *
+   * @return The operation registry used by this router
+   */
+  public PhaseTwoOperationRegistry getOperations() {
+
+    return operations;
+
+  }
 
   /**
    * Register the process service of a workflow module/BPMN process as dispatch
@@ -87,6 +129,151 @@ public final class PhaseTwoRouter {
       final PhaseTwoCall call,
       final boolean previouslyAttempted) {
 
+    final var dispatch = operations
+        .dispatchFor(call.operation())
+        .orElseThrow(() -> new IllegalStateException(
+            """
+                Cannot dispatch outbox entry (operation '%s', aggregate ID '%s'): no phase-two \
+                operation of that name is registered! Registered operations: %s. Either the entry was \
+                written by a newer version of your software, or the extension contributing the \
+                operation is no longer part of this application - the entry stays in the outbox store \
+                for operations until the operation is available again or the entry is removed."""
+                .formatted(
+                    call.operation(),
+                    call.workflowAggregateId(),
+                    String.join(", ", operations.registeredNames()))));
+
+    dispatch.dispatch(call, previouslyAttempted);
+
+  }
+
+  /**
+   * Registers the dispatch of VanillaBP's core operations: each of them routes to
+   * the process service of the call's workflow module and BPMN process.
+   */
+  private void registerCoreOperations() {
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.START_WORKFLOW,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .startWorkflowPhaseTwo(
+                                workflowAggregateId,
+                                call.adapterId(),
+                                previouslyAttempted)));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.COMPLETE_TASK,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .completeTaskPhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_TASK_ID))));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.CANCEL_TASK,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .cancelTaskPhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_TASK_ID),
+                                call.args().get(PhaseTwoCall.ARG_BPMN_ERROR_CODE))));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.COMPLETE_USER_TASK,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .completeUserTaskPhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_TASK_ID))));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.CANCEL_USER_TASK,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .cancelUserTaskPhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_TASK_ID),
+                                call.args().get(PhaseTwoCall.ARG_BPMN_ERROR_CODE))));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.CORRELATE_MESSAGE,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .correlateMessagePhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_MESSAGE_NAME),
+                                call.args().get(PhaseTwoCall.ARG_CORRELATION_ID))));
+
+    operations
+        .registerCoreOperation(
+            PhaseTwoOperation.START_WORKFLOW_BY_MESSAGE,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .startWorkflowByMessagePhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_MESSAGE_NAME),
+                                call.adapterId(),
+                                previouslyAttempted)));
+
+  }
+
+  /**
+   * Resolves the process service of the call's workflow module and BPMN process,
+   * converts the serialized aggregate ID and hands both to the given action - the
+   * shared part of every core operation's dispatch.
+   *
+   * @param call The call being dispatched
+   * @param action What to do with the process service and the converted aggregate
+   *        ID
+   * @throws IllegalStateException If no process service is registered for the
+   *         call's workflow module/BPMN process
+   */
+  private void withProcessService(
+      final PhaseTwoCall call,
+      final BiConsumer<MigrationProcessService<?>, Object> action) {
+
     final var processService = registrations
         .get(new RegistrationKey(call.workflowModuleId(), call.bpmnProcessId()));
     if (processService == null) {
@@ -103,42 +290,10 @@ public final class PhaseTwoRouter {
                   call.workflowModuleId()));
     }
 
-    final var workflowAggregateId = processService
-        .convertAggregateId(call.workflowAggregateId());
-
-    switch (call.operation()) {
-      case START_WORKFLOW -> processService
-          .startWorkflowPhaseTwo(workflowAggregateId, call.adapterId(), previouslyAttempted);
-      case COMPLETE_TASK -> processService
-          .completeTaskPhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_TASK_ID));
-      case CANCEL_TASK -> processService
-          .cancelTaskPhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_TASK_ID),
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_BPMN_ERROR_CODE));
-      case COMPLETE_USER_TASK -> processService
-          .completeUserTaskPhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_TASK_ID));
-      case CANCEL_USER_TASK -> processService
-          .cancelUserTaskPhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_TASK_ID),
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_BPMN_ERROR_CODE));
-      case CORRELATE_MESSAGE -> processService
-          .correlateMessagePhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_MESSAGE_NAME),
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_CORRELATION_ID));
-      case START_WORKFLOW_BY_MESSAGE -> processService
-          .startWorkflowByMessagePhaseTwo(
-              workflowAggregateId,
-              call.args().get(io.vanillabp.integration.spi.PhaseTwoCall.ARG_MESSAGE_NAME),
-              call.adapterId(),
-              previouslyAttempted);
-    }
+    action
+        .accept(
+            processService,
+            processService.convertAggregateId(call.workflowAggregateId()));
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
@@ -243,6 +243,20 @@ public final class PhaseTwoRouter {
 
     operations
         .registerCoreOperation(
+            PhaseTwoOperation.AGGREGATE_CHANGED,
+            (
+                call,
+                previouslyAttempted) -> withProcessService(
+                    call,
+                    (
+                        processService,
+                        workflowAggregateId) -> processService
+                            .aggregateChangedPhaseTwo(
+                                workflowAggregateId,
+                                call.args().get(PhaseTwoCall.ARG_TASK_ID))));
+
+    operations
+        .registerCoreOperation(
             PhaseTwoOperation.SEND_SIGNAL,
             (
                 call,

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
@@ -243,6 +243,34 @@ public final class PhaseTwoRouter {
 
     operations
         .registerCoreOperation(
+            PhaseTwoOperation.SEND_SIGNAL,
+            (
+                call,
+                previouslyAttempted) -> {
+              // a broadcast is not about one workflow: no aggregate ID is converted
+              // and no process service has to hold an aggregate - only the routing
+              // by (module, process) applies
+              final var processService = registrations
+                  .get(new RegistrationKey(call.workflowModuleId(), call.bpmnProcessId()));
+              if (processService == null) {
+                throw new IllegalStateException(
+                    """
+                        Cannot dispatch outbox entry (operation '%s', signal '%s'): BPMN process '%s' of \
+                        workflow module '%s' is not (or no longer) part of this application! If the \
+                        process was removed on purpose, remove the entry from the outbox store - it \
+                        stays visible there for operations."""
+                        .formatted(
+                            call.operation(),
+                            call.args().get(PhaseTwoCall.ARG_SIGNAL_NAME),
+                            call.bpmnProcessId(),
+                            call.workflowModuleId()));
+              }
+              processService
+                  .sendSignalPhaseTwo(call.args().get(PhaseTwoCall.ARG_SIGNAL_NAME), call.adapterId());
+            });
+
+    operations
+        .registerCoreOperation(
             PhaseTwoOperation.START_WORKFLOW_BY_MESSAGE,
             (
                 call,

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/ProcessServiceBase.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/ProcessServiceBase.java
@@ -42,6 +42,26 @@ public abstract class ProcessServiceBase<A> implements ProcessService<A> {
 
   }
 
+  /**
+   * Builds the exception thrown when {@link #sendSignal(String)} is called without
+   * an active transaction. A broadcast needs one for a different reason than a
+   * workflow start does, so it says so itself.
+   *
+   * @return The exception to be thrown by the platform bean
+   */
+  protected static IllegalStateException newMissingTransactionExceptionForSignal() {
+
+    return new IllegalStateException(
+        """
+            No transaction is active! Broadcasting a signal has to run within a transaction: an \
+            embedded BPMS broadcasts inside it (so a rollback takes the broadcast with it), and for \
+            a remote BPMS the outbox entry carrying the broadcast rides it. Annotate the service \
+            method calling 'sendSignal' with @Transactional \
+            (org.springframework.transaction.annotation.Transactional on Spring Boot, \
+            jakarta.transaction.Transactional on Quarkus).""");
+
+  }
+
   @Override
   public A completeUserTask(
       final A workflowAggregate,

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/values/ValueConversion.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/values/ValueConversion.java
@@ -1,0 +1,156 @@
+package io.vanillabp.integration.adapter.migration.values;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+/**
+ * Converts a value a BPMS reported (a process variable, an input mapping) into the
+ * type the application expects. Shared by everything binding BPMS values to Java:
+ * the parameters of a <code>&#64;WorkflowTask</code> method, the parameters of a
+ * <code>&#64;WorkflowStartedByBpms</code> method and the attributes of a workflow
+ * aggregate built for a BPMS-initiated start.
+ * <p>
+ * Deliberately narrow: identity, the String and Number conversions between the
+ * types a BPMS can carry, and a guiding failure for everything else. Anything
+ * richer belongs to the application, which knows what its values mean.
+ */
+public final class ValueConversion {
+
+  private ValueConversion() {
+  }
+
+  /**
+   * Converts a value supplied by a BPMS to the target type: assignable values pass
+   * through, Strings become the common primitive/wrapper types and
+   * BigDecimal/BigInteger, numbers are narrowed or widened between number types.
+   *
+   * @param value The value reported by the BPMS (may be <code>null</code>)
+   * @param targetType The type the application expects
+   * @param location What is being bound, named by the failure message
+   * @return The converted value
+   * @throws IllegalStateException If the value cannot be converted, or if it is
+   *           <code>null</code> and the target type is primitive
+   */
+  public static Object convert(
+      final Object value,
+      final Class<?> targetType,
+      final String location) {
+
+    if (value == null) {
+      if (targetType.isPrimitive()) {
+        throw new IllegalStateException(
+            """
+                The value bound to %s is null but the parameter's type is primitive! Use the \
+                wrapper type or ensure the BPMN input mapping provides a value."""
+                .formatted(location));
+      }
+      return null;
+    }
+    if (wrapperOf(targetType).isInstance(value)) {
+      return value;
+    }
+    final var target = wrapperOf(targetType);
+    if (value instanceof String string) {
+      if (target.equals(Integer.class)) {
+        return Integer.valueOf(string);
+      }
+      if (target.equals(Long.class)) {
+        return Long.valueOf(string);
+      }
+      if (target.equals(Double.class)) {
+        return Double.valueOf(string);
+      }
+      if (target.equals(Float.class)) {
+        return Float.valueOf(string);
+      }
+      if (target.equals(Short.class)) {
+        return Short.valueOf(string);
+      }
+      if (target.equals(Byte.class)) {
+        return Byte.valueOf(string);
+      }
+      if (target.equals(Boolean.class)) {
+        return Boolean.valueOf(string);
+      }
+      if (target.equals(BigDecimal.class)) {
+        return new BigDecimal(string);
+      }
+      if (target.equals(BigInteger.class)) {
+        return new BigInteger(string);
+      }
+    }
+    if (value instanceof Number number) {
+      if (target.equals(Integer.class)) {
+        return number.intValue();
+      }
+      if (target.equals(Long.class)) {
+        return number.longValue();
+      }
+      if (target.equals(Double.class)) {
+        return number.doubleValue();
+      }
+      if (target.equals(Float.class)) {
+        return number.floatValue();
+      }
+      if (target.equals(Short.class)) {
+        return number.shortValue();
+      }
+      if (target.equals(Byte.class)) {
+        return number.byteValue();
+      }
+      if (target.equals(BigDecimal.class)) {
+        return new BigDecimal(number.toString());
+      }
+      if (target.equals(BigInteger.class)) {
+        return new BigInteger(number.toString());
+      }
+      if (target.equals(String.class)) {
+        return number.toString();
+      }
+    }
+    throw new IllegalStateException(
+        """
+            The value of type '%s' bound to %s cannot be converted to the parameter's type '%s'!"""
+            .formatted(value.getClass().getName(), location, targetType.getName()));
+
+  }
+
+  /**
+   * @param type A type which may be primitive
+   * @return Its wrapper type, or the type itself if it is not primitive
+   */
+  private static Class<?> wrapperOf(
+      final Class<?> type) {
+
+    if (!type.isPrimitive()) {
+      return type;
+    }
+    if (type.equals(int.class)) {
+      return Integer.class;
+    }
+    if (type.equals(long.class)) {
+      return Long.class;
+    }
+    if (type.equals(double.class)) {
+      return Double.class;
+    }
+    if (type.equals(float.class)) {
+      return Float.class;
+    }
+    if (type.equals(short.class)) {
+      return Short.class;
+    }
+    if (type.equals(byte.class)) {
+      return Byte.class;
+    }
+    if (type.equals(boolean.class)) {
+      return Boolean.class;
+    }
+    if (type.equals(char.class)) {
+      return Character.class;
+    }
+    return type;
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
@@ -97,9 +97,50 @@ public class WorkflowEndedHandler {
   boolean matchesVersion(
       final String processVersion) {
 
+    return matchesVersion(processVersion, VersionRange.NO_RESOLVER);
+
+  }
+
+  boolean matchesVersion(
+      final String processVersion,
+      final VersionRange.ProcessVersionResolver resolver) {
+
     return versions
         .stream()
-        .anyMatch(version -> version.matches(processVersion));
+        .anyMatch(version -> version.matches(processVersion, resolver));
+
+  }
+
+  /**
+   * Whether this handler and the given one serve at least one common process version -
+   * two handlers serving the same end event are ambiguous exactly then.
+   *
+   * @param other The other handler
+   * @param resolver Resolves version tags of the BPMN process both belong to
+   * @return Whether both serve a common version
+   */
+  boolean overlapsVersions(
+      final WorkflowEndedHandler other,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    return versions
+        .stream()
+        .anyMatch(version -> other.versions
+            .stream()
+            .anyMatch(otherVersion -> version.overlaps(otherVersion, resolver)));
+
+  }
+
+  /**
+   * @return The version tags this handler's version specifications name
+   */
+  List<String> versionTags() {
+
+    return versions
+        .stream()
+        .flatMap(version -> version.versionTags().stream())
+        .distinct()
+        .toList();
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
@@ -1,0 +1,136 @@
+package io.vanillabp.integration.adapter.migration.workflowend;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+
+/**
+ * One <code>&#64;WorkflowEnded</code> method of a workflow service class, with its
+ * parameter binders and the end event it serves.
+ */
+public class WorkflowEndedHandler {
+
+  /**
+   * Binds one parameter of the method from the workflow aggregate and the adapter's
+   * notification.
+   */
+  @FunctionalInterface
+  interface ParameterBinder {
+
+    Object bind(
+        Object workflowAggregate,
+        WorkflowEndedContext context);
+
+  }
+
+  private final Class<?> workflowServiceClass;
+
+  private final Method method;
+
+  private final Supplier<Object> workflowServiceBean;
+
+  private final List<ParameterBinder> binders;
+
+  /**
+   * The BPMN id of the end event this method serves, or <code>null</code> for every
+   * end of the workflow.
+   */
+  private final String endEventId;
+
+  private final List<VersionRange> versions;
+
+  WorkflowEndedHandler(
+      final Class<?> workflowServiceClass,
+      final Method method,
+      final Supplier<Object> workflowServiceBean,
+      final List<ParameterBinder> binders,
+      final String endEventId,
+      final List<VersionRange> versions) {
+
+    this.workflowServiceClass = workflowServiceClass;
+    this.method = method;
+    this.workflowServiceBean = workflowServiceBean;
+    this.binders = binders;
+    this.endEventId = endEventId;
+    this.versions = versions;
+
+  }
+
+  public String getEndEventId() {
+
+    return endEventId;
+
+  }
+
+  /**
+   * @return The method, for guiding messages
+   */
+  public String describe() {
+
+    return "%s#%s".formatted(workflowServiceClass.getName(), method.getName());
+
+  }
+
+  /**
+   * @return What this handler is wired to, for guiding messages
+   */
+  public String describeWiring() {
+
+    return endEventId == null
+        ? "every end of the workflow"
+        : "end event '%s'".formatted(endEventId);
+
+  }
+
+  boolean matchesEndEvent(
+      final String eventId) {
+
+    // a BPMS reporting no end event id serves the methods which asked for none
+    return (endEventId == null) || endEventId.equals(eventId);
+
+  }
+
+  boolean matchesVersion(
+      final String processVersion) {
+
+    return versions
+        .stream()
+        .anyMatch(version -> version.matches(processVersion));
+
+  }
+
+  /**
+   * Invokes the method with bound parameters. Runtime exceptions propagate - the
+   * transaction rolls back and the BPMS applies its retry semantics.
+   *
+   * @param workflowAggregate The workflow aggregate of the ended workflow
+   * @param context The adapter's notification
+   */
+  void invoke(
+      final Object workflowAggregate,
+      final WorkflowEndedContext context) {
+
+    final var arguments = binders
+        .stream()
+        .map(binder -> binder.bind(workflowAggregate, context))
+        .toArray();
+    try {
+      method.invoke(workflowServiceBean.get(), arguments);
+    } catch (final IllegalAccessException e) {
+      throw new IllegalStateException(
+          "Could not invoke @WorkflowEnded method '%s'!".formatted(describe()), e);
+    } catch (final InvocationTargetException e) {
+      if (e.getTargetException() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new IllegalStateException(
+          "The @WorkflowEnded method '%s' threw a checked exception!".formatted(describe()), e.getTargetException());
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -1,0 +1,187 @@
+package io.vanillabp.integration.adapter.migration.workflowend;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+
+/**
+ * The <code>&#64;WorkflowEnded</code> methods of the application per (workflow
+ * module, BPMN process). Backs the adapter-facing
+ * {@link io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedInvoker},
+ * which the workflow-task registry implements by delegating here.
+ */
+public class WorkflowEndedHandlers {
+
+  private static final Logger log = LoggerFactory.getLogger(WorkflowEndedHandlers.class);
+
+  private record RegistryKey(
+                             String workflowModuleId,
+                             String bpmnProcessId) {
+  }
+
+  private final Map<RegistryKey, List<WorkflowEndedHandler>> handlers = new ConcurrentHashMap<>();
+
+  /**
+   * Scans a workflow service class and registers what it found. Called by the
+   * platform integration at startup, once per (workflow service class, declared
+   * BPMN process ID).
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowServiceClass The <code>&#64;WorkflowService</code> class
+   * @param workflowAggregateClass The workflow-aggregate class
+   * @param workflowServiceBean Supplies the bean instance of that class
+   */
+  public void registerWorkflowService(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Class<?> workflowServiceClass,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean) {
+
+    final var scanned = WorkflowEndedScanner
+        .scan(workflowServiceClass, workflowAggregateClass, workflowServiceBean);
+    if (scanned.isEmpty()) {
+      return;
+    }
+    final var registered = handlers
+        .computeIfAbsent(new RegistryKey(workflowModuleId, bpmnProcessId), key -> new LinkedList<>());
+    synchronized (registered) {
+      scanned
+          .forEach(handler -> {
+            failOnDuplicateWiring(workflowModuleId, bpmnProcessId, registered, handler);
+            registered.add(handler);
+          });
+    }
+
+  }
+
+  private static void failOnDuplicateWiring(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final List<WorkflowEndedHandler> registered,
+      final WorkflowEndedHandler handler) {
+
+    final var duplicate = registered
+        .stream()
+        .filter(existing -> java.util.Objects.equals(existing.getEndEventId(), handler.getEndEventId()))
+        .filter(existing -> existing.matchesVersion(null) && handler.matchesVersion(null))
+        .findFirst();
+    if (duplicate.isPresent()) {
+      throw new IllegalStateException(
+          """
+              The @WorkflowEnded methods '%s' and '%s' both serve %s of BPMN process '%s' of workflow \
+              module '%s'! Remove one of them, name the end events they serve by \
+              @WorkflowEnded(id = ...) or distinguish them by version."""
+              .formatted(
+                  duplicate.get().describe(),
+                  handler.describe(),
+                  handler.describeWiring(),
+                  bpmnProcessId,
+                  workflowModuleId));
+    }
+
+  }
+
+  /**
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return Whether the application wants to be told about the end of workflows of
+   *         that process
+   */
+  public boolean handlerExists(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return handlers.containsKey(new RegistryKey(workflowModuleId, bpmnProcessId));
+
+  }
+
+  /**
+   * Tells the application that a workflow ended: loads the aggregate, calls the
+   * method and saves the aggregate, in one transaction.
+   *
+   * @param <A> The workflow-aggregate type
+   * @param processService The process service of the BPMN process
+   * @param context The adapter's notification
+   * @param transactionRunner The platform's transaction runner
+   */
+  public <A> void workflowEnded(
+      final MigrationProcessService<A> processService,
+      final WorkflowEndedContext context,
+      final TransactionRunner transactionRunner) {
+
+    final var registered = handlers
+        .get(
+            new RegistryKey(processService.getWorkflowModuleId(), processService.getBpmnProcessId()));
+    if (registered == null) {
+      // the adapter attached a listener although nothing is registered - possible
+      // when a deployed model outlives the workflow service which asked for it
+      log
+          .debug(
+              "No @WorkflowEnded method for BPMN process '{}' of workflow module '{}' - the end of "
+                  + "workflow '{}' is not reported to the application",
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              context.getWorkflowAggregateId());
+      return;
+    }
+
+    final var handler = registered
+        .stream()
+        .filter(candidate -> candidate.matchesEndEvent(context.getEndEventId()))
+        .filter(candidate -> candidate.matchesVersion(context.getProcessVersion()))
+        .findFirst()
+        .orElse(null);
+    if (handler == null) {
+      log
+          .debug(
+              "No @WorkflowEnded method of BPMN process '{}' (workflow module '{}') serves end event "
+                  + "'{}' of process version '{}' - the end of workflow '{}' is not reported",
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              context.getEndEventId(),
+              context.getProcessVersion(),
+              context.getWorkflowAggregateId());
+      return;
+    }
+
+    final Supplier<Void> transactionalWork = () -> {
+      final var workflowAggregate = processService
+          .loadWorkflowAggregate(context.getWorkflowAggregateId());
+      if (workflowAggregate == null) {
+        // NOT an error: an application may delete the aggregate of a workflow which
+        // ended, and a redelivered notification would find nothing either
+        log
+            .info(
+                "The workflow aggregate '{}' of BPMN process '{}' (workflow module '{}') does not "
+                    + "exist (any more) - the end of that workflow is not reported to '{}'",
+                context.getWorkflowAggregateId(),
+                processService.getBpmnProcessId(),
+                processService.getWorkflowModuleId(),
+                handler.describe());
+        return null;
+      }
+      handler.invoke(workflowAggregate, context);
+      processService.saveWorkflowAggregate(workflowAggregate);
+      return null;
+    };
+
+    if (context.runInCurrentTransaction()) {
+      transactionRunner.inCurrent(transactionalWork);
+    } else {
+      transactionRunner.requireNew(transactionalWork);
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -31,6 +31,20 @@ public class WorkflowEndedHandlers {
   private final Map<RegistryKey, List<WorkflowEndedHandler>> handlers = new ConcurrentHashMap<>();
 
   /**
+   * What the BPMS know about the deployed versions of the BPMN processes - owned by the
+   * {@link io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry}
+   * and shared, since all three annotations carry a <code>version</code> attribute.
+   */
+  private final io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions processVersions;
+
+  public WorkflowEndedHandlers(
+      final io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions processVersions) {
+
+    this.processVersions = processVersions;
+
+  }
+
+  /**
    * Scans a workflow service class and registers what it found. Called by the
    * platform integration at startup, once per (workflow service class, declared
    * BPMN process ID).
@@ -58,10 +72,58 @@ public class WorkflowEndedHandlers {
     synchronized (registered) {
       scanned
           .forEach(handler -> {
-            failOnDuplicateWiring(workflowModuleId, bpmnProcessId, registered, handler);
+            failOnDuplicateWiring(
+                workflowModuleId,
+                bpmnProcessId,
+                registered,
+                handler,
+                io.vanillabp.integration.adapter.migration.workflowtask.VersionRange.NO_RESOLVER);
             registered.add(handler);
           });
     }
+
+  }
+
+  /**
+   * Resolves the version tags the methods of the given workflow module name and checks
+   * the version ranges naming a tag for overlaps - those could not be placed while
+   * registering, since no BPMS had been asked about its versions at that point.
+   *
+   * @param workflowModuleId The workflow module ID
+   */
+  public void resolveProcessVersions(
+      final String workflowModuleId) {
+
+    handlers
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().workflowModuleId().equals(workflowModuleId))
+        .forEach(entry -> {
+          final var bpmnProcessId = entry.getKey().bpmnProcessId();
+          final var registered = entry.getValue();
+          if (registered.stream().allMatch(handler -> handler.versionTags().isEmpty())) {
+            return;
+          }
+          processVersions.warmUp(workflowModuleId, bpmnProcessId);
+          final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+          synchronized (registered) {
+            registered
+                .forEach(handler -> handler
+                    .versionTags()
+                    .forEach(tag -> processVersions.reportUnknownVersionTag(
+                        workflowModuleId,
+                        bpmnProcessId,
+                        tag,
+                        handler.describe())));
+            registered
+                .forEach(handler -> failOnDuplicateWiring(
+                    workflowModuleId,
+                    bpmnProcessId,
+                    registered,
+                    handler,
+                    resolver));
+          }
+        });
 
   }
 
@@ -69,12 +131,16 @@ public class WorkflowEndedHandlers {
       final String workflowModuleId,
       final String bpmnProcessId,
       final List<WorkflowEndedHandler> registered,
-      final WorkflowEndedHandler handler) {
+      final WorkflowEndedHandler handler,
+      final io.vanillabp.integration.adapter.migration.workflowtask.VersionRange.ProcessVersionResolver resolver) {
 
     final var duplicate = registered
         .stream()
+        .filter(existing -> existing != handler)
         .filter(existing -> java.util.Objects.equals(existing.getEndEventId(), handler.getEndEventId()))
-        .filter(existing -> existing.matchesVersion(null) && handler.matchesVersion(null))
+        // overlapping version ranges are ambiguous; disjoint ones are a legitimate
+        // way to serve several process versions
+        .filter(existing -> existing.overlapsVersions(handler, resolver))
         .findFirst();
     if (duplicate.isPresent()) {
       throw new IllegalStateException(
@@ -139,7 +205,11 @@ public class WorkflowEndedHandlers {
     final var handler = registered
         .stream()
         .filter(candidate -> candidate.matchesEndEvent(context.getEndEventId()))
-        .filter(candidate -> candidate.matchesVersion(context.getProcessVersion()))
+        .filter(candidate -> candidate.matchesVersion(
+            context.getProcessVersion(),
+            processVersions.resolverFor(
+                processService.getWorkflowModuleId(),
+                processService.getBpmnProcessId())))
         .findFirst()
         .orElse(null);
     if (handler == null) {

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedScanner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedScanner.java
@@ -1,0 +1,128 @@
+package io.vanillabp.integration.adapter.migration.workflowend;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.vanillabp.integration.adapter.migration.workflowend.WorkflowEndedHandler.ParameterBinder;
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.spi.service.WorkflowEnd;
+import io.vanillabp.spi.service.WorkflowEnded;
+
+/**
+ * Scans a <code>&#64;WorkflowService</code> class for
+ * <code>&#64;WorkflowEnded</code> methods and builds their handlers. Runs once at
+ * startup per workflow service class; defects yield guiding exceptions naming the
+ * method and the fix.
+ * <p>
+ * The binding surface is the smallest of all handler kinds: a workflow which ended
+ * has no task and no variables worth binding, so what a method may ask for is the
+ * workflow aggregate and a {@link WorkflowEnd}.
+ */
+public final class WorkflowEndedScanner {
+
+  private WorkflowEndedScanner() {
+  }
+
+  /**
+   * @param workflowServiceClass The <code>&#64;WorkflowService</code> class
+   * @param workflowAggregateClass The workflow-aggregate class of that service
+   * @param workflowServiceBean Supplies the bean instance of the class
+   * @return The handlers, possibly empty
+   */
+  public static List<WorkflowEndedHandler> scan(
+      final Class<?> workflowServiceClass,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean) {
+
+    final var handlers = new LinkedList<WorkflowEndedHandler>();
+    for (final var method : workflowServiceClass.getMethods()) {
+      final var annotation = method.getAnnotation(WorkflowEnded.class);
+      if (annotation == null) {
+        continue;
+      }
+      handlers
+          .add(
+              buildHandler(
+                  workflowServiceClass,
+                  method,
+                  workflowAggregateClass,
+                  workflowServiceBean,
+                  annotation));
+    }
+    return handlers;
+
+  }
+
+  private static WorkflowEndedHandler buildHandler(
+      final Class<?> workflowServiceClass,
+      final Method method,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean,
+      final WorkflowEnded annotation) {
+
+    final var location = "%s#%s".formatted(workflowServiceClass.getName(), method.getName());
+    // a public method of a package-private bean class is not accessible through
+    // plain reflection - lift the check once at scan time
+    method.trySetAccessible();
+
+    if (!method.getReturnType().equals(void.class)) {
+      throw new IllegalStateException(
+          """
+              The @WorkflowEnded method '%s' returns '%s'! A workflow which ended cannot be \
+              influenced any more, so the method has nothing to return - declare it void."""
+              .formatted(location, method.getReturnType().getName()));
+    }
+
+    final var binders = Arrays
+        .stream(method.getParameters())
+        .map(parameter -> buildParameterBinder(
+            parameter,
+            workflowAggregateClass,
+            "parameter '%s' of @WorkflowEnded method '%s'".formatted(parameter.getName(), location)))
+        .toList();
+
+    final var versions = Arrays
+        .stream(annotation.version())
+        .map(version -> VersionRange.parse(version, location))
+        .toList();
+    final var endEventId = annotation.id().equals(WorkflowEnded.ANY_END_EVENT)
+        ? null
+        : annotation.id();
+
+    return new WorkflowEndedHandler(
+        workflowServiceClass, method, workflowServiceBean, binders, endEventId, versions);
+
+  }
+
+  private static ParameterBinder buildParameterBinder(
+      final Parameter parameter,
+      final Class<?> workflowAggregateClass,
+      final String location) {
+
+    if (parameter.getType().equals(WorkflowEnd.class)) {
+      return (
+          aggregate,
+          context) -> new WorkflowEnd(
+              context.getKind(), context.getEndTime(), context.getEndEventId());
+    }
+
+    if (parameter.getType().isAssignableFrom(workflowAggregateClass)) {
+      return (
+          aggregate,
+          context) -> aggregate;
+    }
+
+    throw new IllegalStateException(
+        """
+            The %s is neither of the workflow-aggregate type '%s' nor of type '%s'! A workflow which \
+            ended offers nothing else: its tasks are gone and its variables are the aggregate you \
+            already hold."""
+            .formatted(location, workflowAggregateClass.getName(), WorkflowEnd.class.getName()));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/AggregatePropertyWriter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/AggregatePropertyWriter.java
@@ -1,0 +1,126 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.integration.adapter.migration.values.ValueConversion;
+
+/**
+ * Writes an attribute of a workflow aggregate by reflection: setter
+ * (<code>setX(value)</code>) first, then the field - the writing counterpart of the
+ * reader embedded BPMS use to evaluate expressions against the aggregate.
+ * <p>
+ * Used for a workflow the BPMS started on its own: the aggregate's ID and the
+ * process variables the BPMN model set are written into the freshly built
+ * aggregate.
+ */
+final class AggregatePropertyWriter {
+
+  private static final Logger log = LoggerFactory.getLogger(AggregatePropertyWriter.class);
+
+  private AggregatePropertyWriter() {
+  }
+
+  /**
+   * Writes the value if the aggregate has a writable attribute of that name.
+   *
+   * @param workflowAggregate The aggregate to write to
+   * @param propertyName The attribute's name
+   * @param value The value to write
+   * @param location What is being written, named by a failure message
+   * @return Whether the aggregate had such an attribute
+   */
+  static boolean write(
+      final Object workflowAggregate,
+      final String propertyName,
+      final Object value,
+      final String location) {
+
+    final var aggregateClass = workflowAggregate.getClass();
+    final var setter = findSetter(aggregateClass, propertyName);
+    if (setter != null) {
+      setter.trySetAccessible();
+      invoke(
+          () -> setter
+              .invoke(
+                  workflowAggregate,
+                  ValueConversion.convert(value, setter.getParameterTypes()[0], location)),
+          location);
+      return true;
+    }
+
+    final var field = findField(aggregateClass, propertyName);
+    if (field == null) {
+      return false;
+    }
+    if (!field.trySetAccessible()) {
+      log
+          .debug(
+              "The attribute '{}' of '{}' is not accessible - {} is skipped",
+              propertyName,
+              aggregateClass.getName(),
+              location);
+      return false;
+    }
+    invoke(
+        () -> field.set(workflowAggregate, ValueConversion.convert(value, field.getType(), location)),
+        location);
+    return true;
+
+  }
+
+  private static Method findSetter(
+      final Class<?> aggregateClass,
+      final String propertyName) {
+
+    final var setterName = "set"
+        + Character.toUpperCase(propertyName.charAt(0))
+        + propertyName.substring(1);
+    for (final var method : aggregateClass.getMethods()) {
+      if (method.getName().equals(setterName) && (method.getParameterCount() == 1)) {
+        return method;
+      }
+    }
+    return null;
+
+  }
+
+  private static Field findField(
+      final Class<?> aggregateClass,
+      final String propertyName) {
+
+    var current = aggregateClass;
+    while ((current != null) && !current.equals(Object.class)) {
+      try {
+        return current.getDeclaredField(propertyName);
+      } catch (final NoSuchFieldException e) {
+        current = current.getSuperclass();
+      }
+    }
+    return null;
+
+  }
+
+  @FunctionalInterface
+  private interface ReflectiveWrite {
+
+    void run() throws ReflectiveOperationException;
+
+  }
+
+  private static void invoke(
+      final ReflectiveWrite write,
+      final String location) {
+
+    try {
+      write.run();
+    } catch (final ReflectiveOperationException e) {
+      throw new IllegalStateException("Could not write %s!".formatted(location), e);
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartExecution.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartExecution.java
@@ -1,0 +1,223 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
+
+/**
+ * Builds the workflow aggregate of a workflow the BPMS started on its own, in one
+ * transaction: derive the ID, reuse an aggregate already carrying it, otherwise
+ * instantiate one, write the ID and the process variables into it, let the optional
+ * <code>&#64;WorkflowStartedByBpms</code> method have its say and save.
+ */
+public final class BpmsInitiatedStartExecution {
+
+  private static final Logger log = LoggerFactory.getLogger(BpmsInitiatedStartExecution.class);
+
+  private BpmsInitiatedStartExecution() {
+  }
+
+  /**
+   * @param <A> The workflow-aggregate type
+   * @param processService The process service of the BPMN process (persistence, ID
+   *          type, aggregate class)
+   * @param handler The application's method building or enriching the aggregate, or
+   *          <code>null</code> if it does not have one
+   * @param context The adapter's notification
+   * @param transactionRunner The platform's transaction runner
+   * @return The aggregate's ID and the variables the adapter writes back (the
+   *         aggregate-ID variable; shared aggregate values are added by the caller)
+   */
+  public static <A> BpmsInitiatedStartResult run(
+      final MigrationProcessService<A> processService,
+      final BpmsInitiatedStartHandler handler,
+      final BpmsInitiatedStartContext context,
+      final TransactionRunner transactionRunner) {
+
+    final Supplier<BpmsInitiatedStartResult> transactionalWork = () -> build(
+        processService,
+        handler,
+        context);
+
+    return context.runInCurrentTransaction()
+        ? transactionRunner.inCurrent(transactionalWork)
+        : transactionRunner.requireNew(transactionalWork);
+
+  }
+
+  private static <A> BpmsInitiatedStartResult build(
+      final MigrationProcessService<A> processService,
+      final BpmsInitiatedStartHandler handler,
+      final BpmsInitiatedStartContext context) {
+
+    final var aggregateClass = processService.getWorkflowAggregateClass();
+    final var derivedId = BpmsInitiatedStartId
+        .derive(
+            context.getKind(),
+            context.getTriggerTime(),
+            context.getNaturalIdentity(),
+            processService.getAggregateIdType(),
+            aggregateClass);
+
+    if (derivedId.isPresent()) {
+      final var existing = processService.loadWorkflowAggregateById(derivedId.get());
+      if (existing != null) {
+        // at-least-once: the BPMS reported this start before (a retried listener
+        // job, a replayed engine transaction) - the workflow already has its
+        // aggregate, and building a second one would overwrite business data
+        log
+            .debug(
+                "The workflow aggregate '{}' of the BPMS-initiated start of BPMN process '{}' "
+                    + "(workflow module '{}', start event '{}') exists already - nothing is created",
+                derivedId.get(),
+                processService.getBpmnProcessId(),
+                processService.getWorkflowModuleId(),
+                context.getStartEventId());
+        return result(processService, existing, false);
+      }
+    }
+
+    final var built = instantiate(processService, context);
+    if (derivedId.isPresent()) {
+      AggregatePropertyWriter
+          .write(
+              built,
+              processService.getAggregateIdName(),
+              derivedId.get(),
+              "the ID of the workflow aggregate '%s'".formatted(aggregateClass.getName()));
+    }
+    writeVariables(processService, built, context);
+    var workflowAggregate = built;
+
+    if (handler != null) {
+      final var returned = handler.invoke(workflowAggregate, context);
+      if (handler.isReturningAggregate()) {
+        if (returned == null) {
+          throw new IllegalStateException(
+              """
+                  The @WorkflowStartedByBpms method '%s' returned null! Return the workflow aggregate \
+                  of the workflow the BPMS started (BPMN process '%s' of workflow module '%s', start \
+                  event '%s') - without it the workflow has no data at all."""
+                  .formatted(
+                      handler.describe(),
+                      processService.getBpmnProcessId(),
+                      processService.getWorkflowModuleId(),
+                      context.getStartEventId()));
+        }
+        workflowAggregate = aggregateClass.cast(returned);
+        // an aggregate built by the application may carry no ID yet - the derived
+        // one applies unless the application assigned its own
+        if ((processService.getWorkflowAggregateId(workflowAggregate) == null) && derivedId.isPresent()) {
+          AggregatePropertyWriter
+              .write(
+                  workflowAggregate,
+                  processService.getAggregateIdName(),
+                  derivedId.get(),
+                  "the ID of the workflow aggregate '%s'".formatted(aggregateClass.getName()));
+        }
+      }
+    }
+
+    final var attached = processService.saveWorkflowAggregate(workflowAggregate);
+    final var aggregateId = processService.getWorkflowAggregateId(attached);
+    if ((aggregateId == null) || aggregateId.toString().isBlank()) {
+      throw new IllegalStateException(
+          """
+              The ID of the workflow aggregate of class '%s' is null or blank after saving the \
+              workflow the BPMS started (BPMN process '%s' of workflow module '%s', start event \
+              '%s')! The ID identifies the workflow in the BPMS - use a generated ID which is \
+              assigned on save, or assign one in a @WorkflowStartedByBpms method."""
+              .formatted(
+                  aggregateClass.getName(),
+                  processService.getBpmnProcessId(),
+                  processService.getWorkflowModuleId(),
+                  context.getStartEventId()));
+    }
+    return result(processService, attached, true);
+
+  }
+
+  private static <A> A instantiate(
+      final MigrationProcessService<A> processService,
+      final BpmsInitiatedStartContext context) {
+
+    final var aggregateClass = processService.getWorkflowAggregateClass();
+    try {
+      final var constructor = aggregateClass.getDeclaredConstructor();
+      constructor.trySetAccessible();
+      return constructor.newInstance();
+    } catch (final ReflectiveOperationException | RuntimeException e) {
+      throw new IllegalStateException(
+          """
+              The workflow aggregate '%s' cannot be instantiated for the workflow the BPMS started \
+              (BPMN process '%s' of workflow module '%s', start event '%s')! Give the class an \
+              accessible constructor without arguments, or add a @WorkflowStartedByBpms method to \
+              its workflow service which returns the aggregate it built itself."""
+              .formatted(
+                  aggregateClass.getName(),
+                  processService.getBpmnProcessId(),
+                  processService.getWorkflowModuleId(),
+                  context.getStartEventId()), e);
+    }
+
+  }
+
+  /**
+   * Copies the process variables into equally-named attributes of the aggregate.
+   * Variables the aggregate does not model are skipped: a BPMN model may carry
+   * values which are none of the application's business.
+   */
+  private static <A> void writeVariables(
+      final MigrationProcessService<A> processService,
+      final A workflowAggregate,
+      final BpmsInitiatedStartContext context) {
+
+    final var aggregateIdName = processService.getAggregateIdName();
+    for (final var variable : context.getVariables().entrySet()) {
+      if (variable.getKey().equals(aggregateIdName)) {
+        continue;
+      }
+      final var written = AggregatePropertyWriter
+          .write(
+              workflowAggregate,
+              variable.getKey(),
+              variable.getValue(),
+              "the process variable '%s' into the workflow aggregate '%s'".formatted(
+                  variable.getKey(),
+                  processService.getWorkflowAggregateClass().getName()));
+      if (!written) {
+        log
+            .debug(
+                "The workflow aggregate '{}' has no attribute '{}' - the process variable of the "
+                    + "BPMS-initiated start of BPMN process '{}' (workflow module '{}') is not copied",
+                processService.getWorkflowAggregateClass().getName(),
+                variable.getKey(),
+                processService.getBpmnProcessId(),
+                processService.getWorkflowModuleId());
+      }
+    }
+
+  }
+
+  private static <A> BpmsInitiatedStartResult result(
+      final MigrationProcessService<A> processService,
+      final A workflowAggregate,
+      final boolean created) {
+
+    final var aggregateIdName = processService.getAggregateIdName();
+    final var serializedId = String.valueOf(processService.getWorkflowAggregateId(workflowAggregate));
+    final Map<String, Object> variables = new LinkedHashMap<>();
+    variables.put(aggregateIdName, serializedId);
+    return new BpmsInitiatedStartResult(serializedId, aggregateIdName, variables, created);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
@@ -1,0 +1,154 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+
+/**
+ * One <code>&#64;WorkflowStartedByBpms</code> method of a workflow service class,
+ * with its parameter binders and the start event it serves.
+ */
+public class BpmsInitiatedStartHandler {
+
+  /**
+   * Binds one parameter of the method from the aggregate VanillaBP built and the
+   * adapter's notification.
+   */
+  @FunctionalInterface
+  interface ParameterBinder {
+
+    Object bind(
+        Object workflowAggregate,
+        BpmsInitiatedStartContext context);
+
+  }
+
+  private final Class<?> workflowServiceClass;
+
+  private final Method method;
+
+  private final Supplier<Object> workflowServiceBean;
+
+  private final List<ParameterBinder> binders;
+
+  /**
+   * The BPMN id of the start event this method serves, or <code>null</code> for
+   * every BPMS-initiated start event of the process.
+   */
+  private final String startEventId;
+
+  private final List<VersionRange> versions;
+
+  /**
+   * Whether the method RETURNS the aggregate (instead of modifying the one passed
+   * in). Both shapes are allowed; a returned aggregate replaces what VanillaBP
+   * built.
+   */
+  private final boolean returnsAggregate;
+
+  BpmsInitiatedStartHandler(
+      final Class<?> workflowServiceClass,
+      final Method method,
+      final Supplier<Object> workflowServiceBean,
+      final List<ParameterBinder> binders,
+      final String startEventId,
+      final List<VersionRange> versions,
+      final boolean returnsAggregate) {
+
+    this.workflowServiceClass = workflowServiceClass;
+    this.method = method;
+    this.workflowServiceBean = workflowServiceBean;
+    this.binders = binders;
+    this.startEventId = startEventId;
+    this.versions = versions;
+    this.returnsAggregate = returnsAggregate;
+
+  }
+
+  public String getStartEventId() {
+
+    return startEventId;
+
+  }
+
+  public boolean isReturningAggregate() {
+
+    return returnsAggregate;
+
+  }
+
+  /**
+   * @return The method, for guiding messages
+   */
+  public String describe() {
+
+    return "%s#%s".formatted(workflowServiceClass.getName(), method.getName());
+
+  }
+
+  /**
+   * @return What this handler is wired to, for guiding messages
+   */
+  public String describeWiring() {
+
+    return startEventId == null
+        ? "every BPMS-initiated start event"
+        : "start event '%s'".formatted(startEventId);
+
+  }
+
+  boolean matchesStartEvent(
+      final String eventId) {
+
+    return (startEventId == null) || startEventId.equals(eventId);
+
+  }
+
+  boolean matchesVersion(
+      final String processVersion) {
+
+    return versions
+        .stream()
+        .anyMatch(version -> version.matches(processVersion));
+
+  }
+
+  /**
+   * Invokes the method with bound parameters. Runtime exceptions of the method
+   * propagate unchanged - the transaction of the start rolls back, so no aggregate
+   * exists and the BPMS retries.
+   *
+   * @param workflowAggregate The aggregate VanillaBP built
+   * @param context The adapter's notification
+   * @return The aggregate the method returned, or <code>null</code> for a
+   *         <code>void</code> method
+   */
+  Object invoke(
+      final Object workflowAggregate,
+      final BpmsInitiatedStartContext context) {
+
+    final var arguments = binders
+        .stream()
+        .map(binder -> binder.bind(workflowAggregate, context))
+        .toArray();
+    try {
+      return method.invoke(workflowServiceBean.get(), arguments);
+    } catch (final IllegalAccessException e) {
+      throw new IllegalStateException(
+          "Could not invoke @WorkflowStartedByBpms method '%s'!".formatted(describe()), e);
+    } catch (final InvocationTargetException e) {
+      if (e.getTargetException() instanceof RuntimeException runtimeException) {
+        throw runtimeException;
+      }
+      throw new IllegalStateException(
+          "The @WorkflowStartedByBpms method '%s' threw a checked exception!".formatted(describe()), e
+              .getTargetException());
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
@@ -111,9 +111,50 @@ public class BpmsInitiatedStartHandler {
   boolean matchesVersion(
       final String processVersion) {
 
+    return matchesVersion(processVersion, VersionRange.NO_RESOLVER);
+
+  }
+
+  boolean matchesVersion(
+      final String processVersion,
+      final VersionRange.ProcessVersionResolver resolver) {
+
     return versions
         .stream()
-        .anyMatch(version -> version.matches(processVersion));
+        .anyMatch(version -> version.matches(processVersion, resolver));
+
+  }
+
+  /**
+   * Whether this handler and the given one serve at least one common process version -
+   * two handlers serving the same start event are ambiguous exactly then.
+   *
+   * @param other The other handler
+   * @param resolver Resolves version tags of the BPMN process both belong to
+   * @return Whether both serve a common version
+   */
+  boolean overlapsVersions(
+      final BpmsInitiatedStartHandler other,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    return versions
+        .stream()
+        .anyMatch(version -> other.versions
+            .stream()
+            .anyMatch(otherVersion -> version.overlaps(otherVersion, resolver)));
+
+  }
+
+  /**
+   * @return The version tags this handler's version specifications name
+   */
+  List<String> versionTags() {
+
+    return versions
+        .stream()
+        .flatMap(version -> version.versionTags().stream())
+        .distinct()
+        .toList();
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartId.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartId.java
@@ -1,0 +1,159 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.spi.service.BpmsStartTrigger;
+
+/**
+ * Derives the ID of the workflow aggregate of a workflow the BPMS started on its
+ * own. Nobody handed VanillaBP an aggregate, so the ID has to come from the trigger
+ * itself.
+ * <p>
+ * <strong>What the BPMS itself identifies the start by wins.</strong> A remote BPMS
+ * reports its process instance key, and using it as the aggregate's ID is what makes
+ * a redelivered notification harmless: the aggregate is found, not built again.
+ * <p>
+ * <strong>Otherwise a timer's ID is its trigger time.</strong> That is not cosmetic: a cyclic
+ * timer firing the same instant twice - a retried listener job, an engine
+ * transaction replayed after a crash - derives the same ID, finds the aggregate
+ * already there and creates nothing twice. The time is converted into whatever type
+ * the aggregate's ID attribute has.
+ * <p>
+ * Signals and conditions have no such natural identity: two workflows started by the
+ * same broadcast are two workflows, so their IDs are generated. Where no ID can be
+ * derived at all - a numeric ID attribute without a natural value - none is assigned
+ * and the persistence layer generates one while saving, which is how an application
+ * with <code>&#64;GeneratedValue</code> IDs works anyway. An application wanting a
+ * business ID provides a <code>&#64;WorkflowStartedByBpms</code> method and returns
+ * an aggregate carrying it.
+ */
+final class BpmsInitiatedStartId {
+
+  private static final Logger log = LoggerFactory.getLogger(BpmsInitiatedStartId.class);
+
+  private BpmsInitiatedStartId() {
+  }
+
+  /**
+   * @param kind The kind of start event which fired
+   * @param triggerTime When it fired
+   * @param naturalIdentity What the BPMS identifies this start by, or
+   *          <code>null</code>
+   * @param aggregateIdType The type of the aggregate's ID attribute, or
+   *          <code>null</code> if the persistence layer does not tell
+   * @param workflowAggregateClass The aggregate class, named by log messages
+   * @return The ID to assign in the aggregate's ID type, or
+   *         {@link Optional#empty()} to let the persistence layer assign one
+   */
+  static Optional<Object> derive(
+      final BpmsStartTrigger.Kind kind,
+      final Instant triggerTime,
+      final String naturalIdentity,
+      final Class<?> aggregateIdType,
+      final Class<?> workflowAggregateClass) {
+
+    if (naturalIdentity != null) {
+      final var fromBpms = ofNaturalIdentity(naturalIdentity, aggregateIdType);
+      if (fromBpms.isPresent()) {
+        return fromBpms;
+      }
+      log
+          .debug(
+              """
+                  The BPMS identifies the start of a workflow of '{}' as '{}', but the aggregate's ID \
+                  attribute is of type '{}' and cannot carry it - the ID is derived from the trigger \
+                  instead, so a repeated notification may build a second aggregate.""",
+              workflowAggregateClass.getName(),
+              naturalIdentity,
+              aggregateIdType == null ? "unknown" : aggregateIdType.getName());
+    }
+
+    if (kind == BpmsStartTrigger.Kind.TIMER) {
+      final var fromTriggerTime = ofTriggerTime(triggerTime, aggregateIdType);
+      if (fromTriggerTime.isPresent()) {
+        return fromTriggerTime;
+      }
+      log
+          .debug(
+              """
+                  The ID attribute of the workflow aggregate '{}' is of type '{}' and cannot carry the \
+                  trigger time - the ID of this timer-started workflow is generated instead, so a \
+                  repeated notification for the same trigger time cannot be recognized.""",
+              workflowAggregateClass.getName(),
+              aggregateIdType == null ? "unknown" : aggregateIdType.getName());
+    }
+    return generate(aggregateIdType);
+
+  }
+
+  private static Optional<Object> ofNaturalIdentity(
+      final String naturalIdentity,
+      final Class<?> aggregateIdType) {
+
+    if ((aggregateIdType == null) || aggregateIdType.equals(String.class)) {
+      return Optional.of(naturalIdentity);
+    }
+    if (aggregateIdType.equals(Long.class) || aggregateIdType.equals(long.class)) {
+      try {
+        return Optional.of(Long.valueOf(naturalIdentity));
+      } catch (final NumberFormatException e) {
+        return Optional.empty();
+      }
+    }
+    return Optional.empty();
+
+  }
+
+  private static Optional<Object> ofTriggerTime(
+      final Instant triggerTime,
+      final Class<?> aggregateIdType) {
+
+    if ((aggregateIdType == null) || aggregateIdType.equals(String.class)) {
+      // no ID type reported means the persistence layer owns the serialized form -
+      // the ISO-8601 representation is what travels everywhere else, too
+      return Optional.of(triggerTime.toString());
+    }
+    if (aggregateIdType.equals(Instant.class)) {
+      return Optional.of(triggerTime);
+    }
+    if (aggregateIdType.equals(OffsetDateTime.class)) {
+      return Optional.of(OffsetDateTime.ofInstant(triggerTime, ZoneId.systemDefault()));
+    }
+    if (aggregateIdType.equals(ZonedDateTime.class)) {
+      return Optional.of(ZonedDateTime.ofInstant(triggerTime, ZoneId.systemDefault()));
+    }
+    if (aggregateIdType.equals(LocalDateTime.class)) {
+      return Optional.of(LocalDateTime.ofInstant(triggerTime, ZoneId.systemDefault()));
+    }
+    if (aggregateIdType.equals(Long.class) || aggregateIdType.equals(long.class)) {
+      return Optional.of(triggerTime.toEpochMilli());
+    }
+    return Optional.empty();
+
+  }
+
+  private static Optional<Object> generate(
+      final Class<?> aggregateIdType) {
+
+    if ((aggregateIdType == null) || aggregateIdType.equals(String.class)) {
+      return Optional.of(UUID.randomUUID().toString());
+    }
+    if (aggregateIdType.equals(UUID.class)) {
+      return Optional.of(UUID.randomUUID());
+    }
+    // numeric and everything else: let the persistence layer assign the ID while
+    // saving instead of inventing one which might collide
+    return Optional.empty();
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartScanner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartScanner.java
@@ -1,0 +1,171 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.vanillabp.integration.adapter.migration.values.ValueConversion;
+import io.vanillabp.integration.adapter.migration.workflowstart.BpmsInitiatedStartHandler.ParameterBinder;
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowStartedByBpms;
+
+/**
+ * Scans a <code>&#64;WorkflowService</code> class for
+ * <code>&#64;WorkflowStartedByBpms</code> methods and builds their handlers. Runs
+ * once at startup per workflow service class; defects yield guiding exceptions
+ * naming the method and the fix.
+ * <p>
+ * The binding surface is deliberately smaller than the one of
+ * <code>&#64;WorkflowTask</code>: there is no task, so no task ID, no task event and
+ * no multi-instance context. What a method may ask for is the workflow aggregate,
+ * the {@link BpmsStartTrigger} and process variables via
+ * <code>&#64;TaskParam</code>.
+ */
+public final class BpmsInitiatedStartScanner {
+
+  private BpmsInitiatedStartScanner() {
+  }
+
+  /**
+   * @param workflowServiceClass The <code>&#64;WorkflowService</code> class
+   * @param workflowAggregateClass The workflow-aggregate class of that service
+   * @param workflowServiceBean Supplies the bean instance of the class
+   * @return The handlers, possibly empty
+   */
+  public static List<BpmsInitiatedStartHandler> scan(
+      final Class<?> workflowServiceClass,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean) {
+
+    final var handlers = new LinkedList<BpmsInitiatedStartHandler>();
+    for (final var method : workflowServiceClass.getMethods()) {
+      final var annotation = method.getAnnotation(WorkflowStartedByBpms.class);
+      if (annotation == null) {
+        continue;
+      }
+      handlers
+          .add(
+              buildHandler(
+                  workflowServiceClass,
+                  method,
+                  workflowAggregateClass,
+                  workflowServiceBean,
+                  annotation));
+    }
+    return handlers;
+
+  }
+
+  private static BpmsInitiatedStartHandler buildHandler(
+      final Class<?> workflowServiceClass,
+      final Method method,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean,
+      final WorkflowStartedByBpms annotation) {
+
+    final var location = "%s#%s".formatted(workflowServiceClass.getName(), method.getName());
+    // a public method of a package-private bean class is not accessible through
+    // plain reflection - lift the check once at scan time
+    method.trySetAccessible();
+
+    final var returnsAggregate = validateReturnType(
+        method,
+        workflowAggregateClass,
+        location);
+    final var binders = Arrays
+        .stream(method.getParameters())
+        .map(parameter -> buildParameterBinder(
+            parameter,
+            workflowAggregateClass,
+            "parameter '%s' of @WorkflowStartedByBpms method '%s'"
+                .formatted(parameter.getName(), location)))
+        .toList();
+    if (!returnsAggregate && Arrays
+        .stream(method.getParameters())
+        .noneMatch(parameter -> parameter.getType().isAssignableFrom(workflowAggregateClass))) {
+      throw new IllegalStateException(
+          """
+              The @WorkflowStartedByBpms method '%s' returns void but does not take the workflow \
+              aggregate of class '%s' either! Take the aggregate VanillaBP built as a parameter to \
+              enrich it, or return an aggregate you built yourself."""
+              .formatted(location, workflowAggregateClass.getName()));
+    }
+
+    final var versions = Arrays
+        .stream(annotation.version())
+        .map(version -> VersionRange.parse(version, location))
+        .toList();
+    final var startEventId = annotation.id().equals(WorkflowStartedByBpms.ANY_START_EVENT)
+        ? null
+        : annotation.id();
+
+    return new BpmsInitiatedStartHandler(
+        workflowServiceClass, method, workflowServiceBean, binders, startEventId, versions, returnsAggregate);
+
+  }
+
+  private static boolean validateReturnType(
+      final Method method,
+      final Class<?> workflowAggregateClass,
+      final String location) {
+
+    if (method.getReturnType().equals(void.class)) {
+      return false;
+    }
+    if (method.getReturnType().isAssignableFrom(workflowAggregateClass)) {
+      return true;
+    }
+    throw new IllegalStateException(
+        """
+            The @WorkflowStartedByBpms method '%s' returns '%s' which is not the workflow aggregate \
+            of class '%s'! Return the aggregate you built, or declare the method void and modify \
+            the aggregate VanillaBP passes in."""
+            .formatted(location, method.getReturnType().getName(), workflowAggregateClass.getName()));
+
+  }
+
+  private static ParameterBinder buildParameterBinder(
+      final Parameter parameter,
+      final Class<?> workflowAggregateClass,
+      final String location) {
+
+    if (parameter.getType().equals(BpmsStartTrigger.class)) {
+      return (
+          aggregate,
+          context) -> new BpmsStartTrigger(
+              context.getKind(), context.getTriggerTime(), context.getSignalName(), context.getStartEventId());
+    }
+
+    final var taskParam = parameter.getAnnotation(TaskParam.class);
+    if (taskParam != null) {
+      final var targetType = parameter.getType();
+      return (
+          aggregate,
+          context) -> ValueConversion
+              .convert(
+                  context.getVariables().get(taskParam.value()),
+                  targetType,
+                  "@TaskParam(\"%s\") %s".formatted(taskParam.value(), location));
+    }
+
+    if (parameter.getType().isAssignableFrom(workflowAggregateClass)) {
+      return (
+          aggregate,
+          context) -> aggregate;
+    }
+
+    throw new IllegalStateException(
+        """
+            The %s is neither annotated with @TaskParam nor of the workflow-aggregate type '%s' nor \
+            of type '%s'! A method building the aggregate of a BPMS-initiated start may ask for the \
+            aggregate, the trigger and process variables - nothing else exists at that moment."""
+            .formatted(location, workflowAggregateClass.getName(), BpmsStartTrigger.class.getName()));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
@@ -44,6 +44,20 @@ public class BpmsInitiatedStarts {
   private final Map<RegistryKey, RegistryEntry> entries = new ConcurrentHashMap<>();
 
   /**
+   * What the BPMS know about the deployed versions of the BPMN processes - owned by the
+   * {@link io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry}
+   * and shared, since all three annotations carry a <code>version</code> attribute.
+   */
+  private final io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions processVersions;
+
+  public BpmsInitiatedStarts(
+      final io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions processVersions) {
+
+    this.processVersions = processVersions;
+
+  }
+
+  /**
    * Scans a workflow service class and registers what it found. Called by the
    * platform integration at startup, once per (workflow service class, declared
    * BPMN process ID).
@@ -73,10 +87,58 @@ public class BpmsInitiatedStarts {
       // compared against each other as well
       handlers
           .forEach(handler -> {
-            failOnDuplicateWiring(workflowModuleId, bpmnProcessId, entry, handler);
+            failOnDuplicateWiring(
+                workflowModuleId,
+                bpmnProcessId,
+                entry,
+                handler,
+                io.vanillabp.integration.adapter.migration.workflowtask.VersionRange.NO_RESOLVER);
             entry.handlers.add(handler);
           });
     }
+
+  }
+
+  /**
+   * Resolves the version tags the methods of the given workflow module name and checks
+   * the version ranges naming a tag for overlaps - those could not be placed while
+   * registering, since no BPMS had been asked about its versions at that point.
+   *
+   * @param workflowModuleId The workflow module ID
+   */
+  public void resolveProcessVersions(
+      final String workflowModuleId) {
+
+    entries
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().workflowModuleId().equals(workflowModuleId))
+        .forEach(entry -> {
+          final var bpmnProcessId = entry.getKey().bpmnProcessId();
+          final var registryEntry = entry.getValue();
+          if (registryEntry.handlers.stream().allMatch(handler -> handler.versionTags().isEmpty())) {
+            return;
+          }
+          processVersions.warmUp(workflowModuleId, bpmnProcessId);
+          final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+          synchronized (registryEntry) {
+            registryEntry.handlers
+                .forEach(handler -> handler
+                    .versionTags()
+                    .forEach(tag -> processVersions.reportUnknownVersionTag(
+                        workflowModuleId,
+                        bpmnProcessId,
+                        tag,
+                        handler.describe())));
+            registryEntry.handlers
+                .forEach(handler -> failOnDuplicateWiring(
+                    workflowModuleId,
+                    bpmnProcessId,
+                    registryEntry,
+                    handler,
+                    resolver));
+          }
+        });
 
   }
 
@@ -84,14 +146,16 @@ public class BpmsInitiatedStarts {
       final String workflowModuleId,
       final String bpmnProcessId,
       final RegistryEntry entry,
-      final BpmsInitiatedStartHandler handler) {
+      final BpmsInitiatedStartHandler handler,
+      final io.vanillabp.integration.adapter.migration.workflowtask.VersionRange.ProcessVersionResolver resolver) {
 
     final var duplicate = entry.handlers
         .stream()
+        .filter(existing -> existing != handler)
         .filter(existing -> java.util.Objects.equals(existing.getStartEventId(), handler.getStartEventId()))
-        // both matching every version = genuinely ambiguous; disjoint version
-        // ranges are a legitimate way to serve several process versions
-        .filter(existing -> existing.matchesVersion(null) && handler.matchesVersion(null))
+        // overlapping version ranges are ambiguous; disjoint ones are a legitimate
+        // way to serve several process versions
+        .filter(existing -> existing.overlapsVersions(handler, resolver))
         .findFirst();
     if (duplicate.isPresent()) {
       throw new IllegalStateException(
@@ -198,7 +262,11 @@ public class BpmsInitiatedStarts {
         : entry.handlers
             .stream()
             .filter(candidate -> candidate.matchesStartEvent(context.getStartEventId()))
-            .filter(candidate -> candidate.matchesVersion(context.getProcessVersion()))
+            .filter(candidate -> candidate.matchesVersion(
+                context.getProcessVersion(),
+                processVersions.resolverFor(
+                    processService.getWorkflowModuleId(),
+                    processService.getBpmnProcessId())))
             .findFirst()
             .orElse(null);
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
@@ -1,0 +1,229 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+
+/**
+ * The <code>&#64;WorkflowStartedByBpms</code> methods of the application per
+ * (workflow module, BPMN process), and the start events the adapters reported for
+ * those processes. Backs the adapter-facing
+ * {@link io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker},
+ * which the workflow-task registry implements by delegating here.
+ */
+public class BpmsInitiatedStarts {
+
+  private record RegistryKey(
+                             String workflowModuleId,
+                             String bpmnProcessId) {
+  }
+
+  private static class RegistryEntry {
+
+    private final List<BpmsInitiatedStartHandler> handlers = new LinkedList<>();
+
+    /**
+     * The start events reported by the adapters deploying this process. Several
+     * adapters may report the same process (the migration case) - the union is
+     * what the application may serve.
+     */
+    private final List<BpmsInitiatedStartSpec> startEvents = new LinkedList<>();
+
+  }
+
+  private final Map<RegistryKey, RegistryEntry> entries = new ConcurrentHashMap<>();
+
+  /**
+   * Scans a workflow service class and registers what it found. Called by the
+   * platform integration at startup, once per (workflow service class, declared
+   * BPMN process ID).
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowServiceClass The <code>&#64;WorkflowService</code> class
+   * @param workflowAggregateClass The workflow-aggregate class
+   * @param workflowServiceBean Supplies the bean instance of that class
+   */
+  public void registerWorkflowService(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Class<?> workflowServiceClass,
+      final Class<?> workflowAggregateClass,
+      final Supplier<Object> workflowServiceBean) {
+
+    final var handlers = BpmsInitiatedStartScanner
+        .scan(workflowServiceClass, workflowAggregateClass, workflowServiceBean);
+    if (handlers.isEmpty()) {
+      return;
+    }
+    final var entry = entries
+        .computeIfAbsent(new RegistryKey(workflowModuleId, bpmnProcessId), key -> new RegistryEntry());
+    synchronized (entry) {
+      // one by one, so two methods of the SAME class serving one start event are
+      // compared against each other as well
+      handlers
+          .forEach(handler -> {
+            failOnDuplicateWiring(workflowModuleId, bpmnProcessId, entry, handler);
+            entry.handlers.add(handler);
+          });
+    }
+
+  }
+
+  private static void failOnDuplicateWiring(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final RegistryEntry entry,
+      final BpmsInitiatedStartHandler handler) {
+
+    final var duplicate = entry.handlers
+        .stream()
+        .filter(existing -> java.util.Objects.equals(existing.getStartEventId(), handler.getStartEventId()))
+        // both matching every version = genuinely ambiguous; disjoint version
+        // ranges are a legitimate way to serve several process versions
+        .filter(existing -> existing.matchesVersion(null) && handler.matchesVersion(null))
+        .findFirst();
+    if (duplicate.isPresent()) {
+      throw new IllegalStateException(
+          """
+              The @WorkflowStartedByBpms methods '%s' and '%s' both serve %s of BPMN process '%s' of \
+              workflow module '%s'! Remove one of them, name the start events they serve by \
+              @WorkflowStartedByBpms(id = ...) or distinguish them by version."""
+              .formatted(
+                  duplicate.get().describe(),
+                  handler.describe(),
+                  handler.describeWiring(),
+                  bpmnProcessId,
+                  workflowModuleId));
+    }
+
+  }
+
+  /**
+   * Registers the start events an adapter reported while wiring a deployed BPMN
+   * process and validates the application's methods against them.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param startEvents The BPMS-initiated start events of the process
+   * @throws IllegalStateException If a method serves a process without such a start
+   *           event, or names a start event the process does not have
+   */
+  public void validate(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Collection<BpmsInitiatedStartSpec> startEvents) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (entry == null) {
+      // no application method for this process: the core builds the aggregate on
+      // its own, which is the whole point of the hook being optional
+      return;
+    }
+    synchronized (entry) {
+      startEvents
+          .stream()
+          .filter(spec -> entry.startEvents
+              .stream()
+              .noneMatch(known -> known.elementId().equals(spec.elementId())))
+          .forEach(entry.startEvents::add);
+
+      if (entry.startEvents.isEmpty()) {
+        throw new IllegalStateException(
+            """
+                The @WorkflowStartedByBpms method(s) %s serve BPMN process '%s' of workflow module \
+                '%s', but that process has no start event the BPMS fires on its own (timer, signal or \
+                conditional)! Either the model is missing such a start event, or the method belongs \
+                to another process - a workflow started by the application gets its aggregate from \
+                ProcessService#startWorkflow."""
+                .formatted(
+                    describeHandlers(entry.handlers),
+                    bpmnProcessId,
+                    workflowModuleId));
+      }
+
+      entry.handlers
+          .stream()
+          .filter(handler -> handler.getStartEventId() != null)
+          .filter(handler -> entry.startEvents
+              .stream()
+              .noneMatch(spec -> spec.elementId().equals(handler.getStartEventId())))
+          .findFirst()
+          .ifPresent(handler -> {
+            throw new IllegalStateException(
+                """
+                    The @WorkflowStartedByBpms method '%s' serves start event '%s' of BPMN process '%s' \
+                    of workflow module '%s', but that process has no such start event fired by the \
+                    BPMS! Its BPMS-initiated start events are: %s."""
+                    .formatted(
+                        handler.describe(),
+                        handler.getStartEventId(),
+                        bpmnProcessId,
+                        workflowModuleId,
+                        describeStartEvents(entry.startEvents)));
+          });
+    }
+
+  }
+
+  /**
+   * Builds the workflow aggregate of a workflow the BPMS started on its own.
+   *
+   * @param <A> The workflow-aggregate type
+   * @param processService The process service of the BPMN process
+   * @param context The adapter's notification
+   * @param transactionRunner The platform's transaction runner
+   * @return The aggregate's ID and the variables the adapter writes back
+   */
+  public <A> BpmsInitiatedStartResult start(
+      final MigrationProcessService<A> processService,
+      final BpmsInitiatedStartContext context,
+      final TransactionRunner transactionRunner) {
+
+    final var entry = entries
+        .get(
+            new RegistryKey(processService.getWorkflowModuleId(), processService.getBpmnProcessId()));
+    final var handler = entry == null
+        ? null
+        : entry.handlers
+            .stream()
+            .filter(candidate -> candidate.matchesStartEvent(context.getStartEventId()))
+            .filter(candidate -> candidate.matchesVersion(context.getProcessVersion()))
+            .findFirst()
+            .orElse(null);
+
+    return BpmsInitiatedStartExecution.run(processService, handler, context, transactionRunner);
+
+  }
+
+  private static String describeHandlers(
+      final List<BpmsInitiatedStartHandler> handlers) {
+
+    return handlers
+        .stream()
+        .map(handler -> "'%s' (%s)".formatted(handler.describe(), handler.describeWiring()))
+        .collect(Collectors.joining(", "));
+
+  }
+
+  private static String describeStartEvents(
+      final List<BpmsInitiatedStartSpec> startEvents) {
+
+    return startEvents
+        .stream()
+        .map(spec -> "'%s' (%s)".formatted(spec.elementId(), spec.kind()))
+        .collect(Collectors.joining(", "));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/AggregatePropertyReader.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/AggregatePropertyReader.java
@@ -17,6 +17,52 @@ class AggregatePropertyReader {
   private AggregatePropertyReader() {
   }
 
+  /**
+   * Whether the aggregate CLASS declares such an attribute - the same resolution
+   * order as {@link #read}, but without loading an aggregate. Adapters ask this
+   * while resolving a BPMN expression, to tell an attribute of the workflow
+   * aggregate from a name meaning something else.
+   *
+   * @param aggregateClass The workflow aggregate's class
+   * @param propertyName The attribute's name
+   * @return Whether the class has such a getter, boolean getter or field
+   */
+  static boolean has(
+      final Class<?> aggregateClass,
+      final String propertyName) {
+
+    if ((aggregateClass == null) || (propertyName == null) || propertyName.isEmpty()) {
+      return false;
+    }
+    final var capitalized = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
+
+    try {
+      aggregateClass.getMethod("get"
+          + capitalized);
+      return true;
+    } catch (final NoSuchMethodException e) {
+      // fall through to the boolean getter
+    }
+    try {
+      aggregateClass.getMethod("is"
+          + capitalized);
+      return true;
+    } catch (final NoSuchMethodException e) {
+      // fall through to field access
+    }
+    var currentClass = aggregateClass;
+    while ((currentClass != null) && (currentClass != Object.class)) {
+      try {
+        currentClass.getDeclaredField(propertyName);
+        return true;
+      } catch (final NoSuchFieldException e) {
+        currentClass = currentClass.getSuperclass();
+      }
+    }
+    return false;
+
+  }
+
   static Object read(
       final Object workflowAggregate,
       final String propertyName) {

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/ProcessVersions.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/ProcessVersions.java
@@ -1,0 +1,236 @@
+package io.vanillabp.integration.adapter.migration.workflowtask;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog;
+
+/**
+ * What the BPMS of every adapter knows about the deployed versions of the BPMN
+ * processes, per (workflow module, BPMN process) - registered by the adapters during
+ * <code>wireBpmn</code> (see
+ * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#registerProcessVersions})
+ * and used to place a version TAG named by <code>&#64;WorkflowTask(version = ...)</code>
+ * and its siblings in the deployment order.
+ * <p>
+ * A version specification made of numbers never gets here: it is compared to the
+ * version the adapter reported. That is what keeps the cost of the feature at zero for
+ * applications not using version tags.
+ * <p>
+ * While a BPMS migration is running, two adapters may serve the same BPMN process. Each
+ * BPMS counts its own versions, so the catalogs are asked in registration order and the
+ * first one knowing the version or tag answers.
+ */
+public class ProcessVersions {
+
+  private static final Logger log = LoggerFactory.getLogger(ProcessVersions.class);
+
+  private record RegistryKey(
+                             String workflowModuleId,
+                             String bpmnProcessId) {
+  }
+
+  private record RegisteredCatalog(
+                                   String adapterId,
+                                   ProcessVersionCatalog catalog) {
+  }
+
+  private final Map<RegistryKey, List<RegisteredCatalog>> catalogs = new ConcurrentHashMap<>();
+
+  /**
+   * The version identifiers and tags already reported as unknown - a task delivery
+   * must not log the same message over and over.
+   */
+  private final java.util.Set<String> reportedAsUnknown = ConcurrentHashMap.newKeySet();
+
+  /**
+   * Registers what one BPMS knows about one BPMN process. Registering the same catalog
+   * again (a module deployed at every boot, several workflow service classes) does not
+   * duplicate it.
+   *
+   * @param adapterId The adapter ID
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param catalog The versions of that process
+   */
+  public void register(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final ProcessVersionCatalog catalog) {
+
+    if (catalog == null) {
+      return;
+    }
+    final var registered = catalogs
+        .computeIfAbsent(
+            new RegistryKey(workflowModuleId, bpmnProcessId),
+            key -> new CopyOnWriteArrayList<>());
+    if (registered
+        .stream()
+        .noneMatch(existing -> existing.adapterId().equals(adapterId) && (existing.catalog() == catalog))) {
+      registered.add(new RegisteredCatalog(adapterId, catalog));
+    }
+
+  }
+
+  /**
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @return Resolves version identifiers and version tags of that BPMN process
+   */
+  public VersionRange.ProcessVersionResolver resolverFor(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return versionOrVersionTag -> resolve(workflowModuleId, bpmnProcessId, versionOrVersionTag);
+
+  }
+
+  private io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion resolve(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String versionOrVersionTag) {
+
+    final var resolved = lookup(workflowModuleId, bpmnProcessId, versionOrVersionTag);
+    if (resolved != null) {
+      return resolved;
+    }
+    final var registered = catalogs.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    reportUnknown(workflowModuleId, bpmnProcessId, versionOrVersionTag, (registered == null) || registered.isEmpty());
+    return null;
+
+  }
+
+  /**
+   * Asks the catalogs without reporting anything - the startup check reports in its own
+   * words, naming the method whose specification cannot be served.
+   */
+  private io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion lookup(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String versionOrVersionTag) {
+
+    final var registered = catalogs.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((registered != null) && !registered.isEmpty()) {
+      // asking a catalog may query the BPMS: a version deployed by ANOTHER cluster
+      // node is unknown here until it is asked for (the catalogs cache the answer)
+      for (final var candidate : registered) {
+        final var resolved = candidate
+            .catalog()
+            .resolveVersion(workflowModuleId, bpmnProcessId, versionOrVersionTag);
+        if (resolved != null) {
+          return resolved;
+        }
+      }
+    }
+    return null;
+
+  }
+
+  /**
+   * Loads all versions of the given BPMN process the BPMS knows - called at startup
+   * for the processes whose annotations name a version tag, so the tags are resolved
+   * before the first workflow needs them.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   */
+  public void warmUp(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    final var registered = catalogs.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (registered == null) {
+      return;
+    }
+    registered
+        .forEach(candidate -> {
+          final var versions = candidate.catalog().deployedVersionsOf(workflowModuleId, bpmnProcessId);
+          log.debug(
+              "Adapter '{}' knows {} deployed version(s) of BPMN process '{}' of workflow module '{}': {}",
+              candidate.adapterId(),
+              versions == null
+                  ? 0
+                  : versions.size(),
+              bpmnProcessId,
+              workflowModuleId,
+              versions);
+        });
+
+  }
+
+  /**
+   * Reports a version tag no BPMS knows, ONCE, naming what the developer can do about
+   * it. Not a boot failure: the tagged version may be deployed later (a rolling
+   * deployment where another cluster node is ahead), and an application whose other
+   * methods serve the deployed versions has to keep running.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param versionTag The version tag named by an annotation
+   * @param describedMethod The method naming it
+   */
+  public void reportUnknownVersionTag(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String versionTag,
+      final String describedMethod) {
+
+    if (lookup(workflowModuleId, bpmnProcessId, versionTag) != null) {
+      return;
+    }
+    log.warn(
+        """
+            The version specification '{}' of method '{}' names a version tag no BPMS knows for \
+            BPMN process '{}' of workflow module '{}'! Until a version tagged that way is \
+            deployed, that method serves no workflow. Check the tag against the BPMN model \
+            (Camunda 7: 'camunda:versionTag', Camunda 8: 'zeebe:versionTag') - a version \
+            specification made of numbers (e.g. '>2') needs no tag at all.""",
+        versionTag,
+        describedMethod,
+        bpmnProcessId,
+        workflowModuleId);
+
+  }
+
+  private void reportUnknown(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String versionOrVersionTag,
+      final boolean withoutCatalog) {
+
+    final var key = "%s|%s|%s".formatted(workflowModuleId, bpmnProcessId, versionOrVersionTag);
+    if (!reportedAsUnknown.add(key)) {
+      return;
+    }
+    if (withoutCatalog) {
+      log.warn(
+          """
+              The version specifications of the methods serving BPMN process '{}' of workflow \
+              module '{}' name '{}', but no BPMS of this application reports the deployed \
+              versions of its processes! Version specifications made of numbers (e.g. '1-3', \
+              '>2') work on every BPMS which reports the version of a process - version TAGS \
+              need a BPMS which can be asked about them.""",
+          bpmnProcessId,
+          workflowModuleId,
+          versionOrVersionTag);
+      return;
+    }
+    log.warn(
+        """
+            Neither a deployed version nor a version tag '{}' of BPMN process '{}' of workflow \
+            module '{}' is known to any BPMS - version specifications naming it match nothing \
+            until it is deployed.""",
+        versionOrVersionTag,
+        bpmnProcessId,
+        workflowModuleId);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
@@ -7,7 +7,7 @@ package io.vanillabp.integration.adapter.migration.workflowtask;
  * which is not numeric only matches <code>*</code> or an exactly equal
  * specification.
  */
-class VersionRange {
+public class VersionRange {
 
   private final String spec;
 
@@ -18,7 +18,7 @@ class VersionRange {
 
   }
 
-  static VersionRange parse(
+  public static VersionRange parse(
       final String spec,
       final String describedLocation) {
 
@@ -40,7 +40,7 @@ class VersionRange {
 
   }
 
-  boolean matches(
+  public boolean matches(
       final String processVersion) {
 
     if ((processVersion == null) || spec.equals("*")) {

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
@@ -1,20 +1,130 @@
 package io.vanillabp.integration.adapter.migration.workflowtask;
 
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+
 /**
- * One version specification of <code>&#64;WorkflowTask(version = ...)</code>:
- * <code>*</code> (all versions), <code>1</code> (exactly), <code>1-3</code>
- * (inclusive range), <code>&gt;3</code>, <code>&lt;3</code>. A process version
- * which is not numeric only matches <code>*</code> or an exactly equal
- * specification.
+ * One version specification of the <code>version</code> attribute of
+ * <code>&#64;WorkflowTask</code>, <code>&#64;WorkflowStartedByBpms</code> or
+ * <code>&#64;WorkflowEnded</code>.
+ * <p>
+ * A boundary is either a version as the BPMS counts it (a number for Camunda 7 and
+ * Camunda 8) or a version TAG the modeller gave a version
+ * (<code>camunda:versionTag</code>, <code>zeebe:versionTag</code>):
+ * <ul>
+ * <li><code>*</code> - every version (the default);</li>
+ * <li><code>3</code> or <code>release-2024</code> - exactly that version
+ * respectively every version carrying that tag;</li>
+ * <li><code>1-3</code> or <code>v1.0..v2.0</code> - a range, both boundaries
+ * included;</li>
+ * <li><code>&gt;3</code>, <code>&gt;=3</code>, <code>&lt;v2.0</code>,
+ * <code>&lt;=v2.0</code> - open ended.</li>
+ * </ul>
+ * Ranges accept <code>..</code> as well as <code>-</code> as their separator, and a
+ * boundary naming a tag which contains a <code>-</code> HAS to use <code>..</code> -
+ * otherwise there is no telling a range from a tag.
+ * <p>
+ * <b>What "greater" and "less" mean:</b> the deployment order. For a BPMS counting
+ * versions upwards that IS the numeric order, which is why a specification made of
+ * numbers is compared to the reported version straight away. As soon as a tag is
+ * involved, both sides are resolved through the
+ * {@link io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog} of the
+ * BPMS (see {@link ProcessVersionResolver}) - a tag says nothing about its position
+ * on its own. Without a resolver, or if the BPMS does not know a tag, such a
+ * specification matches nothing.
  */
 public class VersionRange {
 
+  private enum Kind {
+    /**
+     * <code>*</code> - every version.
+     */
+    ALL,
+    /**
+     * A single version or version tag.
+     */
+    EXACT,
+    /**
+     * Both boundaries included.
+     */
+    RANGE,
+    /**
+     * <code>&gt;x</code> respectively <code>&gt;=x</code>.
+     */
+    GREATER,
+    /**
+     * <code>&lt;x</code> respectively <code>&lt;=x</code>.
+     */
+    LESS
+  }
+
+  /**
+   * Resolves a version identifier or a version tag to the deployed version of ONE
+   * BPMN process - see
+   * {@link io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog}.
+   */
+  public interface ProcessVersionResolver {
+
+    /**
+     * @param versionOrVersionTag A version identifier or a version tag
+     * @return The deployed version or <code>null</code> if the BPMS does not know it
+     */
+    DeployedProcessVersion resolve(
+        String versionOrVersionTag);
+
+  }
+
+  /**
+   * Used wherever no BPMS can be asked (a version specification made of numbers
+   * never needs one).
+   */
+  public static final ProcessVersionResolver NO_RESOLVER = versionOrVersionTag -> null;
+
+  private static final String RANGE_SEPARATOR = "..";
+
   private final String spec;
 
+  private final Kind kind;
+
+  /**
+   * The lower boundary of a {@link Kind#RANGE}, the single value of
+   * {@link Kind#EXACT} and the excluded boundary of {@link Kind#GREATER}.
+   */
+  private final String lower;
+
+  /**
+   * The upper boundary of a {@link Kind#RANGE} and the excluded boundary of
+   * {@link Kind#LESS}.
+   */
+  private final String upper;
+
+  /**
+   * Whether the boundary of a {@link Kind#GREATER} or {@link Kind#LESS} belongs to the
+   * range - <code>&gt;=3</code> and <code>&lt;=3</code> say it does.
+   */
+  private final boolean boundaryIncluded;
+
   private VersionRange(
-      final String spec) {
+      final String spec,
+      final Kind kind,
+      final String lower,
+      final String upper) {
+
+    this(spec, kind, lower, upper, false);
+
+  }
+
+  private VersionRange(
+      final String spec,
+      final Kind kind,
+      final String lower,
+      final String upper,
+      final boolean boundaryIncluded) {
 
     this.spec = spec;
+    this.kind = kind;
+    this.lower = lower;
+    this.upper = upper;
+    this.boundaryIncluded = boundaryIncluded;
 
   }
 
@@ -25,47 +135,296 @@ public class VersionRange {
     final var trimmed = spec == null
         ? "*"
         : spec.trim();
-    if (trimmed.isEmpty()) {
-      return new VersionRange("*");
+    if (trimmed.isEmpty() || trimmed.equals("*")) {
+      return new VersionRange("*", Kind.ALL, null, null);
     }
-    if (!trimmed.equals("*") && !trimmed.matches("\\d+") && !trimmed.matches("\\d+-\\d+") && !trimmed
-        .matches("[<>]\\d+")) {
-      throw new IllegalStateException(
-          """
-              Unsupported version specification '%s' of @WorkflowTask at %s! Supported formats: \
-              '*' (all versions), '1' (exactly), '1-3' (inclusive range), '>3', '<3'."""
-              .formatted(spec, describedLocation));
+    if (trimmed.chars().anyMatch(Character::isWhitespace)) {
+      throw unsupported(spec, describedLocation, "it contains a blank");
     }
-    return new VersionRange(trimmed);
+    if (trimmed.startsWith(">") || trimmed.startsWith("<")) {
+      final var included = trimmed.startsWith(">=") || trimmed.startsWith("<=");
+      final var boundary = trimmed.substring(included
+          ? 2
+          : 1);
+      if (boundary.isEmpty()) {
+        throw unsupported(spec, describedLocation, "the version after '%s' is missing"
+            .formatted(included
+                ? trimmed.substring(0, 2)
+                : trimmed.substring(0, 1)));
+      }
+      return trimmed.startsWith(">")
+          ? new VersionRange(trimmed, Kind.GREATER, boundary, null, included)
+          : new VersionRange(trimmed, Kind.LESS, null, boundary, included);
+    }
+    final var explicitSeparator = trimmed.indexOf(RANGE_SEPARATOR);
+    if (explicitSeparator >= 0) {
+      final var lower = trimmed.substring(0, explicitSeparator);
+      final var upper = trimmed.substring(explicitSeparator + RANGE_SEPARATOR.length());
+      if (lower.isEmpty() || upper.isEmpty() || upper.contains(RANGE_SEPARATOR)) {
+        throw unsupported(spec, describedLocation, "a range needs exactly one version on each "
+            + "side of '..'");
+      }
+      return new VersionRange(trimmed, Kind.RANGE, lower, upper);
+    }
+    if (trimmed.matches("\\d+-\\d+")) {
+      final var boundaries = trimmed.split("-");
+      return new VersionRange(trimmed, Kind.RANGE, boundaries[0], boundaries[1]);
+    }
+    // anything else is a single version respectively a version tag - a tag may
+    // contain a '-', which is why a RANGE of tags is written with '..'
+    return new VersionRange(trimmed, Kind.EXACT, trimmed, null);
 
   }
 
+  private static IllegalStateException unsupported(
+      final String spec,
+      final String describedLocation,
+      final String reason) {
+
+    return new IllegalStateException(
+        """
+            Unsupported version specification '%s' at %s: %s! Supported formats: '*' (all \
+            versions), '3' or 'release-2024' (that version respectively that version tag), \
+            '1-3' or 'v1.0..v2.0' (a range, both boundaries included), '>3', '>=3', '<v2.0' \
+            and '<=v2.0' (open ended). Use '..' as the separator if a boundary is a version tag \
+            containing a '-'."""
+            .formatted(spec, describedLocation, reason));
+
+  }
+
+  /**
+   * @param processVersion The version the BPMS reported
+   * @return Whether this specification covers that version - always
+   *         <code>true</code> for <code>null</code> (a BPMS which cannot report a
+   *         version matches every method)
+   */
   public boolean matches(
       final String processVersion) {
 
-    if ((processVersion == null) || spec.equals("*")) {
+    return matches(processVersion, NO_RESOLVER);
+
+  }
+
+  /**
+   * @param processVersion The version the BPMS reported
+   * @param resolver Resolves version tags of the BPMN process the version belongs to
+   * @return Whether this specification covers that version
+   */
+  public boolean matches(
+      final String processVersion,
+      final ProcessVersionResolver resolver) {
+
+    if ((kind == Kind.ALL) || (processVersion == null)) {
       return true;
     }
-    if (spec.equals(processVersion)) {
-      return true;
+    if (kind == Kind.EXACT) {
+      if (lower.equals(processVersion)) {
+        return true;
+      }
+      if (isNumeric(lower) && isNumeric(processVersion)) {
+        return Long.parseLong(lower) == Long.parseLong(processVersion);
+      }
+      if (isNumeric(lower)) {
+        return false;
+      }
+      // a tag: it matches the version carrying it - which only the BPMS knows, and
+      // which may have changed since this application booted (another cluster node
+      // deploying a new version tagged the same way)
+      final var reported = resolve(processVersion, resolver);
+      return (reported != null) && lower.equals(reported.versionTag());
     }
-    final int version;
-    try {
-      version = Integer.parseInt(processVersion.trim());
-    } catch (final NumberFormatException e) {
+    final var version = ordinalOf(processVersion, resolver);
+    final var boundaries = boundaries(resolver);
+    if ((version == null) || (boundaries == null) || !sameScale(version, boundaries[0]) || !sameScale(version,
+        boundaries[1])) {
       return false;
     }
-    if (spec.matches("\\d+")) {
-      return Integer.parseInt(spec) == version;
+    // the boundaries are closed - '>' and '<' moved theirs by one when they were built
+    return ((boundaries[0] == null) || (version.value() >= boundaries[0]
+        .value())) && ((boundaries[1] == null) || (version.value() <= boundaries[1].value()));
+
+  }
+
+  /**
+   * Whether two specifications cover at least one common version - what makes two
+   * methods wired to the same BPMN element ambiguous. Disjoint ranges are a
+   * legitimate way of serving several versions of a process, which is why
+   * <code>1-2</code> next to <code>&gt;2</code> is fine and <code>1-3</code> next to
+   * <code>2</code> is not.
+   * <p>
+   * A specification naming a version tag can only be placed once the BPMS resolved
+   * it, so without a resolver two of them are reported as NOT overlapping unless
+   * they are written identically. The check runs a second time when the tags are
+   * resolved after the deployment (see
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#resolveProcessVersions}).
+   *
+   * @param other The other specification
+   * @param resolver Resolves version tags of the BPMN process both belong to
+   * @return Whether both cover a common version
+   */
+  public boolean overlaps(
+      final VersionRange other,
+      final ProcessVersionResolver resolver) {
+
+    if ((kind == Kind.ALL) || (other.kind == Kind.ALL)) {
+      return true;
     }
-    if (spec.matches("\\d+-\\d+")) {
-      final var boundaries = spec.split("-");
-      return (version >= Integer.parseInt(boundaries[0])) && (version <= Integer.parseInt(boundaries[1]));
+    // identically written specifications overlap by definition - no BPMS needed
+    if (spec.equals(other.spec)) {
+      return true;
     }
-    if (spec.startsWith(">")) {
-      return version > Integer.parseInt(spec.substring(1));
+    final var here = boundaries(resolver);
+    final var there = other.boundaries(resolver);
+    if ((here == null) || (there == null)) {
+      return false;
     }
-    return version < Integer.parseInt(spec.substring(1));
+    if (!sameScale(here[0], there[0]) || !sameScale(here[0], there[1]) || !sameScale(here[1],
+        there[0]) || !sameScale(here[1], there[1])) {
+      return false;
+    }
+    return ((here[0] == null) || (there[1] == null) || (here[0].value() <= there[1]
+        .value())) && ((there[0] == null) || (here[1] == null) || (there[0].value() <= here[1].value()));
+
+  }
+
+  /**
+   * @param other The other specification
+   * @return Whether both cover a common version, decided without asking a BPMS
+   */
+  public boolean overlaps(
+      final VersionRange other) {
+
+    return overlaps(other, NO_RESOLVER);
+
+  }
+
+  /**
+   * The version tags this specification names - the boundaries which are not numbers.
+   * Empty for a specification a BPMS never has to be asked about.
+   *
+   * @return The version tags named
+   */
+  public java.util.List<String> versionTags() {
+
+    return java.util.stream.Stream
+        .of(lower, upper)
+        .filter(java.util.Objects::nonNull)
+        .filter(boundary -> !isNumeric(boundary))
+        .distinct()
+        .toList();
+
+  }
+
+  /**
+   * A position in the deployment order and how it was determined - the version number
+   * of a BPMS counting upwards, or a deployment timestamp. Positions of different
+   * scales are not comparable.
+   */
+  private record Ordinal(
+                         long value,
+                         boolean numeric) {
+  }
+
+  /**
+   * The closed interval this specification covers, <code>null</code> for an
+   * unbounded end - or <code>null</code> altogether if a boundary names a version tag
+   * the resolver does not know.
+   */
+  private Ordinal[] boundaries(
+      final ProcessVersionResolver resolver) {
+
+    switch (kind) {
+      case ALL:
+        return new Ordinal[]{
+            null, null
+        };
+      case EXACT: {
+        final var value = ordinalOf(lower, resolver);
+        return value == null
+            ? null
+            : new Ordinal[]{
+                value, value
+            };
+      }
+      case GREATER: {
+        final var value = ordinalOf(lower, resolver);
+        return value == null
+            ? null
+            : new Ordinal[]{
+                new Ordinal(value.value() + (boundaryIncluded ? 0 : 1), value.numeric()), null
+            };
+      }
+      case LESS: {
+        final var value = ordinalOf(upper, resolver);
+        return value == null
+            ? null
+            : new Ordinal[]{
+                null, new Ordinal(value.value() - (boundaryIncluded ? 0 : 1), value.numeric())
+            };
+      }
+      default: {
+        final var from = ordinalOf(lower, resolver);
+        final var to = ordinalOf(upper, resolver);
+        return (from == null) || (to == null)
+            ? null
+            : new Ordinal[]{
+                from, to
+            };
+      }
+    }
+
+  }
+
+  /**
+   * Where a version or a version tag sits in the deployment order: the number itself
+   * for a BPMS counting versions upwards, the deployment timestamp otherwise.
+   */
+  private static Ordinal ordinalOf(
+      final String versionOrVersionTag,
+      final ProcessVersionResolver resolver) {
+
+    if (isNumeric(versionOrVersionTag)) {
+      return new Ordinal(Long.parseLong(versionOrVersionTag), true);
+    }
+    final var resolved = resolve(versionOrVersionTag, resolver);
+    if (resolved == null) {
+      return null;
+    }
+    if (isNumeric(resolved.version())) {
+      return new Ordinal(Long.parseLong(resolved.version()), true);
+    }
+    return resolved.deployedAt() == null
+        ? null
+        : new Ordinal(resolved.deployedAt().toEpochMilli(), false);
+
+  }
+
+  /**
+   * Whether two positions were determined the same way - a version number and a
+   * deployment timestamp say nothing about each other.
+   */
+  private static boolean sameScale(
+      final Ordinal one,
+      final Ordinal other) {
+
+    return (one == null) || (other == null) || (one.numeric() == other.numeric());
+
+  }
+
+  private static DeployedProcessVersion resolve(
+      final String versionOrVersionTag,
+      final ProcessVersionResolver resolver) {
+
+    return resolver == null
+        ? null
+        : resolver.resolve(versionOrVersionTag);
+
+  }
+
+  private static boolean isNumeric(
+      final String value) {
+
+    return (value != null) && value.matches("\\d+");
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
@@ -165,9 +165,50 @@ public class WorkflowTaskHandler {
   boolean matchesVersion(
       final String processVersion) {
 
+    return matchesVersion(processVersion, VersionRange.NO_RESOLVER);
+
+  }
+
+  boolean matchesVersion(
+      final String processVersion,
+      final VersionRange.ProcessVersionResolver resolver) {
+
     return versions
         .stream()
-        .anyMatch(version -> version.matches(processVersion));
+        .anyMatch(version -> version.matches(processVersion, resolver));
+
+  }
+
+  /**
+   * Whether this handler and the given one serve at least one common process version -
+   * two handlers wired to the same BPMN task are ambiguous exactly then.
+   *
+   * @param other The other handler
+   * @param resolver Resolves version tags of the BPMN process both belong to
+   * @return Whether both serve a common version
+   */
+  boolean overlapsVersions(
+      final WorkflowTaskHandler other,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    return versions
+        .stream()
+        .anyMatch(version -> other.versions
+            .stream()
+            .anyMatch(otherVersion -> version.overlaps(otherVersion, resolver)));
+
+  }
+
+  /**
+   * @return The version tags this handler's version specifications name
+   */
+  List<String> versionTags() {
+
+    return versions
+        .stream()
+        .flatMap(version -> version.versionTags().stream())
+        .distinct()
+        .toList();
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -83,16 +83,24 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
   private final Map<RegistryKey, RegistryEntry> entries = new ConcurrentHashMap<>();
 
   /**
+   * What the BPMS know about the deployed versions of the BPMN processes - needed to
+   * place a version TAG named by a <code>version</code> attribute in the deployment
+   * order (story 48). Shared by all three handler kinds, since all three annotations
+   * carry that attribute.
+   */
+  private final ProcessVersions processVersions = new ProcessVersions();
+
+  /**
    * The <code>&#64;WorkflowStartedByBpms</code> methods of the same workflow service
    * classes - what a workflow started by the BPMS itself needs (story 41).
    */
-  private final BpmsInitiatedStarts bpmsInitiatedStarts = new BpmsInitiatedStarts();
+  private final BpmsInitiatedStarts bpmsInitiatedStarts = new BpmsInitiatedStarts(processVersions);
 
   /**
    * The <code>&#64;WorkflowEnded</code> methods of the same workflow service classes
    * (story 43).
    */
-  private final WorkflowEndedHandlers workflowEndedHandlers = new WorkflowEndedHandlers();
+  private final WorkflowEndedHandlers workflowEndedHandlers = new WorkflowEndedHandlers(processVersions);
 
   /**
    * The transaction annotations of the running platform (story 40b), supplied by the
@@ -204,8 +212,18 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
           workflowServiceBean,
           beanResolver,
           transactionAnnotations);
-      handlers.forEach(handler -> failOnDuplicateWiring(workflowModuleId, bpmnProcessId, entry, handler));
-      entry.handlers.addAll(handlers);
+      // one by one, so two methods of the SAME class wired to one task definition are
+      // compared against each other as well (story 48)
+      handlers
+          .forEach(handler -> {
+            failOnDuplicateWiring(
+                workflowModuleId,
+                bpmnProcessId,
+                entry,
+                handler,
+                VersionRange.NO_RESOLVER);
+            entry.handlers.add(handler);
+          });
       entry.workflowServiceClasses.add(workflowServiceClass);
       entry.processService = processService;
     }
@@ -232,15 +250,18 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
       final String workflowModuleId,
       final String bpmnProcessId,
       final RegistryEntry entry,
-      final WorkflowTaskHandler handler) {
+      final WorkflowTaskHandler handler,
+      final VersionRange.ProcessVersionResolver resolver) {
 
     final var duplicate = entry.handlers
         .stream()
+        .filter(existing -> existing != handler)
         .filter(existing -> sameWiring(existing.getTaskDefinition(),
             handler.getTaskDefinition()) || sameWiring(existing.getActivityId(), handler.getActivityId()))
-        // both matching every version = genuinely ambiguous; disjoint version
-        // ranges are a legitimate way to serve several process versions
-        .filter(existing -> existing.matchesVersion(null) && handler.matchesVersion(null))
+        // overlapping version ranges are ambiguous; disjoint ones are a legitimate
+        // way to serve several process versions ('1-2' next to '>2' is fine, '1-3'
+        // next to '2' is not)
+        .filter(existing -> existing.overlapsVersions(handler, resolver))
         .findFirst();
     if (duplicate.isPresent()) {
       throw new IllegalStateException(
@@ -430,7 +451,9 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
         .stream()
         .filter(candidate -> sameWiring(candidate.getTaskDefinition(),
             context.getTaskDefinition()) || sameWiring(candidate.getActivityId(), context.getTaskDefinition()))
-        .filter(candidate -> candidate.matchesVersion(context.getProcessVersion()))
+        .filter(candidate -> candidate.matchesVersion(
+            context.getProcessVersion(),
+            processVersions.resolverFor(workflowModuleId, bpmnProcessId)))
         .findFirst()
         .orElseThrow(() -> new IllegalStateException(
             """
@@ -450,6 +473,64 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
         context,
         transactionRunner,
         rollbackRuleRemedies);
+
+  }
+
+  @Override
+  public void registerProcessVersions(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog catalog) {
+
+    processVersions.register(adapterId, workflowModuleId, bpmnProcessId, catalog);
+
+  }
+
+  @Override
+  public void resolveProcessVersions(
+      final String workflowModuleId) {
+
+    entries
+        .entrySet()
+        .stream()
+        .filter(entry -> entry.getKey().workflowModuleId().equals(workflowModuleId))
+        .forEach(entry -> {
+          final var bpmnProcessId = entry.getKey().bpmnProcessId();
+          final var registryEntry = entry.getValue();
+          final var tagsUsed = registryEntry.handlers
+              .stream()
+              .anyMatch(handler -> !handler.versionTags().isEmpty());
+          if (!tagsUsed) {
+            return;
+          }
+          // the BPMS is asked ONCE per process, right after the deployment: the
+          // version deployed by this boot is part of the answer, and a tag the
+          // application names is either known now or reported as unknown
+          processVersions.warmUp(workflowModuleId, bpmnProcessId);
+          final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+          synchronized (registryEntry) {
+            registryEntry.handlers
+                .forEach(handler -> handler
+                    .versionTags()
+                    .forEach(tag -> processVersions.reportUnknownVersionTag(
+                        workflowModuleId,
+                        bpmnProcessId,
+                        tag,
+                        handler.describe())));
+            // ranges naming a tag could not be placed while registering - now they can
+            registryEntry.handlers
+                .forEach(handler -> failOnDuplicateWiring(
+                    workflowModuleId,
+                    bpmnProcessId,
+                    registryEntry,
+                    handler,
+                    resolver));
+          }
+        });
+
+    bpmsInitiatedStarts.resolveProcessVersions(workflowModuleId);
+    workflowEndedHandlers.resolveProcessVersions(workflowModuleId);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -14,21 +14,33 @@ import org.slf4j.LoggerFactory;
 
 import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
 import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowstart.BpmsInitiatedStarts;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
 import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
 import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
 
 /**
- * The core-owned registry of <code>&#64;WorkflowTask</code> handlers per (workflow
- * module, BPMN process ID) and the implementation of the adapter-facing
- * {@link WorkflowTaskInvoker}. The platform integration registers every workflow
- * service class under all BPMN process IDs it declares
- * ({@code @WorkflowService.bpmnProcess} and {@code secondaryBpmnProcesses});
+ * The core-owned registry of the annotated handler methods of the application per
+ * (workflow module, BPMN process ID), and the implementation of the adapter-facing
+ * {@link WorkflowTaskInvoker} and {@link BpmsInitiatedStartInvoker}. The platform
+ * integration registers every workflow service class under all BPMN process IDs it
+ * declares ({@code @WorkflowService.bpmnProcess} and {@code secondaryBpmnProcesses});
  * adapters validate the wiring during <code>wireBpmn</code> and dispatch task
  * invocations at runtime.
+ * <p>
+ * <code>&#64;WorkflowTask</code> methods are held here; the
+ * <code>&#64;WorkflowStartedByBpms</code> methods of the same classes are held by
+ * {@link BpmsInitiatedStarts}, to which the second interface delegates. Both
+ * mechanisms scan the same classes and share the value conversion - generalizing
+ * them into ONE pluggable handler contract is the subject of the extension-enablement
+ * story.
  */
-public class WorkflowTaskRegistry implements WorkflowTaskInvoker {
+public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedStartInvoker {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowTaskRegistry.class);
 
@@ -65,6 +77,12 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker {
   private final io.vanillabp.integration.adapter.spi.WorkflowAggregateSync aggregateSync;
 
   private final Map<RegistryKey, RegistryEntry> entries = new ConcurrentHashMap<>();
+
+  /**
+   * The <code>&#64;WorkflowStartedByBpms</code> methods of the same workflow service
+   * classes - what a workflow started by the BPMS itself needs (story 41).
+   */
+  private final BpmsInitiatedStarts bpmsInitiatedStarts = new BpmsInitiatedStarts();
 
   /**
    * The transaction annotations of the running platform (story 40b), supplied by the
@@ -181,6 +199,14 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker {
       entry.workflowServiceClasses.add(workflowServiceClass);
       entry.processService = processService;
     }
+
+    bpmsInitiatedStarts
+        .registerWorkflowService(
+            workflowModuleId,
+            bpmnProcessId,
+            workflowServiceClass,
+            processService.getWorkflowAggregateClass(),
+            workflowServiceBean);
 
   }
 
@@ -406,6 +432,63 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker {
         context,
         transactionRunner,
         rollbackRuleRemedies);
+
+  }
+
+  @Override
+  public void validateBpmsInitiatedStarts(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Collection<BpmsInitiatedStartSpec> startEvents) {
+
+    bpmsInitiatedStarts.validate(workflowModuleId, bpmnProcessId, startEvents);
+
+  }
+
+  @Override
+  public BpmsInitiatedStartResult startWorkflowByBpms(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final BpmsInitiatedStartContext context) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((entry == null) || (entry.processService == null)) {
+      throw new IllegalStateException(
+          """
+              No @WorkflowService class is registered for BPMN process '%s' of workflow module \
+              '%s' - the BPMS started a workflow of it (start event '%s') but there is nothing to \
+              build its workflow aggregate! Known processes: %s."""
+              .formatted(
+                  bpmnProcessId,
+                  workflowModuleId,
+                  context.getStartEventId(),
+                  entries
+                      .keySet()
+                      .stream()
+                      .map(key -> "'%s' (module '%s')".formatted(key.bpmnProcessId(), key.workflowModuleId()))
+                      .collect(Collectors.joining(", "))));
+    }
+
+    final var result = bpmsInitiatedStarts.start(entry.processService, context, transactionRunner);
+    if ((aggregateSync == null) || (context
+        .getAggregateSyncMode() == io.vanillabp.integration.adapter.spi.AggregateSyncMode.NONE)) {
+      return result;
+    }
+
+    // the aggregate values shared with a remote BPMS (story 28) - read AFTER the
+    // start's transaction committed, which is why an embedded BPMS (joining the
+    // caller's transaction, sync mode NONE) never gets here
+    final var variables = new java.util.LinkedHashMap<>(result.variables());
+    variables
+        .putAll(
+            syncedWorkflowAggregateValues(
+                workflowModuleId,
+                bpmnProcessId,
+                result.workflowAggregateId(),
+                context.getAggregateSyncMode()));
+    variables.put(result.workflowAggregateIdName(), result.workflowAggregateId());
+    return new BpmsInitiatedStartResult(
+        result.workflowAggregateId(), result.workflowAggregateIdName(), variables, result.created());
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -14,7 +14,10 @@ import org.slf4j.LoggerFactory;
 
 import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
 import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowend.WorkflowEndedHandlers;
 import io.vanillabp.integration.adapter.migration.workflowstart.BpmsInitiatedStarts;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
@@ -35,12 +38,13 @@ import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
  * <p>
  * <code>&#64;WorkflowTask</code> methods are held here; the
  * <code>&#64;WorkflowStartedByBpms</code> methods of the same classes are held by
- * {@link BpmsInitiatedStarts}, to which the second interface delegates. Both
+ * {@link BpmsInitiatedStarts} and the <code>&#64;WorkflowEnded</code> methods by
+ * {@link WorkflowEndedHandlers}, to which the other two interfaces delegate. Both
  * mechanisms scan the same classes and share the value conversion - generalizing
  * them into ONE pluggable handler contract is the subject of the extension-enablement
  * story.
  */
-public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedStartInvoker {
+public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedStartInvoker, WorkflowEndedInvoker {
 
   private static final Logger log = LoggerFactory.getLogger(WorkflowTaskRegistry.class);
 
@@ -83,6 +87,12 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
    * classes - what a workflow started by the BPMS itself needs (story 41).
    */
   private final BpmsInitiatedStarts bpmsInitiatedStarts = new BpmsInitiatedStarts();
+
+  /**
+   * The <code>&#64;WorkflowEnded</code> methods of the same workflow service classes
+   * (story 43).
+   */
+  private final WorkflowEndedHandlers workflowEndedHandlers = new WorkflowEndedHandlers();
 
   /**
    * The transaction annotations of the running platform (story 40b), supplied by the
@@ -201,6 +211,14 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
     }
 
     bpmsInitiatedStarts
+        .registerWorkflowService(
+            workflowModuleId,
+            bpmnProcessId,
+            workflowServiceClass,
+            processService.getWorkflowAggregateClass(),
+            workflowServiceBean);
+
+    workflowEndedHandlers
         .registerWorkflowService(
             workflowModuleId,
             bpmnProcessId,
@@ -489,6 +507,42 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
     variables.put(result.workflowAggregateIdName(), result.workflowAggregateId());
     return new BpmsInitiatedStartResult(
         result.workflowAggregateId(), result.workflowAggregateIdName(), variables, result.created());
+
+  }
+
+  @Override
+  public boolean workflowEndedHandlerExists(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return workflowEndedHandlers.handlerExists(workflowModuleId, bpmnProcessId);
+
+  }
+
+  @Override
+  public void workflowEnded(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final WorkflowEndedContext context) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((entry == null) || (entry.processService == null)) {
+      throw new IllegalStateException(
+          """
+              No @WorkflowService class is registered for BPMN process '%s' of workflow module \
+              '%s' - the end of workflow '%s' cannot be reported! Known processes: %s."""
+              .formatted(
+                  bpmnProcessId,
+                  workflowModuleId,
+                  context.getWorkflowAggregateId(),
+                  entries
+                      .keySet()
+                      .stream()
+                      .map(key -> "'%s' (module '%s')".formatted(key.bpmnProcessId(), key.workflowModuleId()))
+                      .collect(Collectors.joining(", "))));
+    }
+
+    workflowEndedHandlers.workflowEnded(entry.processService, context, transactionRunner);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -640,6 +640,20 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
   }
 
   @Override
+  public boolean workflowAggregateHasProperty(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String propertyName) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((entry == null) || (entry.processService == null)) {
+      return false;
+    }
+    return AggregatePropertyReader.has(entry.processService.getWorkflowAggregateClass(), propertyName);
+
+  }
+
+  @Override
   public Object resolveWorkflowAggregateProperty(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
@@ -2,8 +2,6 @@ package io.vanillabp.integration.adapter.migration.workflowtask;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -13,6 +11,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import io.vanillabp.integration.adapter.migration.values.ValueConversion;
 import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskHandler.ParameterBinder;
 import io.vanillabp.integration.adapter.spi.workflowtask.MultiInstanceValue;
 import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
@@ -241,7 +240,7 @@ class WorkflowTaskScanner {
       final var targetType = parameter.getType();
       return (
           aggregate,
-          context) -> convertValue(
+          context) -> ValueConversion.convert(
               context.getTaskParameter(taskParam.value()),
               targetType,
               "@TaskParam(\"%s\") %s".formatted(taskParam.value(), location));
@@ -392,130 +391,6 @@ class WorkflowTaskScanner {
               type."""
               .formatted(location, annotationName));
     }
-
-  }
-
-  /**
-   * Converts a task-parameter value supplied by the adapter to the handler
-   * parameter's type: assignable values pass through, Strings are converted to the
-   * common primitive/wrapper types and BigDecimal/BigInteger, numbers are narrowed/
-   * widened between number types.
-   */
-  private static Object convertValue(
-      final Object value,
-      final Class<?> targetType,
-      final String location) {
-
-    if (value == null) {
-      if (targetType.isPrimitive()) {
-        throw new IllegalStateException(
-            """
-                The value bound to %s is null but the parameter's type is primitive! Use the \
-                wrapper type or ensure the BPMN input mapping provides a value."""
-                .formatted(location));
-      }
-      return null;
-    }
-    if (wrapperOf(targetType).isInstance(value)) {
-      return value;
-    }
-    final var target = wrapperOf(targetType);
-    if (value instanceof String string) {
-      if (target.equals(Integer.class)) {
-        return Integer.valueOf(string);
-      }
-      if (target.equals(Long.class)) {
-        return Long.valueOf(string);
-      }
-      if (target.equals(Double.class)) {
-        return Double.valueOf(string);
-      }
-      if (target.equals(Float.class)) {
-        return Float.valueOf(string);
-      }
-      if (target.equals(Short.class)) {
-        return Short.valueOf(string);
-      }
-      if (target.equals(Byte.class)) {
-        return Byte.valueOf(string);
-      }
-      if (target.equals(Boolean.class)) {
-        return Boolean.valueOf(string);
-      }
-      if (target.equals(BigDecimal.class)) {
-        return new BigDecimal(string);
-      }
-      if (target.equals(BigInteger.class)) {
-        return new BigInteger(string);
-      }
-    }
-    if (value instanceof Number number) {
-      if (target.equals(Integer.class)) {
-        return number.intValue();
-      }
-      if (target.equals(Long.class)) {
-        return number.longValue();
-      }
-      if (target.equals(Double.class)) {
-        return number.doubleValue();
-      }
-      if (target.equals(Float.class)) {
-        return number.floatValue();
-      }
-      if (target.equals(Short.class)) {
-        return number.shortValue();
-      }
-      if (target.equals(Byte.class)) {
-        return number.byteValue();
-      }
-      if (target.equals(BigDecimal.class)) {
-        return new BigDecimal(number.toString());
-      }
-      if (target.equals(BigInteger.class)) {
-        return new BigInteger(number.toString());
-      }
-      if (target.equals(String.class)) {
-        return number.toString();
-      }
-    }
-    throw new IllegalStateException(
-        """
-            The value of type '%s' bound to %s cannot be converted to the parameter's type '%s'!"""
-            .formatted(value.getClass().getName(), location, targetType.getName()));
-
-  }
-
-  private static Class<?> wrapperOf(
-      final Class<?> type) {
-
-    if (!type.isPrimitive()) {
-      return type;
-    }
-    if (type.equals(int.class)) {
-      return Integer.class;
-    }
-    if (type.equals(long.class)) {
-      return Long.class;
-    }
-    if (type.equals(double.class)) {
-      return Double.class;
-    }
-    if (type.equals(float.class)) {
-      return Float.class;
-    }
-    if (type.equals(short.class)) {
-      return Short.class;
-    }
-    if (type.equals(byte.class)) {
-      return Byte.class;
-    }
-    if (type.equals(boolean.class)) {
-      return Boolean.class;
-    }
-    if (type.equals(char.class)) {
-      return Character.class;
-    }
-    return type;
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/integration/adapter/migration/workflowstart/AggregatePropertyWriterTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/integration/adapter/migration/workflowstart/AggregatePropertyWriterTest.java
@@ -1,0 +1,96 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * How a value the BPMS reported reaches an attribute of a freshly built workflow
+ * aggregate: by setter, else by field, else not at all.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregatePropertyWriterTest {
+
+  public static class Aggregate {
+
+    private String id;
+
+    private int amount;
+
+    String withoutSetter;
+
+    private final String readOnly = "fixed";
+
+    public void setId(
+        final String id) {
+      this.id = id;
+    }
+
+    public void setAmount(
+        final int amount) {
+      this.amount = amount;
+    }
+
+    public String getReadOnly() {
+      return readOnly;
+    }
+
+  }
+
+  public static class Child extends Aggregate {
+
+  }
+
+  @Test
+  @DisplayName("A setter is used, and the value is converted to its parameter type")
+  public void setterWins() {
+
+    final var aggregate = new Aggregate();
+
+    assertTrue(AggregatePropertyWriter.write(aggregate, "id", "4711", "the ID"));
+    assertEquals("4711", aggregate.id);
+
+    assertTrue(AggregatePropertyWriter.write(aggregate, "amount", "42", "the amount"));
+    assertEquals(42, aggregate.amount);
+
+  }
+
+  @Test
+  @DisplayName("Without a setter the field is written, including one inherited from a superclass")
+  public void fieldIsTheFallback() {
+
+    final var aggregate = new Child();
+
+    assertTrue(AggregatePropertyWriter.write(aggregate, "withoutSetter", "value", "the attribute"));
+    assertEquals("value", aggregate.withoutSetter);
+
+  }
+
+  @Test
+  @DisplayName("An attribute the aggregate does not have is reported, not forced")
+  public void unknownAttributeIsReported() {
+
+    assertFalse(AggregatePropertyWriter.write(new Aggregate(), "notModelled", "value", "the attribute"));
+
+  }
+
+  @Test
+  @DisplayName("A value which does not fit the attribute fails naming what was written")
+  public void unconvertibleValueFails() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> AggregatePropertyWriter.write(new Aggregate(), "amount", new Object(), "the amount"));
+
+    assertTrue(exception.getMessage().contains("the amount"));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartIdTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartIdTest.java
@@ -1,0 +1,127 @@
+package io.vanillabp.integration.adapter.migration.workflowstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+
+/**
+ * The rules deciding the ID of a workflow aggregate nobody handed to VanillaBP. Lives
+ * in the package of the class under test because those rules are internal: what the
+ * application sees of them is documented and covered by the acceptance tests.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class BpmsInitiatedStartIdTest {
+
+  private static final Instant TRIGGER_TIME = Instant.parse("2026-08-12T04:00:00Z");
+
+  private static final String INSTANCE_KEY = "2251799813685334";
+
+  private static Object timerId(
+      final Class<?> aggregateIdType) {
+
+    return BpmsInitiatedStartId
+        .derive(BpmsStartTrigger.Kind.TIMER, TRIGGER_TIME, null, aggregateIdType, Object.class)
+        .orElse(null);
+
+  }
+
+  @Test
+  @DisplayName("What the BPMS identifies the start by beats everything else")
+  public void naturalIdentityWins() {
+
+    assertEquals(
+        INSTANCE_KEY,
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.TIMER, TRIGGER_TIME, INSTANCE_KEY, String.class, Object.class)
+            .orElseThrow());
+    assertEquals(
+        Long.valueOf(INSTANCE_KEY),
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.SIGNAL, TRIGGER_TIME, INSTANCE_KEY, Long.class, Object.class)
+            .orElseThrow());
+    // an ID type which cannot carry it falls back to the trigger rules
+    assertEquals(
+        TRIGGER_TIME,
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.TIMER, TRIGGER_TIME, INSTANCE_KEY, Instant.class, Object.class)
+            .orElseThrow());
+    // ... and a non-numeric identity does not become a numeric ID
+    assertTrue(
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.SIGNAL, TRIGGER_TIME, "not-a-number", Long.class, Object.class)
+            .isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A timer's ID is its trigger time, in whatever type the aggregate uses")
+  public void triggerTimeIsConvertedToTheIdType() {
+
+    assertEquals(TRIGGER_TIME.toString(), timerId(String.class));
+    // no ID type reported: the persistence layer owns the serialized form
+    assertEquals(TRIGGER_TIME.toString(), timerId(null));
+    assertEquals(TRIGGER_TIME, timerId(Instant.class));
+    assertEquals(TRIGGER_TIME.toEpochMilli(), timerId(Long.class));
+    assertEquals(TRIGGER_TIME.toEpochMilli(), timerId(long.class));
+    assertEquals(
+        OffsetDateTime.ofInstant(TRIGGER_TIME, ZoneId.systemDefault()),
+        timerId(OffsetDateTime.class));
+    assertEquals(
+        ZonedDateTime.ofInstant(TRIGGER_TIME, ZoneId.systemDefault()),
+        timerId(ZonedDateTime.class));
+    assertEquals(
+        LocalDateTime.ofInstant(TRIGGER_TIME, ZoneId.systemDefault()),
+        timerId(LocalDateTime.class));
+
+  }
+
+  @Test
+  @DisplayName("An ID type which cannot carry the trigger time gets a generated ID or none at all")
+  public void unfittingIdTypesFallBack() {
+
+    // a UUID cannot be a point in time, but it can be generated
+    assertInstanceOf(UUID.class, timerId(UUID.class));
+    // a numeric ID without a natural value is left to the persistence layer
+    assertTrue(
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.SIGNAL, TRIGGER_TIME, null, Long.class, Object.class)
+            .isEmpty());
+    assertTrue(
+        BpmsInitiatedStartId
+            .derive(BpmsStartTrigger.Kind.CONDITIONAL, TRIGGER_TIME, null, java.math.BigInteger.class, Object.class)
+            .isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Signals and conditions have no natural identity, so their IDs are generated and distinct")
+  public void generatedIdsAreDistinct() {
+
+    final var first = BpmsInitiatedStartId
+        .derive(BpmsStartTrigger.Kind.SIGNAL, TRIGGER_TIME, null, String.class, Object.class)
+        .orElseThrow();
+    final var second = BpmsInitiatedStartId
+        .derive(BpmsStartTrigger.Kind.CONDITIONAL, TRIGGER_TIME, null, String.class, Object.class)
+        .orElseThrow();
+
+    assertFalse(first.equals(second), "two starts by broadcast are two workflows");
+    assertFalse(first.equals(TRIGGER_TIME.toString()), "the trigger time is not an identity here");
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/AggregateChangedTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/AggregateChangedTest.java
@@ -1,0 +1,312 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoOutboxResolver;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.process.WorkflowNotFoundException;
+
+/**
+ * Pushing a changed workflow-aggregate to the BPMS (story 44). The shape is the one
+ * of message correlation - save, probe, phase one or outbox - so these tests cover
+ * what is different: the task id deciding the scope, the missing idempotency key and
+ * an ended workflow being a warning instead of a failure.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregateChangedTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  /**
+   * Records what the adapter was asked to push, and in which phase.
+   */
+  static class RecordingAdapter extends SendSignalTest.RecordingAdapter {
+
+    record Push(Object aggregate, String taskId) {
+    }
+
+    final List<Push> phaseOnePushes = new LinkedList<>();
+
+    final List<Push> phaseTwoPushes = new LinkedList<>();
+
+    WorkflowAwareness awareness = WorkflowAwareness.ACTIVE;
+
+    RecordingAdapter(
+        final String adapterId,
+        final boolean twoPhase) {
+      super(adapterId, twoPhase);
+    }
+
+    @Override
+    public WorkflowAwareness awarenessOfWorkflow(
+        final Object workflowAggregateId) {
+      return awareness;
+    }
+
+    @Override
+    public void aggregateChangedPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String taskId) {
+      phaseOnePushes.add(new Push(workflowAggregate, taskId));
+    }
+
+    @Override
+    public void aggregateChangedPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String taskId) {
+      phaseTwoPushes.add(new Push(workflowAggregateId, taskId));
+    }
+
+  }
+
+  /**
+   * Hands back the aggregate it was given and reports a fixed ID - the core saves
+   * before it probes, which is what the tests rely on.
+   */
+  static class PersistenceStub implements AggregatePersistenceAware<Object> {
+
+    final List<Object> saved = new LinkedList<>();
+
+    @Override
+    public Class<Object> getAggregateClass() {
+      return Object.class;
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object save(
+        final Object workflowAggregate) {
+      saved.add(workflowAggregate);
+      return workflowAggregate;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Object workflowAggregate) {
+      return "42";
+    }
+
+  }
+
+  static class RecordingOutbox implements PhaseTwoOutbox {
+
+    final List<PhaseTwoCall> scheduled = new LinkedList<>();
+
+    @Override
+    public boolean schedule(
+        final PhaseTwoCall call) {
+      scheduled.add(call);
+      return true;
+    }
+
+  }
+
+  private final PersistenceStub persistence = new PersistenceStub();
+
+  private MigrationProcessService<Object> processService(
+      final List<MigratableProcessService<Object>> adapters,
+      final PhaseTwoOutbox outbox) {
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of("first-adapter", AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of("first-adapter"))
+        .build();
+    properties.validateAndLink();
+
+    PhaseTwoOutboxResolver resolver = null;
+    if (outbox != null) {
+      resolver = new PhaseTwoOutboxResolver() {
+
+        @Override
+        public PhaseTwoOutbox resolveFor(
+            final Class<?> workflowAggregateClass) {
+          return outbox;
+        }
+
+        @Override
+        public String remediesDescription() {
+          return "test";
+        }
+
+      };
+    }
+
+    return new MigrationProcessService<Object>(
+        MODULE, PROCESS, Object.class, properties, persistence, adapters, resolver);
+
+  }
+
+  @Test
+  @DisplayName("An embedded BPMS is given the saved aggregate inside the transaction")
+  public void embeddedBpmsIsPushedInPhaseOne() {
+
+    final var adapter = new RecordingAdapter("first-adapter", false);
+    final var aggregate = new Object();
+
+    final var attached = processService(List.of(adapter), null).aggregateChanged(aggregate, null);
+
+    assertSame(aggregate, attached);
+    // the aggregate is saved BEFORE the BPMS is told - the caller changed it, and
+    // that change is what the BPMS is supposed to see
+    assertEquals(List.of(aggregate), persistence.saved);
+    assertEquals(1, adapter.phaseOnePushes.size());
+    assertSame(aggregate, adapter.phaseOnePushes.getFirst().aggregate());
+    // no task id: the workflow's global scope
+    assertNull(adapter.phaseOnePushes.getFirst().taskId());
+
+  }
+
+  @Test
+  @DisplayName("The task id travels to the adapter and into the outbox entry")
+  public void theTaskIdDecidesTheScope() {
+
+    final var adapter = new RecordingAdapter("first-adapter", true);
+    final var outbox = new RecordingOutbox();
+
+    processService(List.of(adapter), outbox).aggregateChanged(new Object(), "task-1");
+
+    assertEquals("task-1", adapter.phaseOnePushes.getFirst().taskId());
+
+    assertEquals(1, outbox.scheduled.size());
+    final var call = outbox.scheduled.getFirst();
+    assertEquals("AGGREGATE_CHANGED", call.operation());
+    assertEquals("42", call.workflowAggregateId());
+    assertEquals("task-1", call.args().get(PhaseTwoCall.ARG_TASK_ID));
+    // no adapter id is persisted: the BPMS holding the workflow answers at dispatch
+    // time, like every other probing operation
+    assertNull(call.adapterId());
+    // the values are read when the entry is dispatched, so a repeated dispatch
+    // writes the then-current state - there is nothing to deduplicate
+    assertTrue(call.idempotencyKey().isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Without a task id the outbox entry carries none")
+  public void aGlobalPushCarriesNoTaskId() {
+
+    final var outbox = new RecordingOutbox();
+
+    processService(List.of(new RecordingAdapter("first-adapter", true)), outbox)
+        .aggregateChanged(new Object(), null);
+
+    assertTrue(outbox.scheduled.getFirst().args().isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("An ended workflow is a warning, and the aggregate is saved either way")
+  public void aCompletedWorkflowIsNoFailure() {
+
+    final var adapter = new RecordingAdapter("first-adapter", false);
+    adapter.awareness = WorkflowAwareness.COMPLETED;
+    final var aggregate = new Object();
+
+    final var attached = processService(List.of(adapter), null).aggregateChanged(aggregate, null);
+
+    assertSame(aggregate, attached);
+    assertEquals(List.of(aggregate), persistence.saved);
+    assertTrue(adapter.phaseOnePushes.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A workflow no BPMS knows fails guiding - naming that the aggregate was saved")
+  public void anUnknownWorkflowFailsGuiding() {
+
+    final var adapter = new RecordingAdapter("first-adapter", false);
+    adapter.awareness = WorkflowAwareness.UNKNOWN_TO_BPMS;
+
+    final var exception = assertThrows(
+        WorkflowNotFoundException.class,
+        () -> processService(List.of(adapter), null).aggregateChanged(new Object(), null));
+
+    assertTrue(exception.getMessage().contains("42"));
+    assertTrue(exception.getMessage().contains("was saved"));
+
+  }
+
+  @Test
+  @DisplayName("Phase two pushes through the BPMS holding the workflow")
+  public void phaseTwoElectsByProbing() {
+
+    final var adapter = new RecordingAdapter("first-adapter", true);
+
+    processService(List.of(adapter), new RecordingOutbox()).aggregateChangedPhaseTwo("42", "task-1");
+
+    assertEquals(1, adapter.phaseTwoPushes.size());
+    assertEquals("42", adapter.phaseTwoPushes.getFirst().aggregate());
+    assertEquals("task-1", adapter.phaseTwoPushes.getFirst().taskId());
+
+  }
+
+  @Test
+  @DisplayName("A workflow gone by dispatch time consumes the entry instead of failing")
+  public void phaseTwoTolerAtesAStaleEntry() {
+
+    final var adapter = new RecordingAdapter("first-adapter", true);
+    adapter.awareness = WorkflowAwareness.COMPLETED;
+
+    processService(List.of(adapter), new RecordingOutbox()).aggregateChangedPhaseTwo("42", null);
+
+    assertTrue(adapter.phaseTwoPushes.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("An adapter whose BPMS cannot update a running instance says so")
+  public void anAdapterWithoutSupportFailsGuiding() {
+
+    final var adapter = new SendSignalTest.RecordingAdapter("first-adapter", false) {
+
+      @Override
+      public WorkflowAwareness awarenessOfWorkflow(
+          final Object workflowAggregateId) {
+        return WorkflowAwareness.ACTIVE;
+      }
+
+    };
+
+    final var exception = assertThrows(
+        UnsupportedOperationException.class,
+        () -> processService(List.of(adapter), null).aggregateChanged(new Object(), null));
+
+    assertTrue(exception.getMessage().contains("first-adapter"));
+    assertTrue(exception.getMessage().contains(PROCESS));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
@@ -50,7 +50,8 @@ public class PhaseTwoOperationContractTest {
                 "CANCEL_USER_TASK",
                 "CORRELATE_MESSAGE",
                 "START_WORKFLOW_BY_MESSAGE",
-                "SEND_SIGNAL"),
+                "SEND_SIGNAL",
+                "AGGREGATE_CHANGED"),
         PhaseTwoOperation.coreOperationNames());
 
   }
@@ -143,6 +144,19 @@ public class PhaseTwoOperationContractTest {
             .of(
                 PhaseTwoOperation.SEND_SIGNAL, "test-module", "TestProcess", null, "test-adapter", Map
                     .of(PhaseTwoCall.ARG_SIGNAL_NAME, "OrderReceived"))
+            .idempotencyKey()
+            .isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Pushing a changed aggregate has no key - the values are read at dispatch time")
+  public void aggregateChangedHasNoKey() {
+
+    assertTrue(
+        call(PhaseTwoOperation.AGGREGATE_CHANGED, Map.of()).idempotencyKey().isEmpty());
+    assertTrue(
+        call(PhaseTwoOperation.AGGREGATE_CHANGED, Map.of(PhaseTwoCall.ARG_TASK_ID, "task-1"))
             .idempotencyKey()
             .isEmpty());
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
@@ -49,7 +49,8 @@ public class PhaseTwoOperationContractTest {
                 "COMPLETE_USER_TASK",
                 "CANCEL_USER_TASK",
                 "CORRELATE_MESSAGE",
-                "START_WORKFLOW_BY_MESSAGE"),
+                "START_WORKFLOW_BY_MESSAGE",
+                "SEND_SIGNAL"),
         PhaseTwoOperation.coreOperationNames());
 
   }
@@ -130,6 +131,20 @@ public class PhaseTwoOperationContractTest {
         call(
             PhaseTwoOperation.CORRELATE_MESSAGE,
             Map.of(PhaseTwoCall.ARG_MESSAGE_NAME, "OrderReceived")).idempotencyKey().isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A broadcast signal has nothing to deduplicate by")
+  public void sendSignalHasNoKey() {
+
+    assertTrue(
+        PhaseTwoCall
+            .of(
+                PhaseTwoOperation.SEND_SIGNAL, "test-module", "TestProcess", null, "test-adapter", Map
+                    .of(PhaseTwoCall.ARG_SIGNAL_NAME, "OrderReceived"))
+            .idempotencyKey()
+            .isEmpty());
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationContractTest.java
@@ -1,0 +1,149 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Pins the PERSISTED contract of VanillaBP's core phase-two operations: their names
+ * and their idempotency-key derivation rules. Both were guaranteed by construction
+ * as long as the operations were enum constants; since they are entries of the
+ * operation registry, this test is the guarantee.
+ * <p>
+ * A failure here means outbox entries written by an earlier version of the
+ * application will no longer dispatch or no longer deduplicate. Do not "fix" the
+ * test by adjusting the expectation - fix the operation.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PhaseTwoOperationContractTest {
+
+  private static PhaseTwoCall call(
+      final PhaseTwoOperation operation,
+      final Map<String, String> args) {
+
+    return PhaseTwoCall
+        .of(operation, "test-module", "TestProcess", "42", "test-adapter", args);
+
+  }
+
+  @Test
+  @DisplayName("The core operations are exactly these, named exactly like this")
+  public void coreOperationNamesArePinned() {
+
+    assertEquals(
+        List
+            .of(
+                "START_WORKFLOW",
+                "COMPLETE_TASK",
+                "CANCEL_TASK",
+                "COMPLETE_USER_TASK",
+                "CANCEL_USER_TASK",
+                "CORRELATE_MESSAGE",
+                "START_WORKFLOW_BY_MESSAGE"),
+        PhaseTwoOperation.coreOperationNames());
+
+  }
+
+  @Test
+  @DisplayName("Starting a workflow deduplicates per module, process and aggregate")
+  public void startWorkflowKeyIsPinned() {
+
+    assertEquals(
+        "test-module|TestProcess|42",
+        call(PhaseTwoOperation.START_WORKFLOW, Map.of()).idempotencyKey().orElseThrow());
+
+    // by message: same key - a workflow is started at most once per aggregate,
+    // regardless of the triggering message
+    assertEquals(
+        "test-module|TestProcess|42",
+        call(
+            PhaseTwoOperation.START_WORKFLOW_BY_MESSAGE,
+            Map.of(PhaseTwoCall.ARG_MESSAGE_NAME, "OrderReceived")).idempotencyKey().orElseThrow());
+
+  }
+
+  @Test
+  @DisplayName("Task operations deduplicate per task, not per error code")
+  public void taskKeysArePinned() {
+
+    final var expected = "test-module|TestProcess|42|task-1";
+
+    assertEquals(
+        expected,
+        call(
+            PhaseTwoOperation.COMPLETE_TASK,
+            Map.of(PhaseTwoCall.ARG_TASK_ID, "task-1")).idempotencyKey().orElseThrow());
+    assertEquals(
+        expected,
+        call(
+            PhaseTwoOperation.COMPLETE_USER_TASK,
+            Map.of(PhaseTwoCall.ARG_TASK_ID, "task-1")).idempotencyKey().orElseThrow());
+    assertEquals(
+        expected,
+        call(
+            PhaseTwoOperation.CANCEL_TASK,
+            Map
+                .of(
+                    PhaseTwoCall.ARG_TASK_ID, "task-1",
+                    PhaseTwoCall.ARG_BPMN_ERROR_CODE, "Rejected"))
+            .idempotencyKey().orElseThrow());
+    assertEquals(
+        expected,
+        call(
+            PhaseTwoOperation.CANCEL_USER_TASK,
+            Map
+                .of(
+                    PhaseTwoCall.ARG_TASK_ID, "task-1",
+                    PhaseTwoCall.ARG_BPMN_ERROR_CODE, "Rejected"))
+            .idempotencyKey().orElseThrow());
+
+  }
+
+  @Test
+  @DisplayName("Message correlation deduplicates only with a correlation id")
+  public void correlateMessageKeyIsPinned() {
+
+    assertEquals(
+        "test-module|TestProcess|42|OrderReceived|correlation-1",
+        call(
+            PhaseTwoOperation.CORRELATE_MESSAGE,
+            Map
+                .of(
+                    PhaseTwoCall.ARG_MESSAGE_NAME, "OrderReceived",
+                    PhaseTwoCall.ARG_CORRELATION_ID, "correlation-1"))
+            .idempotencyKey().orElseThrow());
+
+    // without a correlation id the same message may legitimately be correlated
+    // several times - there is no key, and an at-least-once dispatch may
+    // double-correlate (documented residual)
+    assertTrue(
+        call(
+            PhaseTwoOperation.CORRELATE_MESSAGE,
+            Map.of(PhaseTwoCall.ARG_MESSAGE_NAME, "OrderReceived")).idempotencyKey().isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A call rebuilt from a persisted entry carries no key - the store persisted it")
+  public void dispatchCallsCarryNoKey() {
+
+    assertTrue(
+        PhaseTwoCall
+            .forDispatch(
+                "START_WORKFLOW", "test-module", "TestProcess", "42", "test-adapter", Map.of())
+            .idempotencyKey()
+            .isEmpty());
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoOperationRegistryTest.java
@@ -1,0 +1,124 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.spi.PhaseTwoOperationDispatch;
+import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The rules keeping the operation registry unambiguous: an operation is registered
+ * exactly once, extensions namespace their operations, and the core's names are
+ * reserved.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PhaseTwoOperationRegistryTest {
+
+  private static final PhaseTwoOperationDispatch NOOP = (
+      call,
+      previouslyAttempted) -> {
+  };
+
+  private final PhaseTwoOperationRegistry testee = new PhaseTwoOperationRegistry();
+
+  private static PhaseTwoOperation extensionOperation(
+      final String name) {
+
+    return PhaseTwoOperation.extensionOperation(name, call -> Optional.empty());
+
+  }
+
+  @Test
+  @DisplayName("A registered extension operation is found by its name")
+  public void extensionOperationIsFound() {
+
+    final var operation = extensionOperation("my-extension:NOTIFY");
+    testee.register(operation, NOOP);
+
+    assertEquals(operation, testee.find("my-extension:NOTIFY").orElseThrow());
+    assertTrue(testee.dispatchFor("my-extension:NOTIFY").isPresent());
+    assertTrue(testee.find("my-extension:UNKNOWN").isEmpty());
+    assertEquals(java.util.List.of("my-extension:NOTIFY"), testee.registeredNames());
+
+  }
+
+  @Test
+  @DisplayName("An extension operation without a namespace is rejected guiding")
+  public void unnamespacedOperationIsRejected() {
+
+    final var exception = assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> extensionOperation("NOTIFY"));
+
+    // the message has to name the offending operation and show the expected shape
+    assertTrue(exception.getMessage().contains("NOTIFY"));
+    assertTrue(exception.getMessage().contains("my-extension:MY_OPERATION"));
+
+  }
+
+  @Test
+  @DisplayName("An extension claiming a core operation's name is rejected guiding")
+  public void coreOperationNameIsReserved() {
+
+    // built through the plain constructor: 'extensionOperation' would already
+    // reject it for the missing namespace - the point here is the reservation
+    final var squatter = new PhaseTwoOperation(
+        PhaseTwoOperation.START_WORKFLOW.name(), call -> Optional.empty());
+
+    final var exception = assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> testee.register(squatter, NOOP));
+
+    assertTrue(exception.getMessage().contains("START_WORKFLOW"));
+    assertTrue(exception.getMessage().contains("reserved"));
+
+  }
+
+  @Test
+  @DisplayName("Registering a non-core operation as a core operation is rejected guiding")
+  public void registerCoreOperationChecksTheOperation() {
+
+    final var exception = assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> testee.registerCoreOperation(extensionOperation("my-extension:NOTIFY"), NOOP));
+
+    assertTrue(exception.getMessage().contains("my-extension:NOTIFY"));
+    assertTrue(exception.getMessage().contains("START_WORKFLOW"));
+
+  }
+
+  @Test
+  @DisplayName("Registering the same operation twice fails guiding")
+  public void duplicateRegistrationFails() {
+
+    testee.register(extensionOperation("my-extension:NOTIFY"), NOOP);
+
+    final var exception = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> testee.register(extensionOperation("my-extension:NOTIFY"), NOOP));
+
+    assertTrue(exception.getMessage().contains("my-extension:NOTIFY"));
+    assertTrue(exception.getMessage().contains("twice"));
+
+  }
+
+  @Test
+  @DisplayName("A blank operation name is rejected")
+  public void blankNameIsRejected() {
+
+    assertThrowsExactly(
+        IllegalArgumentException.class,
+        () -> new PhaseTwoOperation(" ", call -> Optional.empty()));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,11 +28,17 @@ public class PhaseTwoRouterTest {
 
   private final PhaseTwoRouter testee = new PhaseTwoRouter();
 
-  @BeforeEach
-  public void mockProcessService() {
+  /**
+   * Registers the mocked process service for <code>test-module/TestProcess</code> -
+   * done per test instead of in a setup method, because the tests around the
+   * operation registry need no process service at all.
+   */
+  private void registerProcessService() {
 
     when(processService.getWorkflowModuleId()).thenReturn("test-module");
     when(processService.getBpmnProcessId()).thenReturn("TestProcess");
+
+    testee.register(processService);
 
   }
 
@@ -43,10 +48,11 @@ public class PhaseTwoRouterTest {
 
     when(processService.convertAggregateId("42")).thenReturn(42L);
 
-    testee.register(processService);
+    registerProcessService();
 
-    testee.dispatch(new PhaseTwoCall(
-        PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", "42", "test-adapter", Map.of()));
+    testee.dispatch(PhaseTwoCall
+        .of(
+            PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", "42", "test-adapter", Map.of()));
 
     verify(processService).startWorkflowPhaseTwo(42L, "test-adapter", false);
 
@@ -56,18 +62,63 @@ public class PhaseTwoRouterTest {
   @DisplayName("Dispatch for an unknown BPMN process fails with a guiding message")
   public void dispatchFailsOnUnknownProcess() {
 
-    testee.register(processService);
+    registerProcessService();
 
     final var exception = assertThrowsExactly(
         IllegalStateException.class,
-        () -> testee.dispatch(new PhaseTwoCall(
-            PhaseTwoOperation.START_WORKFLOW, "test-module", "RemovedProcess", "42", "test-adapter", Map.of())));
+        () -> testee.dispatch(PhaseTwoCall
+            .of(
+                PhaseTwoOperation.START_WORKFLOW, "test-module", "RemovedProcess", "42", "test-adapter", Map.of())));
 
     // the message has to name the process, the module and that the entry stays
     // visible in the outbox store
     assertTrue(exception.getMessage().contains("RemovedProcess"));
     assertTrue(exception.getMessage().contains("test-module"));
     assertTrue(exception.getMessage().contains("outbox"));
+
+  }
+
+  @Test
+  @DisplayName("An operation of an extension is dispatched to the extension's own handler")
+  public void extensionOperationIsDispatchedToItsHandler() {
+
+    final var operation = PhaseTwoOperation
+        .extensionOperation("my-extension:NOTIFY", call -> java.util.Optional.empty());
+    final var dispatched = new java.util.concurrent.atomic.AtomicReference<PhaseTwoCall>();
+    testee
+        .getOperations()
+        .register(
+            operation,
+            (
+                call,
+                previouslyAttempted) -> dispatched.set(call));
+
+    // no process service is registered: an extension operation is NOT routed
+    // through the aggregate-ID-to-adapter election of the core operations
+    testee.dispatch(PhaseTwoCall
+        .of(operation, "test-module", "TestProcess", "42", null, Map.of("event", "created")));
+
+    assertTrue(dispatched.get() != null);
+    assertTrue(dispatched.get().operation().equals("my-extension:NOTIFY"));
+    assertTrue(dispatched.get().args().get("event").equals("created"));
+
+  }
+
+  @Test
+  @DisplayName("Dispatching an unregistered operation fails guiding and leaves the entry alone")
+  public void dispatchFailsOnUnknownOperation() {
+
+    final var exception = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> testee.dispatch(PhaseTwoCall
+            .forDispatch(
+                "gone-extension:NOTIFY", "test-module", "TestProcess", "42", null, Map.of())));
+
+    // the message has to name the unknown operation, list what IS registered and
+    // say that the entry stays in the store
+    assertTrue(exception.getMessage().contains("gone-extension:NOTIFY"));
+    assertTrue(exception.getMessage().contains("START_WORKFLOW"));
+    assertTrue(exception.getMessage().contains("outbox store"));
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/SendSignalTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/SendSignalTest.java
@@ -1,0 +1,430 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Broadcasting a BPMN signal (story 42). A signal is not addressed to a workflow, so
+ * nothing is probed and no aggregate is touched - what matters is WHO gets it
+ * (every BPMS the workflow module is deployed to) and WHEN (inside the transaction
+ * for an embedded BPMS, after the commit for a remote one).
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SendSignalTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  /**
+   * Records what an adapter was asked to broadcast, and can be made to fail.
+   */
+  static class RecordingAdapter implements MigratableProcessService<Object> {
+
+    private final String adapterId;
+
+    private final boolean twoPhase;
+
+    final List<String> phaseOne = new LinkedList<>();
+
+    final List<String> phaseTwo = new LinkedList<>();
+
+    boolean fail = false;
+
+    RecordingAdapter(
+        final String adapterId,
+        final boolean twoPhase) {
+      this.adapterId = adapterId;
+      this.twoPhase = twoPhase;
+    }
+
+    @Override
+    public String getAdapterId() {
+      return adapterId;
+    }
+
+    @Override
+    public boolean needsTwoPhaseCommitForStartingWorkflows() {
+      return twoPhase;
+    }
+
+    @Override
+    public void sendSignalPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String signalName) {
+      if (fail) {
+        throw new IllegalStateException("BPMS '%s' is unreachable".formatted(adapterId));
+      }
+      phaseOne.add(signalName);
+    }
+
+    @Override
+    public void sendSignalPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String signalName) {
+      phaseTwo.add(signalName);
+    }
+
+    @Override
+    public WorkflowAwareness awarenessOfTask(
+        final Object workflowAggregateId,
+        final String taskId) {
+      return WorkflowAwareness.UNKNOWN_TO_BPMS;
+    }
+
+    @Override
+    public WorkflowAwareness awarenessOfWorkflow(
+        final Object workflowAggregateId) {
+      return WorkflowAwareness.UNKNOWN_TO_BPMS;
+    }
+
+    @Override
+    public WorkflowAwareness awarenessOfUserTask(
+        final Object workflowAggregateId,
+        final String taskId) {
+      return WorkflowAwareness.UNKNOWN_TO_BPMS;
+    }
+
+    @Override
+    public void startWorkflowPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate) {
+    }
+
+    @Override
+    public void startWorkflowPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId) {
+    }
+
+    @Override
+    public void completeTaskPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String taskId) {
+    }
+
+    @Override
+    public void completeTaskPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String taskId) {
+    }
+
+    @Override
+    public void cancelTaskPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String taskId,
+        final String bpmnErrorCode) {
+    }
+
+    @Override
+    public void cancelTaskPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String taskId,
+        final String bpmnErrorCode) {
+    }
+
+    @Override
+    public void completeUserTaskPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String taskId) {
+    }
+
+    @Override
+    public void completeUserTaskPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String taskId) {
+    }
+
+    @Override
+    public void cancelUserTaskPhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String taskId,
+        final String bpmnErrorCode) {
+    }
+
+    @Override
+    public void cancelUserTaskPhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String taskId,
+        final String bpmnErrorCode) {
+    }
+
+    @Override
+    public void correlateMessagePhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String messageName,
+        final String correlationId) {
+    }
+
+    @Override
+    public void correlateMessagePhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String messageName,
+        final String correlationId) {
+    }
+
+    @Override
+    public void startWorkflowByMessagePhaseOne(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregate,
+        final String messageName) {
+    }
+
+    @Override
+    public void startWorkflowByMessagePhaseTwo(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final AggregatePersistenceAware<Object> aggregatePersistence,
+        final Object workflowAggregateId,
+        final String messageName) {
+    }
+
+  }
+
+  static class RecordingOutbox implements PhaseTwoOutbox {
+
+    final List<PhaseTwoCall> scheduled = new LinkedList<>();
+
+    @Override
+    public boolean schedule(
+        final PhaseTwoCall call) {
+      scheduled.add(call);
+      return true;
+    }
+
+  }
+
+  static class PersistenceStub implements AggregatePersistenceAware<Object> {
+
+    @Override
+    public Class<Object> getAggregateClass() {
+      return Object.class;
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+  }
+
+  /**
+   * One workflow module with TWO adapters, but only the first one is prioritized
+   * for this process - the second serves another workflow of the module, which is
+   * exactly what the deployment union covers.
+   */
+  private MigrationAdapterProperties properties() {
+
+    final var otherWorkflow = WorkflowAdapterProperties
+        .builder()
+        .prioritizedAdapters(List.of("second-adapter"))
+        .build();
+    final var workflowModule = WorkflowModuleAdapterProperties
+        .builder()
+        .workflows(Map.of("OtherProcess", otherWorkflow))
+        .build();
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(
+            Map
+                .of(
+                    "first-adapter", AdapterConfigProperties.ofType("dummy"),
+                    "second-adapter", AdapterConfigProperties.ofType("other")))
+        .prioritizedAdapters(List.of("first-adapter"))
+        .workflowModules(Map.of(MODULE, workflowModule))
+        .build();
+    properties.validateAndLink();
+    return properties;
+
+  }
+
+  private MigrationProcessService<Object> processService(
+      final List<MigratableProcessService<Object>> adapters,
+      final PhaseTwoOutbox outbox) {
+
+    io.vanillabp.integration.adapter.migration.processservice.PhaseTwoOutboxResolver resolver = null;
+    if (outbox != null) {
+      resolver = new io.vanillabp.integration.adapter.migration.processservice.PhaseTwoOutboxResolver() {
+
+        @Override
+        public PhaseTwoOutbox resolveFor(
+            final Class<?> workflowAggregateClass) {
+          return outbox;
+        }
+
+        @Override
+        public String remediesDescription() {
+          return "test";
+        }
+
+      };
+    }
+    return new MigrationProcessService<Object>(
+        MODULE, PROCESS, Object.class, properties(), new PersistenceStub(), adapters, resolver);
+
+  }
+
+  @Test
+  @DisplayName("The broadcast reaches every BPMS the workflow module is deployed to")
+  public void everyDeployedBpmsIsReached() {
+
+    final var first = new RecordingAdapter("first-adapter", false);
+    final var second = new RecordingAdapter("second-adapter", false);
+
+    processService(List.of(first, second), null).sendSignal("OrderReceived");
+
+    // the second adapter serves another workflow of the module, not this process -
+    // a broadcast reaching only the elected BPMS would miss the workflows waiting
+    // there
+    assertEquals(List.of("OrderReceived"), first.phaseOne);
+    assertEquals(List.of("OrderReceived"), second.phaseOne);
+
+  }
+
+  @Test
+  @DisplayName("A remote BPMS gets an outbox entry per BPMS, carrying its adapter and no aggregate")
+  public void remoteBpmsBroadcastsAfterTheCommit() {
+
+    final var embedded = new RecordingAdapter("first-adapter", false);
+    final var remote = new RecordingAdapter("second-adapter", true);
+    final var outbox = new RecordingOutbox();
+
+    processService(List.of(embedded, remote), outbox).sendSignal("OrderReceived");
+
+    // the embedded BPMS broadcast inside the transaction, the remote one did not
+    assertEquals(List.of("OrderReceived"), embedded.phaseOne);
+    assertTrue(remote.phaseTwo.isEmpty());
+
+    assertEquals(1, outbox.scheduled.size());
+    final var call = outbox.scheduled.getFirst();
+    assertEquals("SEND_SIGNAL", call.operation());
+    assertEquals("second-adapter", call.adapterId());
+    assertEquals("OrderReceived", call.args().get(PhaseTwoCall.ARG_SIGNAL_NAME));
+    // a broadcast is not about one workflow
+    assertEquals(null, call.workflowAggregateId());
+    // and nothing about it can be deduplicated
+    assertTrue(call.idempotencyKey().isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Phase two broadcasts to the adapter the entry was written for")
+  public void phaseTwoUsesTheRecordedAdapter() {
+
+    final var first = new RecordingAdapter("first-adapter", true);
+    final var second = new RecordingAdapter("second-adapter", true);
+
+    processService(List.of(first, second), new RecordingOutbox())
+        .sendSignalPhaseTwo("OrderReceived", "second-adapter");
+
+    assertTrue(first.phaseTwo.isEmpty());
+    assertEquals(List.of("OrderReceived"), second.phaseTwo);
+
+  }
+
+  @Test
+  @DisplayName("An entry for an adapter which is gone fails guiding")
+  public void phaseTwoForAnUnknownAdapterFailsGuiding() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> processService(List.of(new RecordingAdapter("first-adapter", true)), new RecordingOutbox())
+            .sendSignalPhaseTwo("OrderReceived", "gone-adapter"));
+
+    assertTrue(exception.getMessage().contains("gone-adapter"));
+    assertTrue(exception.getMessage().contains("OrderReceived"));
+    assertTrue(exception.getMessage().contains("outbox store"));
+
+  }
+
+  @Test
+  @DisplayName("One unreachable BPMS does not stop the broadcast to the others")
+  public void oneFailingBpmsDoesNotStopTheOthers() {
+
+    final var failing = new RecordingAdapter("first-adapter", false);
+    failing.fail = true;
+    final var reachable = new RecordingAdapter("second-adapter", false);
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> processService(List.of(failing, reachable), null).sendSignal("OrderReceived"));
+
+    // the failure is reported, but only after every other BPMS was asked
+    assertTrue(exception.getMessage().contains("first-adapter"));
+    assertEquals(List.of("OrderReceived"), reachable.phaseOne);
+
+  }
+
+  @Test
+  @DisplayName("A blank signal name fails naming the process")
+  public void blankSignalNameFails() {
+
+    final var exception = assertThrows(
+        IllegalArgumentException.class,
+        () -> processService(List.of(new RecordingAdapter("first-adapter", false)), null).sendSignal("  "));
+
+    assertTrue(exception.getMessage().contains(PROCESS));
+    assertTrue(exception.getMessage().contains(MODULE));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowend/WorkflowEndedTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowend/WorkflowEndedTest.java
@@ -1,0 +1,436 @@
+package io.vanillabp.migration.test.workflowend;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.WorkflowEnd;
+import io.vanillabp.spi.service.WorkflowEnded;
+
+/**
+ * Telling the application that a workflow ended (story 43): the aggregate is loaded,
+ * the method is called and the aggregate is saved - and everything about it is
+ * optional, so a process without such a method reports nothing and an aggregate
+ * already deleted is not an error.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowEndedTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final Instant END_TIME = Instant.parse("2026-08-13T09:15:00Z");
+
+  public static class Aggregate {
+
+    String id;
+
+    String status;
+
+    String endedAs;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setStatus(
+        final String status) {
+      this.status = status;
+    }
+
+    public void setEndedAs(
+        final String endedAs) {
+      this.endedAs = endedAs;
+    }
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    boolean saved = false;
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      saved = true;
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    boolean requireNewUsed = false;
+
+    boolean inCurrentUsed = false;
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      requireNewUsed = true;
+      return work.get();
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      inCurrentUsed = true;
+      return work.get();
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  static class NoticingService {
+
+    @WorkflowEnded
+    public void ended(
+        final Aggregate aggregate,
+        final WorkflowEnd end) {
+
+      aggregate.setStatus("ended");
+      aggregate.setEndedAs("%s@%s/%s".formatted(end.kind(), end.time(), end.endEventId()));
+
+    }
+
+  }
+
+  static class SilentService {
+
+    // no @WorkflowEnded method: the application does not want to know
+
+  }
+
+  static class PerEndEventService {
+
+    @WorkflowEnded(id = "Event_Approved")
+    public void approved(
+        final Aggregate aggregate) {
+
+      aggregate.setStatus("approved");
+
+    }
+
+  }
+
+  static class TwoMethodsForOneEndService {
+
+    @WorkflowEnded
+    public void first(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowEnded
+    public void second(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  static class ReturningService {
+
+    @WorkflowEnded
+    public String ended(
+        final Aggregate aggregate) {
+
+      return "nope";
+
+    }
+
+  }
+
+  static class UnbindableParameterService {
+
+    @WorkflowEnded
+    public void ended(
+        final Aggregate aggregate,
+        final StringBuilder somethingElse) {
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  private MigrationProcessService<Aggregate> processService() {
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of("test-adapter", AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of("test-adapter"))
+        .build();
+    properties.validateAndLink();
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn("test-adapter");
+
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null);
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final Class<?> workflowServiceClass,
+      final Supplier<Object> bean,
+      final TransactionRunner transactionRunner) {
+
+    final var registry = new WorkflowTaskRegistry(transactionRunner);
+    registry
+        .registerWorkflowService(MODULE, PROCESS, workflowServiceClass, bean, type -> null, processService());
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    aggregate.status = "running";
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  private WorkflowEndedContext context(
+      final String aggregateId,
+      final WorkflowEnd.Kind kind,
+      final String endEventId,
+      final boolean joinTransaction) {
+
+    return new WorkflowEndedContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public WorkflowEnd.Kind getKind() {
+        return kind;
+      }
+
+      @Override
+      public Instant getEndTime() {
+        return END_TIME;
+      }
+
+      @Override
+      public String getEndEventId() {
+        return endEventId;
+      }
+
+      @Override
+      public boolean runInCurrentTransaction() {
+        return joinTransaction;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("The method is called with the aggregate and how the workflow ended, and the aggregate is saved")
+  public void theApplicationIsToldTheEnd() {
+
+    final var transactionRunner = new TransactionRunnerStub();
+    final var testee = registry(NoticingService.class, NoticingService::new, transactionRunner);
+    storeAggregate("4711");
+
+    testee
+        .workflowEnded(
+            MODULE, PROCESS, context("4711", WorkflowEnd.Kind.COMPLETED, "Event_Done", false));
+
+    final var aggregate = persistence.aggregates.get("4711");
+    assertEquals("ended", aggregate.status);
+    assertEquals("COMPLETED@%s/Event_Done".formatted(END_TIME), aggregate.endedAs);
+    assertTrue(persistence.saved, "the aggregate has to be saved - that is what the method changed it for");
+    assertTrue(transactionRunner.requireNewUsed);
+
+  }
+
+  @Test
+  @DisplayName("A notification of an embedded BPMS joins the transaction which ended the workflow")
+  public void embeddedBpmsJoinTheCallersTransaction() {
+
+    final var transactionRunner = new TransactionRunnerStub();
+    final var testee = registry(NoticingService.class, NoticingService::new, transactionRunner);
+    storeAggregate("4712");
+
+    testee
+        .workflowEnded(
+            MODULE, PROCESS, context("4712", WorkflowEnd.Kind.TERMINATED, null, true));
+
+    assertTrue(transactionRunner.inCurrentUsed);
+    assertFalse(transactionRunner.requireNewUsed);
+
+  }
+
+  @Test
+  @DisplayName("Without a method nothing is registered and nothing is reported")
+  public void withoutAMethodNothingHappens() {
+
+    final var testee = registry(SilentService.class, SilentService::new, new TransactionRunnerStub());
+    storeAggregate("4713");
+
+    assertFalse(testee.workflowEndedHandlerExists(MODULE, PROCESS));
+    // an adapter which notifies anyway (a deployed model outliving its workflow
+    // service) must not fail
+    testee
+        .workflowEnded(MODULE, PROCESS, context("4713", WorkflowEnd.Kind.COMPLETED, null, false));
+    assertFalse(persistence.saved);
+
+  }
+
+  @Test
+  @DisplayName("An aggregate which does not exist any more is not an error")
+  public void aDeletedAggregateIsNoError() {
+
+    final var testee = registry(NoticingService.class, NoticingService::new, new TransactionRunnerStub());
+
+    testee
+        .workflowEnded(MODULE, PROCESS, context("gone", WorkflowEnd.Kind.COMPLETED, null, false));
+
+    assertFalse(persistence.saved);
+
+  }
+
+  @Test
+  @DisplayName("A method serving one end event ignores the ends of the others")
+  public void endEventIdIsHonored() {
+
+    final var testee = registry(PerEndEventService.class, PerEndEventService::new, new TransactionRunnerStub());
+    storeAggregate("4714");
+
+    testee
+        .workflowEnded(
+            MODULE, PROCESS, context("4714", WorkflowEnd.Kind.COMPLETED, "Event_Rejected", false));
+    assertEquals("running", persistence.aggregates.get("4714").status);
+
+    testee
+        .workflowEnded(
+            MODULE, PROCESS, context("4714", WorkflowEnd.Kind.COMPLETED, "Event_Approved", false));
+    assertEquals("approved", persistence.aggregates.get("4714").status);
+
+  }
+
+  @Test
+  @DisplayName("Two methods serving the same end are ambiguous and fail at startup")
+  public void twoMethodsForOneEndFail() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> registry(
+            TwoMethodsForOneEndService.class,
+            TwoMethodsForOneEndService::new,
+            new TransactionRunnerStub()));
+
+    assertTrue(exception.getMessage().contains(TwoMethodsForOneEndService.class.getName()));
+    assertTrue(exception.getMessage().contains("every end of the workflow"));
+
+  }
+
+  @Test
+  @DisplayName("A method returning something fails at startup - a workflow which ended cannot be influenced")
+  public void returningMethodFails() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> registry(ReturningService.class, ReturningService::new, new TransactionRunnerStub()));
+
+    assertTrue(exception.getMessage().contains("void"));
+
+  }
+
+  @Test
+  @DisplayName("A parameter which is neither the aggregate nor the end fails at startup")
+  public void unbindableParameterFails() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> registry(
+            UnbindableParameterService.class,
+            UnbindableParameterService::new,
+            new TransactionRunnerStub()));
+
+    assertTrue(exception.getMessage().contains(WorkflowEnd.class.getName()));
+    assertTrue(exception.getMessage().contains(Aggregate.class.getName()));
+
+  }
+
+  @Test
+  @DisplayName("A notification for a process without any workflow service fails guiding")
+  public void unknownProcessFailsGuiding() {
+
+    final var testee = registry(NoticingService.class, NoticingService::new, new TransactionRunnerStub());
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .workflowEnded(
+                MODULE, "OtherProcess", context("4715", WorkflowEnd.Kind.COMPLETED, null, false)));
+
+    assertTrue(exception.getMessage().contains("OtherProcess"));
+    assertNull(persistence.aggregates.get("4715"));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowstart/BpmsInitiatedStartTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowstart/BpmsInitiatedStartTest.java
@@ -1,0 +1,923 @@
+package io.vanillabp.migration.test.workflowstart;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowStartedByBpms;
+
+/**
+ * Unit tests of what a workflow started by the BPMS itself needs: the workflow
+ * aggregate has to come into existence, get an ID, receive the process variables the
+ * model set and - if the application wants a say - pass through a
+ * <code>&#64;WorkflowStartedByBpms</code> method.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class BpmsInitiatedStartTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String TIMER_EVENT = "DailyTimer";
+
+  private static final Instant TRIGGER_TIME = Instant.parse("2026-08-12T04:00:00Z");
+
+  public static class Aggregate {
+
+    String id;
+
+    String region;
+
+    int amount;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(
+        final String id) {
+      this.id = id;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(
+        final String region) {
+      this.region = region;
+    }
+
+    public int getAmount() {
+      return amount;
+    }
+
+    public void setAmount(
+        final int amount) {
+      this.amount = amount;
+    }
+
+  }
+
+  /** An aggregate whose ID is assigned by the persistence layer while saving. */
+  public static class GeneratedIdAggregate {
+
+    Long id;
+
+    public Long getId() {
+      return id;
+    }
+
+  }
+
+  /** An aggregate VanillaBP cannot build on its own. */
+  public static class NoDefaultConstructorAggregate {
+
+    String id;
+
+    public NoDefaultConstructorAggregate(
+        final String id) {
+      this.id = id;
+    }
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    boolean requireNewUsed = false;
+
+    boolean inCurrentUsed = false;
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      requireNewUsed = true;
+      return work.get();
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      inCurrentUsed = true;
+      return work.get();
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  static class InMemoryPersistence<A> implements AggregatePersistenceAware<A> {
+
+    final Map<Object, A> aggregates = new HashMap<>();
+
+    private final Class<A> aggregateClass;
+
+    private final Class<?> idType;
+
+    private final java.util.function.Function<A, Object> idOf;
+
+    private final java.util.function.BiConsumer<A, Object> assignId;
+
+    private final AtomicLong sequence = new AtomicLong();
+
+    InMemoryPersistence(
+        final Class<A> aggregateClass,
+        final Class<?> idType,
+        final java.util.function.Function<A, Object> idOf,
+        final java.util.function.BiConsumer<A, Object> assignId) {
+      this.aggregateClass = aggregateClass;
+      this.idType = idType;
+      this.idOf = idOf;
+      this.assignId = assignId;
+    }
+
+    @Override
+    public Class<A> getAggregateClass() {
+      return aggregateClass;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return idType;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final A aggregate) {
+      return idOf.apply(aggregate);
+    }
+
+    @Override
+    public A save(
+        final A aggregate) {
+      if (idOf.apply(aggregate) == null) {
+        assignId.accept(aggregate, sequence.incrementAndGet());
+      }
+      aggregates.put(idOf.apply(aggregate), aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public A loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  static class SimpleService {
+
+    // no @WorkflowStartedByBpms method at all: VanillaBP builds the aggregate
+
+  }
+
+  static class BuildingService {
+
+    @WorkflowStartedByBpms(id = TIMER_EVENT)
+    public Aggregate build(
+        final BpmsStartTrigger trigger) {
+
+      final var aggregate = new Aggregate();
+      aggregate.setId("settlement-"
+          + trigger.time());
+      aggregate.setRegion("built by "
+          + trigger.kind());
+      return aggregate;
+
+    }
+
+  }
+
+  static class EnrichingService {
+
+    BpmsStartTrigger seenTrigger;
+
+    @WorkflowStartedByBpms
+    public void enrich(
+        final Aggregate aggregate,
+        final BpmsStartTrigger trigger,
+        @TaskParam("region") final String region) {
+
+      seenTrigger = trigger;
+      aggregate.setRegion(region.toUpperCase());
+
+    }
+
+  }
+
+  static class FailingService {
+
+    @WorkflowStartedByBpms
+    public void fail(
+        final Aggregate aggregate) {
+
+      throw new IllegalStateException("no aggregate today");
+
+    }
+
+  }
+
+  static class NullReturningService {
+
+    @WorkflowStartedByBpms
+    public Aggregate build() {
+
+      return null;
+
+    }
+
+  }
+
+  static class TwoMethodsForOneStartEventService {
+
+    @WorkflowStartedByBpms(id = TIMER_EVENT)
+    public void first(
+        final Aggregate aggregate) {
+
+    }
+
+    @WorkflowStartedByBpms(id = TIMER_EVENT)
+    public void second(
+        final Aggregate aggregate) {
+
+    }
+
+  }
+
+  static class WrongReturnTypeService {
+
+    @WorkflowStartedByBpms
+    public String build() {
+
+      return "nope";
+
+    }
+
+  }
+
+  static class UnbindableParameterService {
+
+    @WorkflowStartedByBpms
+    public void build(
+        final Aggregate aggregate,
+        final StringBuilder somethingElse) {
+
+    }
+
+  }
+
+  private <A> MigrationProcessService<A> processService(
+      final AggregatePersistenceAware<A> persistence,
+      final Class<A> aggregateClass) {
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of("test-adapter", AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of("test-adapter"))
+        .build();
+    properties.validateAndLink();
+    final var adapterProcessService = new MigratableProcessService<A>() {
+
+      @Override
+      public String getAdapterId() {
+        return "test-adapter";
+      }
+
+      @Override
+      public WorkflowAwareness awarenessOfTask(
+          final Object workflowAggregateId,
+          final String taskId) {
+        return WorkflowAwareness.UNKNOWN_TO_BPMS;
+      }
+
+      @Override
+      public WorkflowAwareness awarenessOfWorkflow(
+          final Object workflowAggregateId) {
+        return WorkflowAwareness.UNKNOWN_TO_BPMS;
+      }
+
+      @Override
+      public WorkflowAwareness awarenessOfUserTask(
+          final Object workflowAggregateId,
+          final String taskId) {
+        return WorkflowAwareness.UNKNOWN_TO_BPMS;
+      }
+
+      @Override
+      public boolean needsTwoPhaseCommitForStartingWorkflows() {
+        return false;
+      }
+
+      @Override
+      public void startWorkflowPhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate) {
+      }
+
+      @Override
+      public void startWorkflowPhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId) {
+      }
+
+      @Override
+      public void completeTaskPhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String taskId) {
+      }
+
+      @Override
+      public void completeTaskPhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String taskId) {
+      }
+
+      @Override
+      public void cancelTaskPhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String taskId,
+          final String bpmnErrorCode) {
+      }
+
+      @Override
+      public void cancelTaskPhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String taskId,
+          final String bpmnErrorCode) {
+      }
+
+      @Override
+      public void completeUserTaskPhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String taskId) {
+      }
+
+      @Override
+      public void completeUserTaskPhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String taskId) {
+      }
+
+      @Override
+      public void cancelUserTaskPhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String taskId,
+          final String bpmnErrorCode) {
+      }
+
+      @Override
+      public void cancelUserTaskPhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String taskId,
+          final String bpmnErrorCode) {
+      }
+
+      @Override
+      public void correlateMessagePhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String messageName,
+          final String correlationId) {
+      }
+
+      @Override
+      public void correlateMessagePhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String messageName,
+          final String correlationId) {
+      }
+
+      @Override
+      public void startWorkflowByMessagePhaseOne(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final A workflowAggregate,
+          final String messageName) {
+      }
+
+      @Override
+      public void startWorkflowByMessagePhaseTwo(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final AggregatePersistenceAware<A> aggregatePersistence,
+          final Object workflowAggregateId,
+          final String messageName) {
+      }
+
+    };
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, aggregateClass, properties, persistence, List.of(adapterProcessService), null);
+
+  }
+
+  private InMemoryPersistence<Aggregate> stringIdPersistence() {
+
+    return new InMemoryPersistence<>(
+        Aggregate.class, String.class, aggregate -> aggregate.id, (
+            aggregate,
+            id) -> aggregate.id = String.valueOf(id));
+
+  }
+
+  private InMemoryPersistence<GeneratedIdAggregate> generatedIdPersistence() {
+
+    return new InMemoryPersistence<>(
+        GeneratedIdAggregate.class, Long.class, aggregate -> aggregate.id, (
+            aggregate,
+            id) -> aggregate.id = Long.valueOf(String.valueOf(id)));
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final TransactionRunner transactionRunner) {
+
+    return new WorkflowTaskRegistry(transactionRunner);
+
+  }
+
+  private BpmsInitiatedStartContext context(
+      final BpmsStartTrigger.Kind kind,
+      final String startEventId,
+      final Map<String, Object> variables) {
+
+    return new BpmsInitiatedStartContext() {
+
+      @Override
+      public String getStartEventId() {
+        return startEventId;
+      }
+
+      @Override
+      public BpmsStartTrigger.Kind getKind() {
+        return kind;
+      }
+
+      @Override
+      public Instant getTriggerTime() {
+        return TRIGGER_TIME;
+      }
+
+      @Override
+      public String getSignalName() {
+        return kind == BpmsStartTrigger.Kind.SIGNAL
+            ? "OrderReceived"
+            : null;
+      }
+
+      @Override
+      public Map<String, Object> getVariables() {
+        return variables;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("Without any application code the aggregate is built, the timer's time is its ID and the variables land in it")
+  public void aggregateIsBuiltFromTheTrigger() {
+
+    final var persistence = stringIdPersistence();
+    final var transactionRunner = new TransactionRunnerStub();
+    final var testee = registry(transactionRunner);
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, Aggregate.class));
+
+    final var result = testee
+        .startWorkflowByBpms(
+            MODULE,
+            PROCESS,
+            context(
+                BpmsStartTrigger.Kind.TIMER,
+                TIMER_EVENT,
+                Map.of("region", "north", "amount", 42, "unknownToTheAggregate", "ignored")));
+
+    assertTrue(result.created());
+    assertEquals(TRIGGER_TIME.toString(), result.workflowAggregateId());
+    assertEquals("id", result.workflowAggregateIdName());
+    // the ID variable is what a remote BPMS needs to address the workflow later
+    assertEquals(TRIGGER_TIME.toString(), result.variables().get("id"));
+
+    final var aggregate = persistence.aggregates.get(TRIGGER_TIME.toString());
+    assertNotNull(aggregate);
+    assertEquals("north", aggregate.getRegion());
+    // conversion happens on the way in: the model's number becomes the int attribute
+    assertEquals(42, aggregate.getAmount());
+    // a new transaction, since the notification did not ask to join one
+    assertTrue(transactionRunner.requireNewUsed);
+
+  }
+
+  @Test
+  @DisplayName("The same timer time reported twice creates nothing twice")
+  public void repeatedNotificationCreatesNothingTwice() {
+
+    final var persistence = stringIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, Aggregate.class));
+
+    testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of("region", "north")));
+    // business data written after the start must survive a repeated notification
+    persistence.aggregates.get(TRIGGER_TIME.toString()).setRegion("changed meanwhile");
+
+    final var second = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of("region", "north")));
+
+    assertFalse(second.created());
+    assertEquals(TRIGGER_TIME.toString(), second.workflowAggregateId());
+    assertEquals(1, persistence.aggregates.size());
+    assertEquals("changed meanwhile", persistence.aggregates.get(TRIGGER_TIME.toString()).getRegion());
+
+  }
+
+  @Test
+  @DisplayName("A signal start has no natural identity, so its aggregate gets a generated ID")
+  public void signalStartGetsAGeneratedId() {
+
+    final var persistence = stringIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, Aggregate.class));
+
+    final var first = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.SIGNAL, "SignalStart", Map.of()));
+    final var second = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.SIGNAL, "SignalStart", Map.of()));
+
+    // two workflows started by two broadcasts are two workflows
+    assertTrue(first.created());
+    assertTrue(second.created());
+    assertFalse(first.workflowAggregateId().equals(second.workflowAggregateId()));
+    assertFalse(first.workflowAggregateId().equals(TRIGGER_TIME.toString()));
+    assertEquals(2, persistence.aggregates.size());
+
+  }
+
+  @Test
+  @DisplayName("A timer whose aggregate has a numeric ID uses the trigger time as epoch millis")
+  public void numericIdCarriesTheTriggerTime() {
+
+    final var persistence = generatedIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, GeneratedIdAggregate.class));
+
+    final var result = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of()));
+
+    // a numeric ID can carry the trigger time, so the repetition guard works here
+    // as well
+    assertEquals(String.valueOf(TRIGGER_TIME.toEpochMilli()), result.workflowAggregateId());
+    assertFalse(
+        testee
+            .startWorkflowByBpms(
+                MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of()))
+            .created());
+
+  }
+
+  @Test
+  @DisplayName("Without a value to derive from, the persistence layer assigns the ID while saving")
+  public void generatedIdIsTakenFromThePersistence() {
+
+    final var persistence = generatedIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, GeneratedIdAggregate.class));
+
+    // a signal has no natural identity and a numeric ID must not be invented -
+    // saving assigns it, exactly what @GeneratedValue applications rely on
+    final var result = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.SIGNAL, "SignalStart", Map.of()));
+
+    assertTrue(result.created());
+    assertEquals("1", result.workflowAggregateId());
+    assertEquals(1, persistence.aggregates.size());
+
+  }
+
+  @Test
+  @DisplayName("A method returning the aggregate replaces what VanillaBP built")
+  public void buildingMethodWins() {
+
+    final var persistence = stringIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, BuildingService.class, BuildingService::new, type -> null, processService(
+                persistence, Aggregate.class));
+    testee
+        .validateBpmsInitiatedStarts(
+            MODULE,
+            PROCESS,
+            List.of(BpmsInitiatedStartSpec.of(TIMER_EVENT, BpmsStartTrigger.Kind.TIMER)));
+
+    final var result = testee
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of()));
+
+    assertEquals("settlement-"
+        + TRIGGER_TIME, result.workflowAggregateId());
+    assertEquals("built by TIMER", persistence.aggregates.get(result.workflowAggregateId()).getRegion());
+
+  }
+
+  @Test
+  @DisplayName("A void method enriches the aggregate VanillaBP built and sees trigger and variables")
+  public void enrichingMethodSeesTriggerAndVariables() {
+
+    final var persistence = stringIdPersistence();
+    final var service = new EnrichingService();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, EnrichingService.class, () -> service, type -> null, processService(
+                persistence, Aggregate.class));
+
+    final var result = testee
+        .startWorkflowByBpms(
+            MODULE,
+            PROCESS,
+            context(BpmsStartTrigger.Kind.SIGNAL, "SignalStart", Map.of("region", "north")));
+
+    assertEquals("NORTH", persistence.aggregates.get(result.workflowAggregateId()).getRegion());
+    assertEquals(BpmsStartTrigger.Kind.SIGNAL, service.seenTrigger.kind());
+    assertEquals("OrderReceived", service.seenTrigger.signalName());
+    assertEquals("SignalStart", service.seenTrigger.startEventId());
+    assertEquals(TRIGGER_TIME, service.seenTrigger.time());
+
+  }
+
+  @Test
+  @DisplayName("A failing method fails the start - the BPMS retries, no aggregate is left behind")
+  public void failingMethodFailsTheStart() {
+
+    final var persistence = stringIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, FailingService.class, FailingService::new, type -> null, processService(
+                persistence, Aggregate.class));
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .startWorkflowByBpms(
+                MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of())));
+
+    assertEquals("no aggregate today", exception.getMessage());
+    // the transaction stub propagates instead of committing: nothing was saved
+    assertTrue(persistence.aggregates.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("An aggregate without a constructor VanillaBP can use fails guiding")
+  public void missingDefaultConstructorFailsGuiding() {
+
+    final var persistence = new InMemoryPersistence<>(
+        NoDefaultConstructorAggregate.class, String.class, aggregate -> aggregate.id, (
+            aggregate,
+            id) -> aggregate.id = String.valueOf(id));
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, SimpleService.class, SimpleService::new, type -> null, processService(
+                persistence, NoDefaultConstructorAggregate.class));
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .startWorkflowByBpms(
+                MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of())));
+
+    assertTrue(exception.getMessage().contains(NoDefaultConstructorAggregate.class.getName()));
+    assertTrue(exception.getMessage().contains("without arguments"));
+    assertTrue(exception.getMessage().contains("@WorkflowStartedByBpms"));
+
+  }
+
+  @Test
+  @DisplayName("A method for a process the BPMS never starts on its own fails the boot")
+  public void methodWithoutSuchStartEventFailsTheBoot() {
+
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, EnrichingService.class, EnrichingService::new, type -> null, processService(
+                stringIdPersistence(), Aggregate.class));
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee.validateBpmsInitiatedStarts(MODULE, PROCESS, List.of()));
+
+    assertTrue(exception.getMessage().contains(EnrichingService.class.getName()));
+    assertTrue(exception.getMessage().contains(PROCESS));
+    assertTrue(exception.getMessage().contains("startWorkflow"));
+
+  }
+
+  @Test
+  @DisplayName("A method naming a start event the process does not have fails the boot")
+  public void methodNamingAnUnknownStartEventFailsTheBoot() {
+
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, BuildingService.class, BuildingService::new, type -> null, processService(
+                stringIdPersistence(), Aggregate.class));
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .validateBpmsInitiatedStarts(
+                MODULE,
+                PROCESS,
+                List.of(BpmsInitiatedStartSpec.of("AnotherTimer", BpmsStartTrigger.Kind.TIMER))));
+
+    assertTrue(exception.getMessage().contains(TIMER_EVENT));
+    assertTrue(exception.getMessage().contains("AnotherTimer"));
+
+  }
+
+  @Test
+  @DisplayName("A method returning null fails naming the workflow it left without an aggregate")
+  public void nullReturningMethodFailsGuiding() {
+
+    final var persistence = stringIdPersistence();
+    final var testee = registry(new TransactionRunnerStub());
+    testee
+        .registerWorkflowService(
+            MODULE, PROCESS, NullReturningService.class, NullReturningService::new, type -> null, processService(
+                persistence, Aggregate.class));
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .startWorkflowByBpms(
+                MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of())));
+
+    assertTrue(exception.getMessage().contains(NullReturningService.class.getName()));
+    assertTrue(exception.getMessage().contains(PROCESS));
+    assertTrue(persistence.aggregates.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Two methods serving the same start event are ambiguous and fail at startup")
+  public void twoMethodsForOneStartEventFail() {
+
+    final var testee = registry(new TransactionRunnerStub());
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .registerWorkflowService(
+                MODULE,
+                PROCESS,
+                TwoMethodsForOneStartEventService.class,
+                TwoMethodsForOneStartEventService::new,
+                type -> null,
+                processService(stringIdPersistence(), Aggregate.class)));
+
+    assertTrue(exception.getMessage().contains(TIMER_EVENT));
+    assertTrue(exception.getMessage().contains(TwoMethodsForOneStartEventService.class.getName()));
+
+  }
+
+  @Test
+  @DisplayName("A method returning something else than the aggregate fails at startup")
+  public void wrongReturnTypeFailsAtStartup() {
+
+    final var testee = registry(new TransactionRunnerStub());
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .registerWorkflowService(
+                MODULE,
+                PROCESS,
+                WrongReturnTypeService.class,
+                WrongReturnTypeService::new,
+                type -> null,
+                processService(stringIdPersistence(), Aggregate.class)));
+
+    assertTrue(exception.getMessage().contains(Aggregate.class.getName()));
+    assertTrue(exception.getMessage().contains("java.lang.String"));
+
+  }
+
+  @Test
+  @DisplayName("A parameter which is neither the aggregate, the trigger nor a variable fails at startup")
+  public void unbindableParameterFailsAtStartup() {
+
+    final var testee = registry(new TransactionRunnerStub());
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee
+            .registerWorkflowService(
+                MODULE,
+                PROCESS,
+                UnbindableParameterService.class,
+                UnbindableParameterService::new,
+                type -> null,
+                processService(stringIdPersistence(), Aggregate.class)));
+
+    assertTrue(exception.getMessage().contains("@TaskParam"));
+    assertTrue(exception.getMessage().contains(BpmsStartTrigger.class.getName()));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/ProcessVersionMatchingTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/ProcessVersionMatchingTest.java
@@ -1,0 +1,831 @@
+package io.vanillabp.migration.test.workflowtask;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions;
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.version.CachingProcessVersionCatalog;
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.WorkflowEnded;
+import io.vanillabp.spi.service.WorkflowStartedByBpms;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * Story 48: what the <code>version</code> attribute of <code>&#64;WorkflowTask</code>,
+ * <code>&#64;WorkflowStartedByBpms</code> and <code>&#64;WorkflowEnded</code> means.
+ * <p>
+ * Two things are tested here: version ranges pick the method serving a process version
+ * (numbers straight away, version tags through the catalog the adapter registered,
+ * including the BPMS query for a version deployed by ANOTHER cluster node), and two
+ * methods wired to one BPMN element are ambiguous exactly when their ranges overlap.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ProcessVersionMatchingTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String ADAPTER = "test-adapter";
+
+  public static class Aggregate {
+
+    String id;
+
+    String servedBy;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  /**
+   * A BPMS answering what it was told to answer, counting how often it was asked - the
+   * BPMS query behind {@link CachingProcessVersionCatalog} must not run per task
+   * delivery, and it HAS to run once when a version shows up this node never deployed.
+   */
+  static class RecordingCatalog extends CachingProcessVersionCatalog {
+
+    final List<DeployedProcessVersion> versions = new ArrayList<>();
+
+    int fetches = 0;
+
+    RecordingCatalog() {
+
+      // no floor between two queries: the test wants the on-demand query to happen
+      super(Duration.ZERO);
+
+    }
+
+    @Override
+    protected List<DeployedProcessVersion> fetchDeployedVersions(
+        final String workflowModuleId,
+        final String bpmnProcessId) {
+
+      fetches++;
+      return List.copyOf(versions);
+
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  private MigrationProcessService<Aggregate> processService() {
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of(ADAPTER))
+        .build();
+    properties.validateAndLink();
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn(ADAPTER);
+
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null);
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final Class<?> workflowServiceClass,
+      final Supplier<Object> bean) {
+
+    final var registry = new WorkflowTaskRegistry(new TransactionRunnerStub());
+    registry
+        .registerWorkflowService(MODULE, PROCESS, workflowServiceClass, bean, type -> null, processService());
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  /**
+   * The messages a logger emitted while the given work ran - the guiding messages of
+   * this story are WARNings, and "normal" logging is switched off during tests.
+   */
+  private List<String> loggedBy(
+      final Class<?> loggingClass,
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggingClass);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAndStopAllAppenders();
+    }
+    return logWatcher.list
+        .stream()
+        .map(event -> event.getFormattedMessage())
+        .toList();
+
+  }
+
+  private TaskInvocationContext taskContext(
+      final String aggregateId,
+      final String processVersion) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return "task";
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getProcessVersion() {
+        return processVersion;
+      }
+
+    };
+
+  }
+
+  @Nested
+  @DisplayName("Overlapping version ranges")
+  class Overlaps {
+
+    private boolean overlaps(
+        final String one,
+        final String other) {
+
+      return VersionRange
+          .parse(one, "test")
+          .overlaps(VersionRange.parse(other, "test"));
+
+    }
+
+    @Test
+    @DisplayName("Ranges made of numbers are placed without asking a BPMS")
+    public void numericRanges() {
+
+      assertTrue(overlaps("*", "3"), "'*' covers every version");
+      assertTrue(overlaps("2", "1-3"), "'2' sits inside '1-3'");
+      assertTrue(overlaps("1-3", "2"), "and the other way round");
+      assertTrue(overlaps("1-3", "3-5"), "the boundaries are included");
+      assertTrue(overlaps("1-3", "<4"), "'<4' covers 1 to 3");
+      assertTrue(overlaps(">2", ">5"), "both are open ended upwards");
+      assertTrue(overlaps("2", "2"), "the same specification twice");
+
+      assertFalse(overlaps("1-2", ">2"), "disjoint - serving two versions of a process");
+      assertFalse(overlaps("<2", "2"), "'<2' excludes its boundary");
+      assertFalse(overlaps(">2", "2"), "'>2' excludes its boundary");
+      assertFalse(overlaps("1-2", "3-4"), "next to each other, not overlapping");
+      assertFalse(overlaps("<2", ">2"), "everything but version 2");
+
+      // version 1's README documented '>=' and '<=' although nothing implemented them
+      assertTrue(overlaps(">=2", "2"), "'>=2' includes its boundary");
+      assertTrue(overlaps("<=2", "2"), "'<=2' includes its boundary");
+      assertFalse(overlaps("<=1", ">=2"), "adjacent, both inclusive");
+
+    }
+
+    @Test
+    @DisplayName("Without a BPMS only identical version tags are known to overlap")
+    public void tagsWithoutCatalog() {
+
+      assertTrue(overlaps("release-2024", "release-2024"), "written identically");
+      assertTrue(overlaps("*", "release-2024"), "'*' covers every version, tagged or not");
+      assertFalse(overlaps("release-2024", "release-2025"), "not comparable without a BPMS");
+      assertFalse(overlaps(">release-2024", "1-3"), "not comparable without a BPMS");
+
+    }
+
+    @Test
+    @DisplayName("Once the BPMS placed the tags, ranges naming them are compared like numbers")
+    public void tagsWithCatalog() {
+
+      final var catalog = new RecordingCatalog();
+      catalog.versions.add(DeployedProcessVersion.of("1", "v1.0"));
+      catalog.versions.add(DeployedProcessVersion.of("2", "v2.0"));
+      catalog.versions.add(DeployedProcessVersion.of("3", "v3.0"));
+      final VersionRange.ProcessVersionResolver resolver = versionOrTag -> catalog
+          .resolveVersion(MODULE, PROCESS, versionOrTag);
+
+      assertTrue(
+          VersionRange.parse("v1.0..v2.0", "test").overlaps(VersionRange.parse("2", "test"), resolver),
+          "version 2 carries tag 'v2.0'");
+      assertFalse(
+          VersionRange.parse("v1.0..v2.0", "test").overlaps(VersionRange.parse(">v2.0", "test"), resolver),
+          "the tagged range ends where the other one starts");
+      assertTrue(
+          VersionRange.parse(">v1.0", "test").overlaps(VersionRange.parse("2-3", "test"), resolver),
+          "'>v1.0' means versions 2 and up");
+      assertFalse(
+          VersionRange.parse("v1.0", "test").overlaps(VersionRange.parse("v2.0", "test"), resolver),
+          "two different tags of two different versions");
+
+    }
+
+  }
+
+  static class TwoMethodsOneTaskService {
+
+    @WorkflowTask(taskDefinition = "task", version = "1-3")
+    public void old(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowTask(taskDefinition = "task", version = "2")
+    public void newer(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  static class DisjointVersionsService {
+
+    @WorkflowTask(taskDefinition = "task", version = "1-2")
+    public void upToTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "upToTwo";
+
+    }
+
+    @WorkflowTask(taskDefinition = "task", version = ">2")
+    public void afterTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "afterTwo";
+
+    }
+
+  }
+
+  static class TaggedVersionsService {
+
+    @WorkflowTask(taskDefinition = "task", version = "release-2024")
+    public void tagged(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "tagged";
+
+    }
+
+    @WorkflowTask(taskDefinition = "task", version = ">release-2024")
+    public void afterTheTag(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "afterTheTag";
+
+    }
+
+  }
+
+  static class OverlappingTagsService {
+
+    @WorkflowTask(taskDefinition = "task", version = "v1.0..v3.0")
+    public void wide(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowTask(taskDefinition = "task", version = "v2.0")
+    public void narrow(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  static class UnknownTagService {
+
+    @WorkflowTask(taskDefinition = "task", version = "does-not-exist")
+    public void nobody(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  @Test
+  @DisplayName("Two methods of ONE class wired to one task definition fail if their ranges overlap")
+  public void twoMethodsOfOneClassAreCompared() {
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> registry(TwoMethodsOneTaskService.class, TwoMethodsOneTaskService::new));
+
+    assertTrue(exception.getMessage().contains("old"));
+    assertTrue(exception.getMessage().contains("newer"));
+    assertTrue(exception.getMessage().contains("version"));
+
+  }
+
+  @Test
+  @DisplayName("An inclusive boundary is honored, as version 1's documentation promised")
+  public void inclusiveBoundaries() {
+
+    assertTrue(VersionRange.parse(">=2", "test").matches("2"));
+    assertTrue(VersionRange.parse(">=2", "test").matches("3"));
+    assertFalse(VersionRange.parse(">=2", "test").matches("1"));
+    assertTrue(VersionRange.parse("<=2", "test").matches("2"));
+    assertFalse(VersionRange.parse("<=2", "test").matches("3"));
+
+  }
+
+  @Test
+  @DisplayName("Disjoint ranges register and the version decides which method runs")
+  public void disjointRangesServeTheirVersions() {
+
+    final var testee = registry(DisjointVersionsService.class, DisjointVersionsService::new);
+    storeAggregate("4711");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "2"));
+    assertEquals("upToTwo", persistence.aggregates.get("4711").servedBy);
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "3"));
+    assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy);
+
+    // a BPMS which cannot report a version is served by the first method - the
+    // compatible behavior every application not using the attribute relies on
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", null));
+    assertEquals("upToTwo", persistence.aggregates.get("4711").servedBy);
+
+  }
+
+  @Test
+  @DisplayName("A version tag names the version carrying it, resolved through the adapter's catalog")
+  public void versionTagsAreResolvedByTheBpms() {
+
+    final var testee = registry(TaggedVersionsService.class, TaggedVersionsService::new);
+    final var catalog = new RecordingCatalog();
+    catalog.versions.add(DeployedProcessVersion.of("1", null));
+    catalog.versions.add(DeployedProcessVersion.of("2", "release-2024"));
+    testee.registerProcessVersions(ADAPTER, MODULE, PROCESS, catalog);
+    testee.resolveProcessVersions(MODULE);
+    storeAggregate("4711");
+
+    // the startup resolution asked the BPMS - a task delivery does not ask again
+    assertEquals(1, catalog.fetches);
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "2"));
+    assertEquals("tagged", persistence.aggregates.get("4711").servedBy);
+    assertEquals(1, catalog.fetches);
+
+    // ANOTHER cluster node deployed version 3 while this one is running: the version
+    // is unknown here, so the BPMS is asked on demand
+    catalog.versions.add(DeployedProcessVersion.of("3", "release-2025"));
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "3"));
+    assertEquals("afterTheTag", persistence.aggregates.get("4711").servedBy);
+    assertTrue(catalog.fetches > 1, "the version deployed elsewhere was looked up on demand");
+
+  }
+
+  @Test
+  @DisplayName("Ranges naming a tag are checked for overlaps once the BPMS placed them")
+  public void overlappingTagRangesFailAfterTheDeployment() {
+
+    // registering cannot decide it: no BPMS was asked at that point
+    final var testee = registry(OverlappingTagsService.class, OverlappingTagsService::new);
+    final var catalog = new RecordingCatalog();
+    catalog.versions.add(DeployedProcessVersion.of("1", "v1.0"));
+    catalog.versions.add(DeployedProcessVersion.of("2", "v2.0"));
+    catalog.versions.add(DeployedProcessVersion.of("3", "v3.0"));
+    testee.registerProcessVersions(ADAPTER, MODULE, PROCESS, catalog);
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee.resolveProcessVersions(MODULE));
+
+    assertTrue(exception.getMessage().contains("wide"));
+    assertTrue(exception.getMessage().contains("narrow"));
+
+  }
+
+  @Test
+  @DisplayName("A version tag no BPMS knows is reported at startup and serves nothing")
+  public void unknownVersionTagIsReported() {
+
+    final var testee = registry(UnknownTagService.class, UnknownTagService::new);
+    final var catalog = new RecordingCatalog();
+    catalog.versions.add(DeployedProcessVersion.of("1", "v1.0"));
+    testee.registerProcessVersions(ADAPTER, MODULE, PROCESS, catalog);
+    final var messages = loggedBy(ProcessVersions.class, () -> testee.resolveProcessVersions(MODULE));
+    storeAggregate("4711");
+
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("does-not-exist")),
+        messages.toString());
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("versionTag")),
+        "the message names where a tag comes from");
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "1")));
+    assertTrue(exception.getMessage().contains("process version '1'"));
+
+  }
+
+  static class TwoStartsOneEventService {
+
+    @WorkflowStartedByBpms(version = "1-3")
+    public void old(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowStartedByBpms(version = "2")
+    public void newer(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  static class VersionedStartsService {
+
+    @WorkflowStartedByBpms(version = "1-2")
+    public void upToTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "upToTwo";
+
+    }
+
+    @WorkflowStartedByBpms(version = ">2")
+    public void afterTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "afterTwo";
+
+    }
+
+  }
+
+  static class TwoEndedOneEventService {
+
+    @WorkflowEnded(version = "1-3")
+    public void old(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowEnded(version = "2")
+    public void newer(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  static class VersionedEndedService {
+
+    @WorkflowEnded(version = "1-2")
+    public void upToTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "upToTwo";
+
+    }
+
+    @WorkflowEnded(version = ">2")
+    public void afterTwo(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "afterTwo";
+
+    }
+
+  }
+
+  private BpmsInitiatedStartContext startContext(
+      final String naturalIdentity,
+      final String processVersion) {
+
+    return new BpmsInitiatedStartContext() {
+
+      @Override
+      public String getStartEventId() {
+        return "StartEvent_Timer";
+      }
+
+      @Override
+      public BpmsStartTrigger.Kind getKind() {
+        return BpmsStartTrigger.Kind.TIMER;
+      }
+
+      @Override
+      public Instant getTriggerTime() {
+        return Instant.parse("2026-08-13T09:15:00Z");
+      }
+
+      @Override
+      public String getNaturalIdentity() {
+        return naturalIdentity;
+      }
+
+      @Override
+      public String getProcessVersion() {
+        return processVersion;
+      }
+
+    };
+
+  }
+
+  private WorkflowEndedContext endedContext(
+      final String processVersion) {
+
+    return new WorkflowEndedContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return "4711";
+      }
+
+      @Override
+      public Instant getEndTime() {
+        return Instant.parse("2026-08-13T09:15:00Z");
+      }
+
+      @Override
+      public io.vanillabp.spi.service.WorkflowEnd.Kind getKind() {
+        return io.vanillabp.spi.service.WorkflowEnd.Kind.COMPLETED;
+      }
+
+      @Override
+      public String getProcessVersion() {
+        return processVersion;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("The same rules hold for @WorkflowStartedByBpms")
+  public void bpmsInitiatedStartsAreVersioned() {
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> registry(TwoStartsOneEventService.class, TwoStartsOneEventService::new),
+        "overlapping ranges of two methods of one class");
+
+    final var testee = registry(VersionedStartsService.class, VersionedStartsService::new);
+
+    testee.startWorkflowByBpms(MODULE, PROCESS, startContext("4711", "2"));
+    assertEquals("upToTwo", persistence.aggregates.get("4711").servedBy);
+
+    // another workflow: a start reporting an identity known already reuses its
+    // aggregate and calls no method at all
+    testee.startWorkflowByBpms(MODULE, PROCESS, startContext("4712", "3"));
+    assertEquals("afterTwo", persistence.aggregates.get("4712").servedBy);
+
+  }
+
+  @Test
+  @DisplayName("The same rules hold for @WorkflowEnded")
+  public void workflowEndedIsVersioned() {
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> registry(TwoEndedOneEventService.class, TwoEndedOneEventService::new),
+        "overlapping ranges of two methods of one class");
+
+    final var testee = registry(VersionedEndedService.class, VersionedEndedService::new);
+    storeAggregate("4711");
+
+    testee.workflowEnded(MODULE, PROCESS, endedContext("2"));
+    assertEquals("upToTwo", persistence.aggregates.get("4711").servedBy);
+
+    testee.workflowEnded(MODULE, PROCESS, endedContext("3"));
+    assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy);
+
+  }
+
+  @Test
+  @DisplayName("Without any catalog a version tag is reported once, naming what a BPMS would have to do")
+  public void withoutCatalogTagsAreReportedOnce() {
+
+    final var testee = registry(UnknownTagService.class, UnknownTagService::new);
+    storeAggregate("4711");
+
+    final var messages = loggedBy(ProcessVersions.class, () -> {
+      assertThrows(
+          IllegalStateException.class,
+          () -> testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "1")));
+      assertThrows(
+          IllegalStateException.class,
+          () -> testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "1")));
+    });
+
+    assertEquals(
+        1,
+        messages
+            .stream()
+            .filter(message -> message.contains("no BPMS of this application reports"))
+            .count(),
+        "the same unknown version is reported once, not per task");
+
+  }
+
+  @Test
+  @DisplayName("Deploy results feed the catalog, so the version deployed now needs no query")
+  public void recordedVersionsAvoidQueries() {
+
+    final var catalog = new RecordingCatalog();
+    catalog.record(MODULE, PROCESS, DeployedProcessVersion.of("7", "release-2026"));
+
+    final var resolved = catalog.resolveVersion(MODULE, PROCESS, "release-2026");
+    assertEquals("7", resolved.version());
+    assertEquals(0, catalog.fetches, "what the deploy command reported is known already");
+
+    // an unknown version is looked up, and what was recorded survives the lookup
+    catalog.versions.add(DeployedProcessVersion.of("6", "release-2025"));
+    assertEquals("6", catalog.resolveVersion(MODULE, PROCESS, "6").version());
+    assertEquals(1, catalog.fetches);
+    assertEquals("7", catalog.resolveVersion(MODULE, PROCESS, "release-2026").version());
+
+  }
+
+  @Test
+  @DisplayName("A version never seen is looked up at once, a value which stays unknown only once per interval")
+  public void theQueryFloorIsPerValue() {
+
+    final var queries = new java.util.concurrent.atomic.AtomicInteger();
+    final var versions = new ArrayList<DeployedProcessVersion>();
+    versions.add(DeployedProcessVersion.of("1", "v1.0"));
+    final var catalog = new CachingProcessVersionCatalog(Duration.ofHours(1)) {
+
+      @Override
+      protected List<DeployedProcessVersion> fetchDeployedVersions(
+          final String workflowModuleId,
+          final String bpmnProcessId) {
+
+        queries.incrementAndGet();
+        return List.copyOf(versions);
+
+      }
+
+    };
+
+    assertEquals("1", catalog.resolveVersion(MODULE, PROCESS, "v1.0").version());
+    assertEquals(1, queries.get());
+
+    // a tag which does not exist: asked once, then held back by the interval
+    assertNull(catalog.resolveVersion(MODULE, PROCESS, "does-not-exist"));
+    assertNull(catalog.resolveVersion(MODULE, PROCESS, "does-not-exist"));
+    assertEquals(2, queries.get());
+
+    // a version another node deployed meanwhile: looked up right away, although the
+    // interval of the unknown tag has not passed
+    versions.add(DeployedProcessVersion.of("2", "v2.0"));
+    assertEquals("2", catalog.resolveVersion(MODULE, PROCESS, "2").version());
+    assertEquals(3, queries.get());
+
+  }
+
+  @Test
+  @DisplayName("A BPMS query failing leaves the version unknown instead of failing the task")
+  public void failingQueryIsSurvived() {
+
+    final var catalog = new CachingProcessVersionCatalog(Duration.ZERO) {
+
+      @Override
+      protected List<DeployedProcessVersion> fetchDeployedVersions(
+          final String workflowModuleId,
+          final String bpmnProcessId) {
+
+        throw new IllegalStateException("BPMS not reachable");
+
+      }
+
+    };
+
+    final var messages = loggedBy(CachingProcessVersionCatalog.class, () -> {
+      assertEquals(List.of(), catalog.deployedVersionsOf(MODULE, PROCESS));
+      assertNull(catalog.resolveVersion(MODULE, PROCESS, "v1.0"));
+    });
+
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("Could not determine the deployed versions")),
+        messages.toString());
+
+  }
+
+  @Test
+  @DisplayName("Versions ordered by deployment time serve ranges of a BPMS not counting upwards")
+  public void deploymentTimeOrdersNonNumericVersions() {
+
+    final var catalog = new RecordingCatalog();
+    catalog.versions
+        .add(new DeployedProcessVersion("a4c1", "v1.0", Instant.parse("2026-01-01T00:00:00Z")));
+    catalog.versions
+        .add(new DeployedProcessVersion("b7f2", "v2.0", Instant.parse("2026-06-01T00:00:00Z")));
+    final VersionRange.ProcessVersionResolver resolver = versionOrTag -> catalog
+        .resolveVersion(MODULE, PROCESS, versionOrTag);
+
+    assertTrue(VersionRange.parse(">v1.0", "test").matches("b7f2", resolver));
+    assertFalse(VersionRange.parse(">v2.0", "test").matches("b7f2", resolver));
+    assertTrue(VersionRange.parse("v1.0..v2.0", "test").matches("a4c1", resolver));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -1058,6 +1058,23 @@ public class WorkflowTaskRegistryTest {
   }
 
   @Test
+  @DisplayName("An attribute is reported from the CLASS, without loading an aggregate")
+  public void aggregatePropertyExistence() {
+
+    // what an embedded BPMS asks while resolving an expression: is this name an
+    // attribute of the workflow aggregate, or does it mean something else entirely?
+    assertTrue(registry.workflowAggregateHasProperty(MODULE, PROCESS, "processedBy"));
+    assertTrue(registry.workflowAggregateHasProperty(MODULE, PROCESS, "index"));
+
+    assertFalse(registry.workflowAggregateHasProperty(MODULE, PROCESS, "noSuchProperty"));
+    assertFalse(registry.workflowAggregateHasProperty(MODULE, "NoSuchProcess", "processedBy"));
+
+    // no aggregate has to exist for the answer - the ID never enters the question
+    assertTrue(persistence.aggregates.containsKey("4711"));
+
+  }
+
+  @Test
   @DisplayName("Aggregate attributes resolve via field access - null for unknowns")
   public void aggregatePropertyResolution() {
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -1341,7 +1341,7 @@ public class WorkflowTaskRegistryTest {
 
     class BadVersionService {
 
-      @WorkflowTask(version = "latest")
+      @WorkflowTask(version = ">")
       public void badVersion(
           final Aggregate aggregate) {
       }
@@ -1358,8 +1358,53 @@ public class WorkflowTaskRegistryTest {
             beans::get,
             createProcessService()));
 
-    assertTrue(exception.getMessage().contains("latest"));
     assertTrue(exception.getMessage().contains("Supported formats"));
+
+    class BlankVersionService {
+
+      @WorkflowTask(version = "1 - 3")
+      public void blankVersion(
+          final Aggregate aggregate) {
+      }
+
+    }
+
+    final var blank = assertThrows(
+        IllegalStateException.class,
+        () -> registry.registerWorkflowService(
+            MODULE,
+            "BlankVersionProcess",
+            BlankVersionService.class,
+            BlankVersionService::new,
+            beans::get,
+            createProcessService()));
+
+    assertTrue(blank.getMessage().contains("blank"));
+
+  }
+
+  @Test
+  @DisplayName("A non-numeric version specification is a version tag, not a defect")
+  public void versionTagSpecIsAccepted() {
+
+    class TaggedService {
+
+      @WorkflowTask(taskDefinition = "tagged", version = "release-2024")
+      public void tagged(
+          final Aggregate aggregate) {
+      }
+
+    }
+
+    // a version tag cannot be validated at registration time: no BPMS was asked yet,
+    // and the tagged version may even be deployed by this very boot
+    registry.registerWorkflowService(
+        MODULE,
+        "TaggedProcess",
+        TaggedService.class,
+        TaggedService::new,
+        beans::get,
+        createProcessService());
 
   }
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
@@ -519,10 +519,16 @@ public interface MigratableProcessService<A> {
    * <p>
    * WHICH values are pushed is not decided here: it is the sync model of the
    * aggregate, the same one a task completion uses. WHERE they land is: without a
-   * task ID they belong to the workflow's global scope, with one to the scope of
-   * that task instance - which is what multi-instance needs, where a global write
-   * would be a lost update between sibling instances. A task-scoped write must NOT
-   * additionally touch the global scope.
+   * task ID they belong to the workflow's global scope, with one to the scope the
+   * task RUNS IN - the process, an embedded subprocess, or the one iteration of a
+   * multi-instance embedded subprocess. That is what multi-instance work needs,
+   * where a global write would be a lost update between the iterations.
+   * <p>
+   * The task's OWN scope is not meant, and adapters have to go around it: engines
+   * give a task a scope of its own where the model asks for one (a boundary event,
+   * an instance of a multi-instance activity), and values written there serve that
+   * one activity and vanish with it. A task-scoped write must NOT additionally touch
+   * the global scope either.
    * <p>
    * The default throws: an adapter whose BPMS cannot update a running instance says
    * so instead of pretending the push happened.

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
@@ -510,6 +510,83 @@ public interface MigratableProcessService<A> {
 
   }
 
+  /**
+   * Push the values shared with the BPMS ({@code @SyncWithBPMS}) of a changed
+   * workflow-aggregate - phase one, executed inside the caller's transaction AFTER
+   * the adapter answered {@link WorkflowAwareness#ACTIVE} for the workflow. An
+   * EMBEDDED BPMS writes here (a rollback takes the write with it), a remote BPMS
+   * does nothing and writes in {@link #aggregateChangedPhaseTwo} after the commit.
+   * <p>
+   * WHICH values are pushed is not decided here: it is the sync model of the
+   * aggregate, the same one a task completion uses. WHERE they land is: without a
+   * task ID they belong to the workflow's global scope, with one to the scope of
+   * that task instance - which is what multi-instance needs, where a global write
+   * would be a lost update between sibling instances. A task-scoped write must NOT
+   * additionally touch the global scope.
+   * <p>
+   * The default throws: an adapter whose BPMS cannot update a running instance says
+   * so instead of pretending the push happened.
+   *
+   * @param workflowModuleId The ID of the workflow module the workflow belongs to
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param aggregatePersistence The persistence of the workflow-aggregate
+   * @param workflowAggregate The workflow-aggregate
+   * @param taskId The ID of the task whose scope receives the values, or
+   *        <code>null</code> for the workflow's global scope
+   */
+  default void aggregateChangedPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final A workflowAggregate,
+      final String taskId) {
+
+    throw aggregateChangedNotSupported(workflowModuleId, bpmnProcessId);
+
+  }
+
+  /**
+   * Push the values of a changed workflow-aggregate - phase two, dispatched through
+   * the outbox after the local transaction was committed. Only called for adapters
+   * requiring a two-phase commit.
+   * <p>
+   * <strong>Idempotency contract:</strong> none is needed. The adapter reads the
+   * values from the aggregate as it is NOW, so a redelivered entry writes the
+   * then-current state - which is what the application asked for either way. A
+   * workflow gone by dispatch time is tolerated (logged) like everywhere else.
+   *
+   * @param workflowModuleId The ID of the workflow module the workflow belongs to
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param aggregatePersistence The persistence of the workflow-aggregate
+   * @param workflowAggregateId The ID of the workflow aggregate
+   * @param taskId The ID of the task whose scope receives the values, or
+   *        <code>null</code> for the workflow's global scope
+   */
+  default void aggregateChangedPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    throw aggregateChangedNotSupported(workflowModuleId, bpmnProcessId);
+
+  }
+
+  private UnsupportedOperationException aggregateChangedNotSupported(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return new UnsupportedOperationException(
+        ("The VanillaBP adapter '%s' cannot push a changed workflow-aggregate of BPMN process '%s' "
+            + "(workflow module '%s') to its BPMS: the BPMS cannot update a running instance, or "
+            + "the adapter predates aggregateChanged. Remove the adapter from the prioritized "
+            + "adapters of this workflow module, or model a task the workflow waits at - completing "
+            + "it pushes the aggregate as well.")
+            .formatted(getAdapterId(), bpmnProcessId, workflowModuleId));
+
+  }
+
   private UnsupportedOperationException signalsNotSupported(
       final String signalName,
       final String workflowModuleId) {

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
@@ -462,6 +462,68 @@ public interface MigratableProcessService<A> {
       String messageName);
 
   /**
+   * Broadcast a BPMN signal - phase one, executed inside the caller's transaction.
+   * A signal is not addressed to a workflow, so nothing is probed and no aggregate
+   * is involved: an EMBEDDED BPMS broadcasts here (a rollback takes the broadcast
+   * with it), a remote BPMS does nothing and broadcasts in
+   * {@link #sendSignalPhaseTwo} after the commit.
+   * <p>
+   * The signal name arrives as the application modelled it; scoping identifiers is
+   * the adapter's business (see
+   * {@link io.vanillabp.integration.adapter.spi.NameClashAvoidanceSupport}).
+   * <p>
+   * The default throws: an adapter whose BPMS has no signals says so instead of
+   * silently swallowing a broadcast.
+   *
+   * @param workflowModuleId The ID of the workflow module the signal belongs to
+   * @param bpmnProcessId The BPMN process ID whose process service was called
+   * @param signalName The PLAIN BPMN signal name
+   */
+  default void sendSignalPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    throw signalsNotSupported(signalName, workflowModuleId);
+
+  }
+
+  /**
+   * Broadcast a BPMN signal - phase two, dispatched through the outbox after the
+   * local transaction was committed. Only called for adapters requiring a two-phase
+   * commit; embedded BPMS broadcast in phase one already.
+   * <p>
+   * <strong>Idempotency contract:</strong> there is NONE. A signal carries no key a
+   * BPMS could deduplicate by, so a redelivered entry broadcasts a second time -
+   * documented, and the reason a signal is a poor fit for exactly-once thinking.
+   *
+   * @param workflowModuleId The ID of the workflow module the signal belongs to
+   * @param bpmnProcessId The BPMN process ID whose process service was called
+   * @param signalName The PLAIN BPMN signal name
+   */
+  default void sendSignalPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    throw signalsNotSupported(signalName, workflowModuleId);
+
+  }
+
+  private UnsupportedOperationException signalsNotSupported(
+      final String signalName,
+      final String workflowModuleId) {
+
+    return new UnsupportedOperationException(
+        ("The VanillaBP adapter '%s' cannot broadcast the signal '%s' of workflow module '%s': its "
+            + "BPMS has no signals, or the adapter predates them. Remove the adapter from the "
+            + "prioritized adapters of this workflow module, or replace the signal by a message "
+            + "correlated to the workflow which waits for it.")
+            .formatted(getAdapterId(), signalName, workflowModuleId));
+
+  }
+
+  /**
    * The viewer/history API - read-only, no phases: the adapter holding the
    * workflow (elected by probing {@link #awarenessOfWorkflow(Object)}) answers.
    * <p>

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/CachingProcessVersionCatalog.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/CachingProcessVersionCatalog.java
@@ -1,0 +1,240 @@
+package io.vanillabp.integration.adapter.spi.version;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The bookkeeping every {@link ProcessVersionCatalog} needs, so an adapter only has to
+ * answer "which versions of this process does the BPMS have right now" - see
+ * {@link #fetchDeployedVersions(String, String)}.
+ * <p>
+ * What is kept here:
+ * <ul>
+ * <li>the versions learned from a BPMS query and the versions the adapter
+ * {@link #record(String, String, DeployedProcessVersion) recorded} from the result of
+ * its deploy command - the deploy command names the version the BPMS assigned to the
+ * model deployed right now, which the query would have to be asked for otherwise;</li>
+ * <li>the on-demand query for a version identifier not seen yet: during a rolling
+ * deployment another cluster node may deploy a new version before this node does, and
+ * the BPMS delivers a task of that version to this node meanwhile;</li>
+ * <li>a floor between two queries for the SAME unknown value
+ * ({@value #DEFAULT_REFRESH_INTERVAL_SECONDS} seconds by default), so a version
+ * specification naming a tag which does not exist cannot turn every task delivery into a
+ * BPMS query, while a version showing up for the first time is looked up right away.</li>
+ * </ul>
+ * A query failing is not an error of the running workflow: it is logged and the version
+ * stays unknown, which lets the version specifications made of numbers keep working.
+ */
+public abstract class CachingProcessVersionCatalog implements ProcessVersionCatalog {
+
+  private static final Logger log = LoggerFactory.getLogger(CachingProcessVersionCatalog.class);
+
+  /**
+   * How long a version identifier or tag stays unknown before the BPMS is asked about
+   * it again.
+   */
+  public static final int DEFAULT_REFRESH_INTERVAL_SECONDS = 60;
+
+  private static class Versions {
+
+    /**
+     * By version identifier, in deployment order (oldest first).
+     */
+    private final Map<String, DeployedProcessVersion> byVersion = new LinkedHashMap<>();
+
+    /**
+     * By version tag - the NEWEST version carrying it, since a tag may be reused by a
+     * later deployment.
+     */
+    private final Map<String, DeployedProcessVersion> byVersionTag = new HashMap<>();
+
+    private Instant fetchedAt;
+
+    /**
+     * When the BPMS was last asked about a version identifier or tag it did not know -
+     * per value, so a version showing up for the first time is looked up right away
+     * while a tag which does not exist cannot be asked for over and over.
+     */
+    private final Map<String, Instant> missedAt = new HashMap<>();
+
+    private DeployedProcessVersion lookup(
+        final String versionOrVersionTag) {
+
+      final var byVersionHit = byVersion.get(versionOrVersionTag);
+      return byVersionHit != null
+          ? byVersionHit
+          : byVersionTag.get(versionOrVersionTag);
+
+    }
+
+    private void add(
+        final DeployedProcessVersion version) {
+
+      byVersion.put(version.version(), version);
+      if (version.versionTag() != null) {
+        byVersionTag.put(version.versionTag(), version);
+      }
+
+    }
+
+  }
+
+  private final Map<String, Versions> versionsByProcess = new ConcurrentHashMap<>();
+
+  private final Duration refreshInterval;
+
+  protected CachingProcessVersionCatalog() {
+
+    this(Duration.ofSeconds(DEFAULT_REFRESH_INTERVAL_SECONDS));
+
+  }
+
+  protected CachingProcessVersionCatalog(
+      final Duration refreshInterval) {
+
+    this.refreshInterval = refreshInterval;
+
+  }
+
+  /**
+   * Asks the BPMS for all versions of the given process, oldest first. Called at
+   * startup for every process whose annotations name a version tag, and at runtime
+   * whenever a version identifier or tag is not known yet.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @return The deployed versions, oldest first; empty if the BPMS cannot tell
+   */
+  protected abstract List<DeployedProcessVersion> fetchDeployedVersions(
+      String workflowModuleId,
+      String bpmnProcessId);
+
+  /**
+   * Adds a version the adapter learned without asking the BPMS - the result of the
+   * deploy command reports the version the BPMS assigned to the model just deployed,
+   * and the model itself carries its version tag.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param version The deployed version
+   */
+  public void record(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final DeployedProcessVersion version) {
+
+    if (version == null) {
+      return;
+    }
+    final var versions = versionsOf(workflowModuleId, bpmnProcessId);
+    synchronized (versions) {
+      versions.add(version);
+    }
+
+  }
+
+  @Override
+  public List<DeployedProcessVersion> deployedVersionsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    final var versions = versionsOf(workflowModuleId, bpmnProcessId);
+    synchronized (versions) {
+      if (versions.fetchedAt == null) {
+        fetch(versions, workflowModuleId, bpmnProcessId);
+      }
+      return List.copyOf(versions.byVersion.values());
+    }
+
+  }
+
+  @Override
+  public DeployedProcessVersion resolveVersion(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String versionOrVersionTag) {
+
+    if (versionOrVersionTag == null) {
+      return null;
+    }
+    final var versions = versionsOf(workflowModuleId, bpmnProcessId);
+    synchronized (versions) {
+      final var known = versions.lookup(versionOrVersionTag);
+      if (known != null) {
+        return known;
+      }
+      // not seen yet: another cluster node may have deployed a version this node
+      // does not know of (rolling deployment), so the BPMS is asked - but not once
+      // per task delivery, which is what the interval per value is for
+      final var missedAt = versions.missedAt.get(versionOrVersionTag);
+      if ((missedAt != null) && Instant.now().isBefore(missedAt.plus(refreshInterval))) {
+        return null;
+      }
+      versions.missedAt.put(versionOrVersionTag, Instant.now());
+      fetch(versions, workflowModuleId, bpmnProcessId);
+      final var found = versions.lookup(versionOrVersionTag);
+      if (found != null) {
+        versions.missedAt.remove(versionOrVersionTag);
+      }
+      return found;
+    }
+
+  }
+
+  private void fetch(
+      final Versions versions,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    versions.fetchedAt = Instant.now();
+    final List<DeployedProcessVersion> fetched;
+    try {
+      fetched = fetchDeployedVersions(workflowModuleId, bpmnProcessId);
+    } catch (final RuntimeException e) {
+      log.warn(
+          "Could not determine the deployed versions of BPMN process '{}' of workflow module "
+              + "'{}' - version specifications naming a version tag do not match until the next "
+              + "attempt",
+          bpmnProcessId,
+          workflowModuleId,
+          e);
+      return;
+    }
+    if (fetched == null) {
+      return;
+    }
+    // the fetched order is the deployment order and replaces what was recorded from
+    // deploy results before - those are part of the fetched list anyway
+    final var recorded = new ArrayList<>(versions.byVersion.values());
+    versions.byVersion.clear();
+    versions.byVersionTag.clear();
+    fetched.forEach(versions::add);
+    recorded
+        .stream()
+        .filter(version -> !versions.byVersion.containsKey(version.version()))
+        .forEach(versions::add);
+
+  }
+
+  private Versions versionsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return versionsByProcess.computeIfAbsent(
+        workflowModuleId
+            + "|"
+            + bpmnProcessId,
+        key -> new Versions());
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/DeployedProcessVersion.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/DeployedProcessVersion.java
@@ -1,0 +1,56 @@
+package io.vanillabp.integration.adapter.spi.version;
+
+import java.time.Instant;
+
+/**
+ * One deployed version of a BPMN process as the BPMS counts it.
+ * <p>
+ * The <code>version</code> is the identifier the BPMS reports at runtime (in
+ * {@link io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext#getProcessVersion()}
+ * and its siblings) - for Camunda 7 and Camunda 8 an integer counted upwards per
+ * BPMN process id. The <code>versionTag</code> is the name the modeller gave that
+ * version (<code>camunda:versionTag</code> respectively <code>zeebe:versionTag</code>)
+ * or <code>null</code>, and the same tag may be used by more than one version.
+ * <p>
+ * <code>deployedAt</code> orders versions whose identifiers are not numbers. Adapters
+ * of a BPMS counting versions upwards may leave it <code>null</code>: counting upwards
+ * IS the deployment order, which is what the core compares by then.
+ *
+ * @param version The version identifier the BPMS reports at runtime
+ * @param versionTag The version tag of that version or <code>null</code>
+ * @param deployedAt When that version was deployed or <code>null</code>
+ */
+public record DeployedProcessVersion(
+                                     String version,
+                                     String versionTag,
+                                     Instant deployedAt) {
+
+  /**
+   * A version of a BPMS counting versions upwards, without a version tag.
+   *
+   * @param version The version identifier
+   * @return The version
+   */
+  public static DeployedProcessVersion of(
+      final String version) {
+
+    return new DeployedProcessVersion(version, null, null);
+
+  }
+
+  /**
+   * A version of a BPMS counting versions upwards.
+   *
+   * @param version The version identifier
+   * @param versionTag The version tag or <code>null</code>
+   * @return The version
+   */
+  public static DeployedProcessVersion of(
+      final String version,
+      final String versionTag) {
+
+    return new DeployedProcessVersion(version, versionTag, null);
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/ProcessVersionCatalog.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/ProcessVersionCatalog.java
@@ -1,0 +1,56 @@
+package io.vanillabp.integration.adapter.spi.version;
+
+import java.util.List;
+
+/**
+ * What a BPMS knows about the deployed versions of a BPMN process - implemented by an
+ * adapter whose BPMS can tell, handed to the core during <code>wireBpmn</code> using
+ * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#registerProcessVersions}.
+ * <p>
+ * The core needs it only for version SPECIFICATIONS naming a version TAG
+ * (<code>&#64;WorkflowTask(version = "release-2024")</code>, <code>version = "&gt;v1.4"</code>):
+ * a specification consisting of numbers is compared to the version the BPMS reported
+ * without asking anybody. That is why an adapter of a BPMS which cannot report tags
+ * simply registers nothing - version specifications made of numbers keep working, and
+ * a specification naming a tag matches nothing and is reported once with a guiding
+ * message.
+ * <p>
+ * <b>Both directions are expected to be cheap:</b> {@link #resolveVersion} is called
+ * while a task is dispatched, so an implementation caches what it learned and asks the
+ * BPMS only for a version it has not seen yet. That case is real: during a rolling
+ * deployment another cluster node may already have deployed a version this node does
+ * not know, and the BPMS delivers a task of it before this node deploys. See
+ * {@link CachingProcessVersionCatalog}, which implements exactly that and leaves the
+ * BPMS query to the adapter.
+ */
+public interface ProcessVersionCatalog {
+
+  /**
+   * All versions of the given process the BPMS knows, ordered by deployment, oldest
+   * first. Called once per process at startup (the deployment pipeline has finished
+   * then, so the version deployed by this very boot is included) to resolve the
+   * version tags the application's annotations name.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @return The deployed versions, oldest first; empty if the BPMS cannot tell
+   */
+  List<DeployedProcessVersion> deployedVersionsOf(
+      String workflowModuleId,
+      String bpmnProcessId);
+
+  /**
+   * The version identified by a version identifier the BPMS reported, or the newest
+   * version carrying the given version tag.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param versionOrVersionTag A version identifier or a version tag
+   * @return The version or <code>null</code> if the BPMS does not know it
+   */
+  DeployedProcessVersion resolveVersion(
+      String workflowModuleId,
+      String bpmnProcessId,
+      String versionOrVersionTag);
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedContext.java
@@ -48,9 +48,12 @@ public interface WorkflowEndedContext {
   }
 
   /**
-   * The version of the deployed BPMN process, matched against
-   * <code>&#64;WorkflowEnded(version = ...)</code>. <code>null</code> matches every
-   * method regardless of its version ranges.
+   * The version of the deployed BPMN process definition the ended workflow ran on, as
+   * the BPMS counts it. It is matched against
+   * <code>&#64;WorkflowEnded(version = ...)</code> like a task's version is matched
+   * against <code>&#64;WorkflowTask(version = ...)</code> - see
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext#getProcessVersion()}.
+   * <code>null</code> matches every method regardless of its version ranges.
    *
    * @return The process version or <code>null</code>
    */

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedContext.java
@@ -1,0 +1,77 @@
+package io.vanillabp.integration.adapter.spi.workflowend;
+
+import java.time.Instant;
+
+import io.vanillabp.spi.service.WorkflowEnd;
+
+/**
+ * All information a BPMS adapter supplies when a workflow ended. The adapter builds
+ * one context per notification (e.g. a Camunda 7 process-end execution listener or
+ * a Camunda 8 end execution-listener job) and passes it to
+ * {@link WorkflowEndedInvoker#workflowEnded(String, String, WorkflowEndedContext)}.
+ * The context is deliberately neutral: it carries only values, no BPMS types.
+ */
+public interface WorkflowEndedContext {
+
+  /**
+   * The workflow aggregate's ID in serialized form (the same String representation
+   * used everywhere else, e.g. the Camunda 7 business key or the Camunda 8
+   * aggregate-ID process variable).
+   *
+   * @return The serialized workflow-aggregate ID
+   */
+  String getWorkflowAggregateId();
+
+  /**
+   * How the workflow ended, as far as this BPMS reports it. An adapter which cannot
+   * tell a cancellation from a regular end reports
+   * {@link WorkflowEnd.Kind#COMPLETED} and says so in its documentation.
+   *
+   * @return The kind of end
+   */
+  WorkflowEnd.Kind getKind();
+
+  /**
+   * @return When the workflow ended - the time reported by the BPMS, or the moment
+   *         of the notification where it reports none
+   */
+  Instant getEndTime();
+
+  /**
+   * @return The BPMN id of the end event reached, or <code>null</code> where the
+   *         BPMS does not report it
+   */
+  default String getEndEventId() {
+
+    return null;
+
+  }
+
+  /**
+   * The version of the deployed BPMN process, matched against
+   * <code>&#64;WorkflowEnded(version = ...)</code>. <code>null</code> matches every
+   * method regardless of its version ranges.
+   *
+   * @return The process version or <code>null</code>
+   */
+  default String getProcessVersion() {
+
+    return null;
+
+  }
+
+  /**
+   * Whether the method has to run within the transaction already active on the
+   * calling thread (an embedded BPMS ending the workflow in its own transaction,
+   * e.g. Camunda 7) instead of a new transaction opened by the core (a remote BPMS
+   * delivering the notification on a worker thread, e.g. Camunda 8).
+   *
+   * @return Whether to join the current transaction
+   */
+  default boolean runInCurrentTransaction() {
+
+    return false;
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowend/WorkflowEndedInvoker.java
@@ -1,0 +1,52 @@
+package io.vanillabp.integration.adapter.spi.workflowend;
+
+/**
+ * The BPMS adapter's entry point into VanillaBP for workflows which ended.
+ * Implemented by the core (the migration adapter) and provided to adapters by the
+ * platform integration. Adapters use it twice:
+ * <ol>
+ * <li>While wiring: {@link #workflowEndedHandlerExists(String, String)} - a model
+ * must not pay for a feature the application does not use, so a listener is
+ * attached only where a <code>&#64;WorkflowEnded</code> method exists.</li>
+ * <li>At runtime: {@link #workflowEnded(String, String, WorkflowEndedContext)} when
+ * the BPMS reports the end. The core loads the workflow aggregate, calls the
+ * application's method and saves the aggregate in a transaction.</li>
+ * </ol>
+ */
+public interface WorkflowEndedInvoker {
+
+  /**
+   * Whether the application wants to be told about the end of workflows of the
+   * given BPMN process.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return Whether a <code>&#64;WorkflowEnded</code> method is registered
+   */
+  boolean workflowEndedHandlerExists(
+      String workflowModuleId,
+      String bpmnProcessId);
+
+  /**
+   * Tells the application that a workflow ended.
+   * <p>
+   * <strong>At-least-once:</strong> a redelivered notification calls the method
+   * again - the core does not deduplicate, because it has nothing to deduplicate
+   * by; the application's method is expected to be idempotent.
+   * <p>
+   * A missing workflow aggregate is NOT an error here: an application may delete
+   * the aggregate of a workflow which ended, and a notification arriving after that
+   * is logged and skipped rather than failing the BPMS' transaction.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification supplied by the adapter
+   * @throws RuntimeException Whatever the application's method threw - the
+   *           transaction was rolled back and the BPMS' retry semantics apply
+   */
+  void workflowEnded(
+      String workflowModuleId,
+      String bpmnProcessId,
+      WorkflowEndedContext context);
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartContext.java
@@ -97,9 +97,12 @@ public interface BpmsInitiatedStartContext {
   }
 
   /**
-   * The version of the deployed BPMN process, matched against
-   * <code>&#64;WorkflowStartedByBpms(version = ...)</code>. <code>null</code>
-   * matches every method regardless of its version ranges.
+   * The version of the deployed BPMN process definition the BPMS started this workflow
+   * from, as the BPMS counts it. It is matched against
+   * <code>&#64;WorkflowStartedByBpms(version = ...)</code> like a task's version is
+   * matched against <code>&#64;WorkflowTask(version = ...)</code> - see
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext#getProcessVersion()}.
+   * <code>null</code> matches every method regardless of its version ranges.
    *
    * @return The process version or <code>null</code>
    */

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartContext.java
@@ -1,0 +1,141 @@
+package io.vanillabp.integration.adapter.spi.workflowstart;
+
+import java.time.Instant;
+import java.util.Map;
+
+import io.vanillabp.integration.adapter.spi.AggregateSyncMode;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+
+/**
+ * All information a BPMS adapter supplies when the BPMS started a workflow on its
+ * own and the workflow aggregate has to be built. The adapter creates one context
+ * per notification (e.g. a Camunda 7 process-start execution listener or a Camunda 8
+ * start execution-listener job) and passes it to
+ * {@link BpmsInitiatedStartInvoker#startWorkflowByBpms(String, String, BpmsInitiatedStartContext)}.
+ * The context is deliberately neutral: it carries only values, no BPMS types.
+ */
+public interface BpmsInitiatedStartContext {
+
+  /**
+   * The BPMN id of the start event which fired - used to resolve the optional
+   * <code>&#64;WorkflowStartedByBpms</code> method and reported to it.
+   *
+   * @return The start event's BPMN id
+   */
+  String getStartEventId();
+
+  /**
+   * @return Which kind of start event fired
+   */
+  BpmsStartTrigger.Kind getKind();
+
+  /**
+   * When the start event fired. For a timer this is the time the engine scheduled
+   * it for, which is what makes it a stable identity: a cyclic timer firing the
+   * same instant twice addresses the same workflow aggregate, so a redelivered
+   * notification creates nothing twice. Adapters which cannot report the scheduled
+   * time report the time of the notification.
+   *
+   * @return The trigger's time, never <code>null</code>
+   */
+  Instant getTriggerTime();
+
+  /**
+   * A value identifying THIS start in the BPMS, stable across repeated
+   * notifications of it - a remote BPMS typically reports its process instance key
+   * here. VanillaBP prefers it over everything else when it derives the workflow
+   * aggregate's ID, which is what keeps a redelivered notification from building a
+   * second aggregate for a workflow which already has one.
+   * <p>
+   * An adapter whose notification cannot repeat once the aggregate is committed
+   * (an embedded engine writing both in one transaction) reports nothing here, and
+   * the aggregate's ID becomes the meaningful one: a timer's trigger time.
+   *
+   * @return The BPMS' identity of this start or <code>null</code>
+   */
+  default String getNaturalIdentity() {
+
+    return null;
+
+  }
+
+  /**
+   * @return The PLAIN signal name for {@link BpmsStartTrigger.Kind#SIGNAL},
+   *         <code>null</code> otherwise
+   */
+  default String getSignalName() {
+
+    return null;
+
+  }
+
+  /**
+   * The process variables visible at the moment the workflow started - typically
+   * values a BPMN expression or an input mapping of the start event set. VanillaBP
+   * copies them into equally-named attributes of the workflow aggregate and binds
+   * them to <code>&#64;TaskParam</code> parameters of the
+   * <code>&#64;WorkflowStartedByBpms</code> method.
+   *
+   * @return The variables by name - possibly empty, never <code>null</code>
+   */
+  default Map<String, Object> getVariables() {
+
+    return Map.of();
+
+  }
+
+  /**
+   * The BPMS' own ID of the started workflow instance. Used for log and error
+   * messages only - VanillaBP addresses workflows by the aggregate's ID.
+   *
+   * @return The native instance ID or <code>null</code>
+   */
+  default String getNativeInstanceId() {
+
+    return null;
+
+  }
+
+  /**
+   * The version of the deployed BPMN process, matched against
+   * <code>&#64;WorkflowStartedByBpms(version = ...)</code>. <code>null</code>
+   * matches every method regardless of its version ranges.
+   *
+   * @return The process version or <code>null</code>
+   */
+  default String getProcessVersion() {
+
+    return null;
+
+  }
+
+  /**
+   * Whether the aggregate has to be built within the transaction already active on
+   * the calling thread (an embedded BPMS notifying inside its own engine
+   * transaction, e.g. Camunda 7) instead of a new transaction opened by the core (a
+   * remote BPMS delivering the notification on a worker thread, e.g. Camunda 8).
+   *
+   * @return Whether to join the current transaction
+   */
+  default boolean runInCurrentTransaction() {
+
+    return false;
+
+  }
+
+  /**
+   * This adapter's default for aggregates carrying no
+   * {@code @SyncWithBPMS}/{@code @NoSyncWithBPMS} annotation of their own - decides
+   * which aggregate values are reported back in
+   * {@link BpmsInitiatedStartResult#variables()}. Embedded BPMS reading the
+   * aggregate live answer {@link AggregateSyncMode#NONE}.
+   *
+   * @return The adapter's sync default
+   */
+  default AggregateSyncMode getAggregateSyncMode() {
+
+    return AggregateSyncMode.NONE;
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartInvoker.java
@@ -1,0 +1,74 @@
+package io.vanillabp.integration.adapter.spi.workflowstart;
+
+import java.util.Collection;
+
+/**
+ * The BPMS adapter's entry point into VanillaBP for workflows the BPMS starts on
+ * its own - by a timer, signal or conditional start event. Implemented by the core
+ * (the migration adapter) and provided to adapters by the platform integration.
+ * Adapters use it twice:
+ * <ol>
+ * <li>During <code>wireBpmn</code>:
+ * {@link #validateBpmsInitiatedStarts(String, String, Collection)} with the start
+ * events of the executable BPMN process which fire without the application. The
+ * core registers them and reports a
+ * <code>&#64;WorkflowStartedByBpms</code> method serving a process (or a start
+ * event) which has none - throwing from <code>wireBpmn</code> automatically honors
+ * the <code>deployment-failure</code> policy for non-first-priority adapters.</li>
+ * <li>At runtime:
+ * {@link #startWorkflowByBpms(String, String, BpmsInitiatedStartContext)} when the
+ * BPMS reports such a start. The core builds and saves the workflow aggregate in a
+ * transaction and returns what the adapter has to write back into the BPMS.</li>
+ * </ol>
+ * An adapter whose BPMS cannot notify VanillaBP about its own starts does not
+ * implement any of this; it fails the deployment of a process carrying such a start
+ * event with a guiding message instead, because that workflow could never obtain a
+ * workflow aggregate.
+ */
+public interface BpmsInitiatedStartInvoker {
+
+  /**
+   * Registers the BPMS-initiated start events of a deployed BPMN process and
+   * validates the application against them.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param startEvents The start events firing without the application - an empty
+   *          collection is normal and means the process is started by the
+   *          application only
+   * @throws IllegalStateException If a <code>&#64;WorkflowStartedByBpms</code>
+   *           method serves a process or start event which does not exist (guiding
+   *           message naming the method and the fix)
+   */
+  void validateBpmsInitiatedStarts(
+      String workflowModuleId,
+      String bpmnProcessId,
+      Collection<BpmsInitiatedStartSpec> startEvents);
+
+  /**
+   * Builds the workflow aggregate of a workflow the BPMS just started, saves it and
+   * reports what the adapter has to write back.
+   * <p>
+   * <strong>Idempotency:</strong> an aggregate already existing under the derived ID
+   * is reused instead of being replaced, and the result says so
+   * ({@link BpmsInitiatedStartResult#created()}). Adapters may therefore deliver a
+   * notification more than once (a retried listener job, a recovered engine
+   * transaction) without creating a second aggregate.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification supplied by the adapter
+   * @return The aggregate's ID and the variables to write into the workflow
+   * @throws IllegalStateException If no workflow service is registered for the BPMN
+   *           process, or if the aggregate can neither be instantiated nor be
+   *           provided by the application (guiding messages)
+   * @throws RuntimeException Whatever a <code>&#64;WorkflowStartedByBpms</code>
+   *           method threw - the transaction was rolled back, so no aggregate
+   *           exists and the BPMS' retry semantics apply
+   */
+  BpmsInitiatedStartResult startWorkflowByBpms(
+      String workflowModuleId,
+      String bpmnProcessId,
+      BpmsInitiatedStartContext context);
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartResult.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartResult.java
@@ -1,0 +1,39 @@
+package io.vanillabp.integration.adapter.spi.workflowstart;
+
+import java.util.Map;
+
+/**
+ * What the core built for a workflow the BPMS started on its own, and what the
+ * adapter has to write back into the BPMS so the workflow can be addressed later.
+ * <p>
+ * A BPMS with a business-identifier concept of its own (e.g. Camunda 7's business
+ * key) stores {@link #workflowAggregateId()} there and ignores the variables. A
+ * BPMS without one (e.g. Camunda 8) writes {@link #variables()}, which already
+ * contains the aggregate-ID variable under {@link #workflowAggregateIdName()} plus
+ * the aggregate values shared per {@code @SyncWithBPMS}.
+ *
+ * @param workflowAggregateId The workflow aggregate's ID in serialized form
+ * @param workflowAggregateIdName The name of the aggregate's ID attribute, which is
+ *          how the ID is named as a process variable
+ * @param variables The variables to write into the workflow instance - never
+ *          <code>null</code>
+ * @param created Whether the aggregate was created by this notification;
+ *          <code>false</code> means it existed already, so the notification was a
+ *          repetition (at-least-once delivery, a retried listener job) and nothing
+ *          was created twice
+ */
+public record BpmsInitiatedStartResult(
+                                       String workflowAggregateId,
+                                       String workflowAggregateIdName,
+                                       Map<String, Object> variables,
+                                       boolean created) {
+
+  public BpmsInitiatedStartResult {
+    // a defensive copy which tolerates NULL values: an aggregate attribute shared
+    // with the BPMS may well be unset, and the BPMS is told exactly that
+    variables = variables == null
+        ? Map.of()
+        : java.util.Collections.unmodifiableMap(new java.util.LinkedHashMap<>(variables));
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartSpec.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowstart/BpmsInitiatedStartSpec.java
@@ -1,0 +1,42 @@
+package io.vanillabp.integration.adapter.spi.workflowstart;
+
+import io.vanillabp.spi.service.BpmsStartTrigger;
+
+/**
+ * One start event of a deployed BPMN process which fires WITHOUT the application
+ * starting the workflow: a timer, signal or conditional start event. Reported by
+ * the adapter during <code>wireBpmn</code> through
+ * {@link BpmsInitiatedStartInvoker#validateBpmsInitiatedStarts}.
+ * <p>
+ * The signal name is the PLAIN one as modelled - name-clash avoidance (story 35)
+ * stays invisible above the BPMS boundary, so an adapter which scopes identifiers
+ * reports what the model said, not what it deployed.
+ *
+ * @param elementId The BPMN id of the start event
+ * @param kind Which kind of start event it is
+ * @param signalName The plain signal name for {@link BpmsStartTrigger.Kind#SIGNAL},
+ *          <code>null</code> otherwise
+ * @param description What the event is defined as (e.g. a timer's cycle or date
+ *          expression) - used in log and error messages only, may be
+ *          <code>null</code>
+ */
+public record BpmsInitiatedStartSpec(
+                                     String elementId,
+                                     BpmsStartTrigger.Kind kind,
+                                     String signalName,
+                                     String description) {
+
+  /**
+   * @param elementId The BPMN id of the start event
+   * @param kind Which kind of start event it is
+   * @return The spec without a signal name and description
+   */
+  public static BpmsInitiatedStartSpec of(
+      final String elementId,
+      final BpmsStartTrigger.Kind kind) {
+
+    return new BpmsInitiatedStartSpec(elementId, kind, null, null);
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
@@ -92,9 +92,14 @@ public interface TaskInvocationContext {
   }
 
   /**
-   * The version of the deployed BPMN process this task belongs to, matched against
-   * <code>&#64;WorkflowTask(version = ...)</code>. <code>null</code> matches every
-   * handler regardless of its version ranges.
+   * The version of the deployed BPMN process definition this task belongs to, as the
+   * BPMS counts it (Camunda 7 and Camunda 8 count integers upwards per BPMN process
+   * id) - NOT a version the application invented. It is matched against
+   * <code>&#64;WorkflowTask(version = ...)</code>, and a specification naming a
+   * version TAG is resolved using the
+   * {@link io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog} the
+   * adapter registered. <code>null</code> matches every handler regardless of its
+   * version ranges - the compatible answer of an adapter whose BPMS cannot tell.
    *
    * @return The process version or <code>null</code>
    */

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -98,6 +98,25 @@ public interface WorkflowTaskInvoker {
    * @return The attribute's value or <code>null</code> if the BPMN process is
    *         unknown, the aggregate does not exist or it has no such attribute
    */
+  /**
+   * Whether the workflow aggregate of the given BPMN process HAS such an attribute
+   * - answered from the aggregate's class, so no aggregate is loaded. Embedded BPMS
+   * use it while resolving a BPMN expression: a name may mean an attribute of the
+   * workflow aggregate or something of the adapter's own (Camunda 7 resolves the
+   * delegate expression of a task through the same resolver), and only the aggregate
+   * class can tell which name is whose.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param propertyName The attribute's name
+   * @return Whether the aggregate class declares that attribute (getter, boolean
+   *         getter or field); <code>false</code> if the BPMN process is unknown
+   */
+  boolean workflowAggregateHasProperty(
+      String workflowModuleId,
+      String bpmnProcessId,
+      String propertyName);
+
   Object resolveWorkflowAggregateProperty(
       String workflowModuleId,
       String bpmnProcessId,

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -188,4 +188,42 @@ public interface WorkflowTaskInvoker {
       String workflowModuleId,
       String bpmnProcessId);
 
+  /**
+   * Hands over what the BPMS knows about the deployed versions of a BPMN process,
+   * called during <code>wireBpmn</code> by an adapter whose BPMS can tell. It serves
+   * the <code>version</code> attribute of ALL annotations carrying one
+   * (<code>&#64;WorkflowTask</code>, <code>&#64;WorkflowStartedByBpms</code>,
+   * <code>&#64;WorkflowEnded</code>) and is needed only for specifications naming a
+   * version TAG - specifications made of numbers are compared to the version the
+   * adapter reports in its invocation contexts, without asking anybody.
+   *
+   * @param adapterId The adapter ID (the catalog answers for THIS BPMS)
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param catalog The versions of that process
+   */
+  default void registerProcessVersions(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog catalog) {
+
+  }
+
+  /**
+   * Resolves the version tags the annotations of the given workflow module name, using
+   * the catalogs registered by {@link #registerProcessVersions}. Called by an adapter
+   * at the END of <code>deployResources</code>, so the version deployed by this very
+   * boot is part of the answer, and version specifications naming a tag are ambiguous
+   * or unknown at STARTUP instead of at the first task delivery.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @throws IllegalStateException If two methods turn out to serve the same BPMN
+   *           element in overlapping version ranges (guiding message)
+   */
+  default void resolveProcessVersions(
+      final String workflowModuleId) {
+
+  }
+
 }

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartAggregate.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartAggregate.java
@@ -1,0 +1,73 @@
+package io.vanillabp.integration.test.deployment;
+
+/**
+ * The aggregate of the acceptance test of workflows the BPMS starts on its own. Its
+ * ID is a String, so a timer's trigger time can be its identity.
+ */
+public class StartAggregate {
+
+  private String id;
+
+  private String region;
+
+  private int amount;
+
+  /**
+   * Set by the <code>&#64;WorkflowStartedByBpms</code> method, so a test can tell
+   * whether the application had its say or VanillaBP built the aggregate alone.
+   */
+  private String startedBy;
+
+  public String getId() {
+
+    return id;
+
+  }
+
+  public void setId(
+      final String id) {
+
+    this.id = id;
+
+  }
+
+  public String getRegion() {
+
+    return region;
+
+  }
+
+  public void setRegion(
+      final String region) {
+
+    this.region = region;
+
+  }
+
+  public int getAmount() {
+
+    return amount;
+
+  }
+
+  public void setAmount(
+      final int amount) {
+
+    this.amount = amount;
+
+  }
+
+  public String getStartedBy() {
+
+    return startedBy;
+
+  }
+
+  public void setStartedBy(
+      final String startedBy) {
+
+    this.startedBy = startedBy;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartAggregatePersistence.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartAggregatePersistence.java
@@ -1,0 +1,107 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * In-memory persistence for the aggregate of the BPMS-initiated-start acceptance
+ * test. Aggregates are copied on save/load so un-saved mutations never leak into
+ * the store.
+ */
+@ApplicationScoped
+public class StartAggregatePersistence implements AggregatePersistenceAware<StartAggregate> {
+
+  private final Map<String, StartAggregate> aggregates = new ConcurrentHashMap<>();
+
+  @Override
+  public Class<StartAggregate> getAggregateClass() {
+
+    return StartAggregate.class;
+
+  }
+
+  @Override
+  public String getAggregateIdName() {
+
+    return "id";
+
+  }
+
+  @Override
+  public Class<?> getAggregateIdType() {
+
+    return String.class;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final StartAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public StartAggregate save(
+      final StartAggregate aggregate) {
+
+    aggregates.put(aggregate.getId(), copyOf(aggregate));
+    return aggregate;
+
+  }
+
+  @Override
+  public StartAggregate loadById(
+      final Object aggregateId) {
+
+    final var stored = aggregates.get(aggregateId);
+    return stored != null
+        ? copyOf(stored)
+        : null;
+
+  }
+
+  /**
+   * @param aggregateId The aggregate's ID
+   * @return What is stored under that ID, or <code>null</code>
+   */
+  public StartAggregate stored(
+      final String aggregateId) {
+
+    return aggregates.get(aggregateId);
+
+  }
+
+  /**
+   * @return How many aggregates the store holds
+   */
+  public int count() {
+
+    return aggregates.size();
+
+  }
+
+  public void put(
+      final StartAggregate aggregate) {
+
+    aggregates.put(aggregate.getId(), copyOf(aggregate));
+
+  }
+
+  private static StartAggregate copyOf(
+      final StartAggregate aggregate) {
+
+    final var copy = new StartAggregate();
+    copy.setId(aggregate.getId());
+    copy.setRegion(aggregate.getRegion());
+    copy.setAmount(aggregate.getAmount());
+    copy.setStartedBy(aggregate.getStartedBy());
+    return copy;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartProcessStartEventSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartProcessStartEventSource.java
@@ -1,0 +1,33 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyBpmsInitiatedStartSource;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of the BPMS-initiated-start acceptance test:
+ * 'StartProcess' has a timer and a signal start event, every other process of the
+ * module has none.
+ */
+@ApplicationScoped
+public class StartProcessStartEventSource implements DummyBpmsInitiatedStartSource {
+
+  @Override
+  public Collection<BpmsInitiatedStartSpec> startEventsOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "StartProcess".equals(bpmnProcessId)
+        ? List.of(
+            BpmsInitiatedStartSpec.of("DailyTimer", BpmsStartTrigger.Kind.TIMER),
+            new BpmsInitiatedStartSpec("SignalStart", BpmsStartTrigger.Kind.SIGNAL, "OrderReceived", null))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartWorkflowService.java
@@ -1,0 +1,35 @@
+package io.vanillabp.integration.test.deployment;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowStartedByBpms;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * The workflow service of the acceptance test of BPMS-initiated starts. It serves
+ * ONE of the two start events of its process, which proves both paths at once: the
+ * timer start is built by VanillaBP alone, the signal start passes through the
+ * application's method.
+ */
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = StartAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "StartProcess"))
+public class StartWorkflowService {
+
+  @WorkflowStartedByBpms(id = "SignalStart")
+  public void aggregateOfSignalStart(
+      final StartAggregate aggregate,
+      final BpmsStartTrigger trigger,
+      @TaskParam("region") final String region) {
+
+    aggregate.setStartedBy("%s/%s".formatted(trigger.kind(), trigger.signalName()));
+    aggregate.setRegion(region == null
+        ? null
+        : region.toUpperCase());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/StartWorkflowService.java
@@ -3,6 +3,8 @@ package io.vanillabp.integration.test.deployment;
 import io.vanillabp.spi.service.BpmnProcess;
 import io.vanillabp.spi.service.BpmsStartTrigger;
 import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowEnd;
+import io.vanillabp.spi.service.WorkflowEnded;
 import io.vanillabp.spi.service.WorkflowService;
 import io.vanillabp.spi.service.WorkflowStartedByBpms;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -18,6 +20,18 @@ import jakarta.enterprise.context.ApplicationScoped;
     workflowAggregateClass = StartAggregate.class,
     bpmnProcess = @BpmnProcess(bpmnProcessId = "StartProcess"))
 public class StartWorkflowService {
+
+  /**
+   * Story 43: the same workflow service also wants to know when a workflow ended.
+   */
+  @WorkflowEnded
+  public void workflowEnded(
+      final StartAggregate aggregate,
+      final WorkflowEnd end) {
+
+    aggregate.setStartedBy("ended:%s/%s".formatted(end.kind(), end.endEventId()));
+
+  }
 
   @WorkflowStartedByBpms(id = "SignalStart")
   public void aggregateOfSignalStart(

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedAggregate.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedAggregate.java
@@ -1,0 +1,33 @@
+package io.vanillabp.integration.test.deployment;
+
+/**
+ * The aggregate of the process-version acceptance test (story 48).
+ */
+public class VersionedAggregate {
+
+  private String id;
+
+  /**
+   * Which method served the task - the version of the deployed process decides it.
+   */
+  private String servedBy;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getServedBy() {
+    return servedBy;
+  }
+
+  public void setServedBy(
+      final String servedBy) {
+    this.servedBy = servedBy;
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedAggregatePersistence.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedAggregatePersistence.java
@@ -1,0 +1,81 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * In-memory persistence for the process-version acceptance test's aggregate.
+ */
+@ApplicationScoped
+public class VersionedAggregatePersistence implements AggregatePersistenceAware<VersionedAggregate> {
+
+  private final Map<String, VersionedAggregate> aggregates = new ConcurrentHashMap<>();
+
+  @Override
+  public Class<VersionedAggregate> getAggregateClass() {
+
+    return VersionedAggregate.class;
+
+  }
+
+  @Override
+  public VersionedAggregate save(
+      final VersionedAggregate aggregate) {
+
+    aggregates.put(aggregate.getId(), aggregate);
+    return aggregate;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final VersionedAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public Class<?> getAggregateIdType() {
+
+    return String.class;
+
+  }
+
+  @Override
+  public VersionedAggregate loadById(
+      final Object aggregateId) {
+
+    return aggregates.get(aggregateId);
+
+  }
+
+  /**
+   * @param id The aggregate ID
+   * @return A stored aggregate the test can hand to a task invocation
+   */
+  public VersionedAggregate seed(
+      final String id) {
+
+    final var aggregate = new VersionedAggregate();
+    aggregate.setId(id);
+    aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  /**
+   * @param id The aggregate ID
+   * @return The stored aggregate
+   */
+  public VersionedAggregate stored(
+      final String id) {
+
+    return aggregates.get(id);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedProcessVersionSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedProcessVersionSource.java
@@ -1,0 +1,67 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.vanillabp.adapter.dummy.runtime.DummyProcessVersionSource;
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMS query a real adapter runs to learn the deployed versions of
+ * a process, and counts how often it ran - the query belongs to the startup and to
+ * versions never seen before, not to every task delivery.
+ */
+@ApplicationScoped
+public class VersionedProcessVersionSource implements DummyProcessVersionSource {
+
+  private final List<DeployedProcessVersion> versions = new CopyOnWriteArrayList<>(
+      List.of(
+          DeployedProcessVersion.of("1", null),
+          DeployedProcessVersion.of("2", null),
+          DeployedProcessVersion.of("3", null),
+          DeployedProcessVersion.of("4", "release-2026")));
+
+  private final AtomicInteger queries = new AtomicInteger();
+
+  @Override
+  public List<DeployedProcessVersion> versionsOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    queries.incrementAndGet();
+    return List.copyOf(versions);
+
+  }
+
+  /**
+   * @return How often the "BPMS" was asked
+   */
+  public int getQueries() {
+
+    return queries.get();
+
+  }
+
+  /**
+   * Mimics another cluster node deploying a new version and moving the version tag
+   * to it - what a rolling deployment does while this node is running.
+   *
+   * @param version The version the other node deployed
+   * @param versionTag The tag it carries now
+   */
+  public void deployedElsewhere(
+      final String version,
+      final String versionTag) {
+
+    versions.replaceAll(
+        known -> versionTag.equals(known.versionTag())
+            ? DeployedProcessVersion.of(known.version(), null)
+            : known);
+    versions.add(DeployedProcessVersion.of(version, versionTag));
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedProcessWiringSource.java
@@ -1,0 +1,29 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of the process-version acceptance test: the one task
+ * all three methods of {@link VersionedWorkflowService} are wired to.
+ */
+@ApplicationScoped
+public class VersionedProcessWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "VersionedProcess".equals(bpmnProcessId)
+        ? List.of(new BpmnTaskSpec("Activity_Versioned", "versionedTask"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/VersionedWorkflowService.java
@@ -1,0 +1,43 @@
+package io.vanillabp.integration.test.deployment;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * The workflow service of the process-version acceptance test (story 48): one BPMN
+ * task served by three methods, told apart by the version of the deployed process -
+ * two version ranges made of numbers and one naming a version tag.
+ */
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = VersionedAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "VersionedProcess"))
+public class VersionedWorkflowService {
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "1-2")
+  public void upToTwo(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("upToTwo");
+
+  }
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "3")
+  public void three(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("three");
+
+  }
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "release-2026")
+  public void tagged(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("tagged");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/BpmsInitiatedStartTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/BpmsInitiatedStartTest.java
@@ -26,6 +26,7 @@ import io.vanillabp.integration.test.deployment.StartProcessStartEventSource;
 import io.vanillabp.integration.test.deployment.StartWorkflowService;
 import io.vanillabp.integration.test.utils.SuppressOutputExtension;
 import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.WorkflowEnd;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
@@ -122,6 +123,8 @@ public class BpmsInitiatedStartTest {
   public void bpmsInitiatedStartsBuildTheirAggregate() {
 
     final var dummyAdapter = dummyAdapter();
+    // the tests of this class share one application and therefore one store
+    final var aggregatesBefore = persistence.count();
 
     // (a) a timer start without any application code
     final var timerStart = dummyAdapter
@@ -152,7 +155,7 @@ public class BpmsInitiatedStartTest {
         .startWorkflowByBpms(
             MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, "DailyTimer", Map.of("region", "north")));
     assertFalse(repeated.created());
-    assertEquals(1, persistence.count());
+    assertEquals(aggregatesBefore + 1, persistence.count(), "nothing may be created twice");
     assertEquals("changed meanwhile", persistence.stored(TRIGGER_TIME.toString()).getRegion());
 
     // (c) the signal start passes through the application's method
@@ -165,6 +168,55 @@ public class BpmsInitiatedStartTest {
     final var signalAggregate = persistence.stored(signalStart.workflowAggregateId());
     assertEquals("SIGNAL/OrderReceived", signalAggregate.getStartedBy());
     assertEquals("SOUTH", signalAggregate.getRegion());
+
+  }
+
+
+  @Test
+  @DisplayName("The end of a workflow is reported, and only processes asking for it get a listener")
+  public void theEndOfAWorkflowIsReported() {
+
+    final var dummyAdapter = dummyAdapter();
+
+    // the model pays for the notification only where the application asked for one
+    assertEquals(
+        List.of(PROCESS),
+        dummyAdapter.getProcessesWithEndListener(),
+        "an end listener may only be attached where a @WorkflowEnded method exists");
+
+    final var aggregate = new StartAggregate();
+    aggregate.setId("ended-4711");
+    persistence.put(aggregate);
+
+    dummyAdapter
+        .notifyWorkflowEnded(
+            MODULE,
+            PROCESS,
+            new io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext() {
+
+              @Override
+              public String getWorkflowAggregateId() {
+                return "ended-4711";
+              }
+
+              @Override
+              public WorkflowEnd.Kind getKind() {
+                return WorkflowEnd.Kind.TERMINATED;
+              }
+
+              @Override
+              public java.time.Instant getEndTime() {
+                return TRIGGER_TIME;
+              }
+
+              @Override
+              public String getEndEventId() {
+                return null;
+              }
+
+            });
+
+    assertEquals("ended:TERMINATED/null", persistence.stored("ended-4711").getStartedBy());
 
   }
 

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/BpmsInitiatedStartTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/BpmsInitiatedStartTest.java
@@ -1,0 +1,171 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.test.deployment.StartAggregate;
+import io.vanillabp.integration.test.deployment.StartAggregatePersistence;
+import io.vanillabp.integration.test.deployment.StartProcessStartEventSource;
+import io.vanillabp.integration.test.deployment.StartWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Acceptance test of workflows the BPMS starts on its own (story 41) on Quarkus,
+ * with the dummy adapter standing in for a BPMS reporting a timer or signal start:
+ * the aggregate is built without a line of application code, a repeated
+ * notification creates nothing twice, and an optional
+ * <code>&#64;WorkflowStartedByBpms</code> method adds what the application wants.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class BpmsInitiatedStartTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "StartProcess";
+
+  private static final Instant TRIGGER_TIME = Instant.parse("2026-08-12T04:00:00Z");
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("bpms-initiated-start/application.yaml", "application.yaml")
+          .addClass(StartAggregate.class)
+          .addClass(StartAggregatePersistence.class)
+          .addClass(StartWorkflowService.class)
+          .addClass(StartProcessStartEventSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/StartProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  StartAggregatePersistence persistence;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private BpmsInitiatedStartContext context(
+      final BpmsStartTrigger.Kind kind,
+      final String startEventId,
+      final Map<String, Object> variables) {
+
+    return new BpmsInitiatedStartContext() {
+
+      @Override
+      public String getStartEventId() {
+        return startEventId;
+      }
+
+      @Override
+      public BpmsStartTrigger.Kind getKind() {
+        return kind;
+      }
+
+      @Override
+      public Instant getTriggerTime() {
+        return TRIGGER_TIME;
+      }
+
+      @Override
+      public String getSignalName() {
+        return kind == BpmsStartTrigger.Kind.SIGNAL
+            ? "OrderReceived"
+            : null;
+      }
+
+      @Override
+      public Map<String, Object> getVariables() {
+        return variables;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A timer start builds the aggregate, a repeated one changes nothing, a signal start runs the application's method")
+  public void bpmsInitiatedStartsBuildTheirAggregate() {
+
+    final var dummyAdapter = dummyAdapter();
+
+    // (a) a timer start without any application code
+    final var timerStart = dummyAdapter
+        .startWorkflowByBpms(
+            MODULE,
+            PROCESS,
+            context(
+                BpmsStartTrigger.Kind.TIMER,
+                "DailyTimer",
+                Map.of("region", "north", "amount", 42, "notModelled", "ignored")));
+
+    assertTrue(timerStart.created());
+    assertEquals(TRIGGER_TIME.toString(), timerStart.workflowAggregateId());
+    assertEquals(TRIGGER_TIME.toString(), timerStart.variables().get("id"));
+
+    final var timerAggregate = persistence.stored(TRIGGER_TIME.toString());
+    assertNotNull(timerAggregate);
+    assertEquals("north", timerAggregate.getRegion());
+    assertEquals(42, timerAggregate.getAmount());
+    // the application's method serves the SIGNAL start event only
+    assertNull(timerAggregate.getStartedBy());
+
+    // (b) the same timer time reported again: nothing is created twice and business
+    // data written meanwhile survives
+    timerAggregate.setRegion("changed meanwhile");
+    persistence.put(timerAggregate);
+    final var repeated = dummyAdapter
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, "DailyTimer", Map.of("region", "north")));
+    assertFalse(repeated.created());
+    assertEquals(1, persistence.count());
+    assertEquals("changed meanwhile", persistence.stored(TRIGGER_TIME.toString()).getRegion());
+
+    // (c) the signal start passes through the application's method
+    final var signalStart = dummyAdapter
+        .startWorkflowByBpms(
+            MODULE, PROCESS, context(BpmsStartTrigger.Kind.SIGNAL, "SignalStart", Map.of("region", "south")));
+
+    assertTrue(signalStart.created());
+    assertNotEquals(TRIGGER_TIME.toString(), signalStart.workflowAggregateId());
+    final var signalAggregate = persistence.stored(signalStart.workflowAggregateId());
+    assertEquals("SIGNAL/OrderReceived", signalAggregate.getStartedBy());
+    assertEquals("SOUTH", signalAggregate.getRegion());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ProcessVersionsTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ProcessVersionsTest.java
@@ -1,0 +1,143 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.test.deployment.VersionedAggregate;
+import io.vanillabp.integration.test.deployment.VersionedAggregatePersistence;
+import io.vanillabp.integration.test.deployment.VersionedProcessVersionSource;
+import io.vanillabp.integration.test.deployment.VersionedProcessWiringSource;
+import io.vanillabp.integration.test.deployment.VersionedWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Acceptance test of <code>&#64;WorkflowTask(version = ...)</code> on Quarkus (story
+ * 48): the version the adapter reports decides which method serves a delivered task,
+ * ranges made of numbers are compared without asking the BPMS, and a range naming a
+ * version TAG is resolved through the catalog the adapter registered - including the
+ * query for a version this application never deployed itself.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ProcessVersionsTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("process-versions/application.yaml", "application.yaml")
+          .addClass(VersionedAggregate.class)
+          .addClass(VersionedAggregatePersistence.class)
+          .addClass(VersionedWorkflowService.class)
+          .addClass(VersionedProcessWiringSource.class)
+          .addClass(VersionedProcessVersionSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/VersionedProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  VersionedAggregatePersistence persistence;
+
+  @Inject
+  VersionedProcessVersionSource versionSource;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String aggregateId,
+      final String processVersion) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return "versionedTask";
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getProcessVersion() {
+        return processVersion;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("The process version decides which method serves the task, tags included")
+  public void theProcessVersionDecidesWhichMethodServesTheTask() {
+
+    final var dummyAdapter = dummyAdapter();
+
+    // the version tag was resolved while the application booted, once
+    assertEquals(1, versionSource.getQueries());
+
+    persistence.seed("4711");
+    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", "2"));
+    assertEquals("upToTwo", persistence.stored("4711").getServedBy());
+
+    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", "3"));
+    assertEquals("three", persistence.stored("4711").getServedBy());
+
+    // the version carrying the tag - and no further BPMS query for it
+    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", "4"));
+    assertEquals("tagged", persistence.stored("4711").getServedBy());
+    assertEquals(1, versionSource.getQueries());
+
+    // a BPMS which cannot report a version is served by the first method - what
+    // every application not using the attribute relies on
+    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", null));
+    assertEquals("upToTwo", persistence.stored("4711").getServedBy());
+
+    // ANOTHER cluster node deploys version 5 and moves the tag to it: this node has
+    // never seen that version, so it asks the BPMS while the task is dispatched
+    versionSource.deployedElsewhere("5", "release-2026");
+    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", "5"));
+    assertEquals("tagged", persistence.stored("4711").getServedBy());
+    assertTrue(
+        versionSource.getQueries() > 1,
+        "the version deployed by another node was looked up on demand");
+
+    // the version which LOST the tag is served by nobody, and the message names it
+    final var unmatched = assertThrows(
+        IllegalStateException.class,
+        () -> dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", "4")));
+    assertTrue(unmatched.getMessage().contains("process version '4'"), unmatched.getMessage());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/bpms-initiated-start/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/bpms-initiated-start/application.yaml
@@ -1,0 +1,15 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:bpms-initiated-start;DB_CLOSE_DELAY=-1
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/process-versions/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/process-versions/application.yaml
@@ -1,0 +1,9 @@
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyBpmsInitiatedStartSource.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyBpmsInitiatedStartSource.java
@@ -1,0 +1,33 @@
+package io.vanillabp.adapter.dummy.runtime;
+
+import java.util.Collection;
+
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to supply the start
+ * events a BPMS would fire on its own (timer, signal, conditional): the dummy
+ * adapter has no real BPMN model, so a bean of this type stands in for what a real
+ * adapter reads during <code>wireBpmn</code>. If a bean is present, the dummy
+ * adapter reports the start events to the core (which validates the application's
+ * <code>&#64;WorkflowStartedByBpms</code> methods against them); without a bean
+ * nothing is reported.
+ */
+@FunctionalInterface
+public interface DummyBpmsInitiatedStartSource {
+
+  /**
+   * The BPMS-initiated start events of the given BPMN process as a real adapter
+   * would read them from the BPMN model.
+   *
+   * @param adapterId The adapter ID performing the wiring
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return The start events to be reported
+   */
+  Collection<BpmsInitiatedStartSpec> startEventsOf(
+      String adapterId,
+      String workflowModuleId,
+      String bpmnProcessId);
+
+}

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
@@ -9,6 +9,8 @@ import org.slf4j.LoggerFactory;
 
 import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.BpmnParseException;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
@@ -56,13 +58,60 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
    */
   private final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource;
 
+  /**
+   * The core's entry point for workflows which ended, provided by the platform
+   * integration.
+   */
+  private final WorkflowEndedInvoker workflowEndedInvoker;
+
+  /**
+   * Which BPMN processes got an end listener attached - a real adapter modifies its
+   * model here, the dummy records the decision so a test can assert that a process
+   * without a handler pays nothing.
+   */
+  private final java.util.List<String> processesWithEndListener = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+  /**
+   * @return The BPMN processes an end listener was attached to
+   */
+  public java.util.List<String> getProcessesWithEndListener() {
+
+    return java.util.List.copyOf(processesWithEndListener);
+
+  }
+
+  /**
+   * Reports that a workflow ended, like a real adapter does from its process-end
+   * listener. Triggered by integration tests.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification (as a real adapter would build it)
+   */
+  public void notifyWorkflowEnded(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final WorkflowEndedContext context) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Workflow '{}' of {} ended ({})",
+        adapterId,
+        context.getWorkflowAggregateId(),
+        workflowModuleId,
+        context.getKind());
+
+    workflowEndedInvoker.workflowEnded(workflowModuleId, bpmnProcessId, context);
+
+  }
+
   public DummyDeploymentService(
       final String adapterId,
       final Instance<DummyDeploymentListener> listeners,
       final WorkflowTaskInvoker workflowTaskInvoker,
       final Instance<DummyTaskWiringSource> taskWiringSource,
       final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker,
-      final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource) {
+      final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource,
+      final WorkflowEndedInvoker workflowEndedInvoker) {
 
     this.adapterId = adapterId;
     this.listeners = listeners;
@@ -70,6 +119,7 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
     this.taskWiringSource = taskWiringSource;
     this.bpmsInitiatedStartInvoker = bpmsInitiatedStartInvoker;
     this.bpmsInitiatedStartSource = bpmsInitiatedStartSource;
+    this.workflowEndedInvoker = workflowEndedInvoker;
 
   }
 
@@ -227,6 +277,17 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
           bpmsInitiatedStartSource
               .get()
               .startEventsOf(adapterId, workflowModuleId, bpmnProcessId));
+    }
+
+    // like a real adapter: a model pays for the end notification only where the
+    // application asked for one
+    if (workflowEndedInvoker.workflowEndedHandlerExists(workflowModuleId, bpmnProcessId)) {
+      processesWithEndListener.add(bpmnProcessId);
+      log.info(
+          "Dummy-Adapter[{}]: attaching an end listener to BPMN process '{}' of {}",
+          adapterId,
+          bpmnProcessId,
+          workflowModuleId);
     }
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
@@ -9,6 +9,9 @@ import org.slf4j.LoggerFactory;
 
 import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.BpmnParseException;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
 import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
@@ -41,16 +44,57 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
    */
   private final Instance<DummyTaskWiringSource> taskWiringSource;
 
+  /**
+   * The core's entry point for workflows the BPMS starts on its own, provided by the
+   * platform integration.
+   */
+  private final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker;
+
+  /**
+   * Test hook standing in for the start events of the BPMN model (see
+   * {@link DummyBpmsInitiatedStartSource}).
+   */
+  private final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource;
+
   public DummyDeploymentService(
       final String adapterId,
       final Instance<DummyDeploymentListener> listeners,
       final WorkflowTaskInvoker workflowTaskInvoker,
-      final Instance<DummyTaskWiringSource> taskWiringSource) {
+      final Instance<DummyTaskWiringSource> taskWiringSource,
+      final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker,
+      final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource) {
 
     this.adapterId = adapterId;
     this.listeners = listeners;
     this.workflowTaskInvoker = workflowTaskInvoker;
     this.taskWiringSource = taskWiringSource;
+    this.bpmsInitiatedStartInvoker = bpmsInitiatedStartInvoker;
+    this.bpmsInitiatedStartSource = bpmsInitiatedStartSource;
+
+  }
+
+  /**
+   * Reports a workflow the BPMS started on its own, like a real adapter does from a
+   * process-start listener. Triggered by integration tests.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification (as a real adapter would build it)
+   * @return The aggregate's ID and the variables to write back into the BPMS
+   */
+  public BpmsInitiatedStartResult startWorkflowByBpms(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final BpmsInitiatedStartContext context) {
+
+    log.info(
+        "Dummy-Adapter[{}]: The BPMS started '{}' of {} by start event '{}'",
+        adapterId,
+        bpmnProcessId,
+        workflowModuleId,
+        context.getStartEventId());
+
+    return bpmsInitiatedStartInvoker.startWorkflowByBpms(workflowModuleId, bpmnProcessId, context);
 
   }
 
@@ -172,6 +216,17 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
           taskWiringSource
               .get()
               .tasksOf(adapterId, workflowModuleId, bpmnProcessId));
+    }
+
+    // like a real adapter: report the start events the BPMS fires on its own, so the
+    // core can check the application's @WorkflowStartedByBpms methods against them
+    if ((bpmsInitiatedStartSource != null) && bpmsInitiatedStartSource.isResolvable()) {
+      bpmsInitiatedStartInvoker.validateBpmsInitiatedStarts(
+          workflowModuleId,
+          bpmnProcessId,
+          bpmsInitiatedStartSource
+              .get()
+              .startEventsOf(adapterId, workflowModuleId, bpmnProcessId));
     }
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
@@ -65,6 +65,34 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
   private final WorkflowEndedInvoker workflowEndedInvoker;
 
   /**
+   * Test hook standing in for the versions the BPMS deployed (see
+   * {@link DummyProcessVersionSource}).
+   */
+  private final Instance<DummyProcessVersionSource> processVersionSource;
+
+  /**
+   * The versions of the deployed BPMN processes, cached like a real adapter caches
+   * them - the test's {@link DummyProcessVersionSource} plays the BPMS query.
+   */
+  private final io.vanillabp.integration.adapter.spi.version.CachingProcessVersionCatalog processVersions = new io.vanillabp.integration.adapter.spi.version.CachingProcessVersionCatalog(
+      java.time.Duration.ZERO) {
+
+    @Override
+    protected java.util.List<io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion> fetchDeployedVersions(
+        final String workflowModuleId,
+        final String bpmnProcessId) {
+
+      return (processVersionSource == null) || !processVersionSource.isResolvable()
+          ? java.util.List.of()
+          : processVersionSource
+              .get()
+              .versionsOf(adapterId, workflowModuleId, bpmnProcessId);
+
+    }
+
+  };
+
+  /**
    * Which BPMN processes got an end listener attached - a real adapter modifies its
    * model here, the dummy records the decision so a test can assert that a process
    * without a handler pays nothing.
@@ -111,7 +139,8 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
       final Instance<DummyTaskWiringSource> taskWiringSource,
       final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker,
       final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource,
-      final WorkflowEndedInvoker workflowEndedInvoker) {
+      final WorkflowEndedInvoker workflowEndedInvoker,
+      final Instance<DummyProcessVersionSource> processVersionSource) {
 
     this.adapterId = adapterId;
     this.listeners = listeners;
@@ -120,6 +149,7 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
     this.bpmsInitiatedStartInvoker = bpmsInitiatedStartInvoker;
     this.bpmsInitiatedStartSource = bpmsInitiatedStartSource;
     this.workflowEndedInvoker = workflowEndedInvoker;
+    this.processVersionSource = processVersionSource;
 
   }
 
@@ -279,6 +309,13 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
               .startEventsOf(adapterId, workflowModuleId, bpmnProcessId));
     }
 
+    // like a real adapter which can be asked about its deployed versions: hand the
+    // catalog over, so version specifications naming a version tag can be resolved
+    if ((processVersionSource != null) && processVersionSource.isResolvable()) {
+      workflowTaskInvoker
+          .registerProcessVersions(adapterId, workflowModuleId, bpmnProcessId, processVersions);
+    }
+
     // like a real adapter: a model pays for the end notification only where the
     // application asked for one
     if (workflowEndedInvoker.workflowEndedHandlerExists(workflowModuleId, bpmnProcessId)) {
@@ -305,6 +342,10 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
     if ((taskWiringSource != null) && taskWiringSource.isResolvable()) {
       workflowTaskInvoker.validateNoUnwiredWorkflowTaskMethods(workflowModuleId);
     }
+
+    // like a real adapter: the deployment is done, so the version tags named by the
+    // application's annotations can be resolved against what the BPMS has now
+    workflowTaskInvoker.resolveProcessVersions(workflowModuleId);
 
   }
 

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
@@ -46,7 +46,8 @@ public class DummyDeploymentServiceProducer {
       @Any final Instance<DummyDeploymentListener> deploymentListeners,
       final io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry workflowTaskRegistry,
       @Any final Instance<DummyTaskWiringSource> taskWiringSource,
-      @Any final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource) {
+      @Any final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource,
+      @Any final Instance<DummyProcessVersionSource> processVersionSource) {
 
     return properties
         .adapterTypes()
@@ -57,7 +58,7 @@ public class DummyDeploymentServiceProducer {
         .sorted()
         .<AdapterDeploymentService<Object, Object>>map(
             adapterId -> new DummyDeploymentService(
-                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource, workflowTaskRegistry))
+                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource, workflowTaskRegistry, processVersionSource))
         .toList();
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
@@ -57,7 +57,7 @@ public class DummyDeploymentServiceProducer {
         .sorted()
         .<AdapterDeploymentService<Object, Object>>map(
             adapterId -> new DummyDeploymentService(
-                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource))
+                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource, workflowTaskRegistry))
         .toList();
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
@@ -45,7 +45,8 @@ public class DummyDeploymentServiceProducer {
       final MigrationAdapterProperties properties,
       @Any final Instance<DummyDeploymentListener> deploymentListeners,
       final io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry workflowTaskRegistry,
-      @Any final Instance<DummyTaskWiringSource> taskWiringSource) {
+      @Any final Instance<DummyTaskWiringSource> taskWiringSource,
+      @Any final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource) {
 
     return properties
         .adapterTypes()
@@ -55,7 +56,8 @@ public class DummyDeploymentServiceProducer {
         .map(Map.Entry::getKey)
         .sorted()
         .<AdapterDeploymentService<Object, Object>>map(
-            adapterId -> new DummyDeploymentService(adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource))
+            adapterId -> new DummyDeploymentService(
+                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource))
         .toList();
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyPhaseTwoListener.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyPhaseTwoListener.java
@@ -137,4 +137,19 @@ public interface DummyPhaseTwoListener {
       final boolean phaseTwo) {
   }
 
+  /**
+   * Called whenever a changed workflow-aggregate is pushed to the BPMS - in phase
+   * one for an adapter without a two-phase commit, in phase two for one with it.
+   *
+   * @param workflowAggregateId The ID of the workflow aggregate
+   * @param taskId The task whose scope received the values, or <code>null</code>
+   *        for the workflow's global scope
+   * @param phaseTwo Whether this was phase two (after the commit)
+   */
+  default void aggregateChanged(
+      final Object workflowAggregateId,
+      final String taskId,
+      final boolean phaseTwo) {
+  }
+
 }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyPhaseTwoListener.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyPhaseTwoListener.java
@@ -124,4 +124,17 @@ public interface DummyPhaseTwoListener {
       final String messageName) {
   }
 
+
+  /**
+   * Called whenever a signal is broadcast - in phase one for an adapter without a
+   * two-phase commit, in phase two for one with it.
+   *
+   * @param signalName The PLAIN BPMN signal name
+   * @param phaseTwo Whether this was phase two (after the commit)
+   */
+  default void broadcastSignal(
+      final String signalName,
+      final boolean phaseTwo) {
+  }
+
 }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyProcessVersionSource.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyProcessVersionSource.java
@@ -1,0 +1,32 @@
+package io.vanillabp.adapter.dummy.runtime;
+
+import java.util.List;
+
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to supply the deployed
+ * versions of a BPMN process: the dummy adapter has no BPMS to ask, so a bean of this
+ * type stands in for what a real adapter queries from its BPMS. If a bean is present,
+ * the dummy adapter registers a version catalog with the core
+ * ({@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#registerProcessVersions}),
+ * which is what makes <code>version = "release-2024"</code> work; without a bean the
+ * dummy adapter reports no versions at all, like a BPMS which cannot tell.
+ */
+@FunctionalInterface
+public interface DummyProcessVersionSource {
+
+  /**
+   * The deployed versions of the given BPMN process, oldest first.
+   *
+   * @param adapterId The adapter ID being asked
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return The deployed versions
+   */
+  List<DeployedProcessVersion> versionsOf(
+      String adapterId,
+      String workflowModuleId,
+      String bpmnProcessId);
+
+}

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
@@ -259,6 +259,40 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
   }
 
   @Override
+  public void aggregateChangedPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final A workflowAggregate,
+      final String taskId) {
+
+    // like an embedded BPMS: without a two-phase commit the push happens here
+    if (!needsTwoPhaseCommitForStartingWorkflows && (phaseTwoListeners != null)) {
+      final var aggregateId = aggregatePersistence.getAggregateId(workflowAggregate);
+      phaseTwoListeners
+          .stream()
+          .forEach(listener -> listener.aggregateChanged(aggregateId, taskId, false));
+    }
+
+  }
+
+  @Override
+  public void aggregateChangedPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    if (phaseTwoListeners != null) {
+      phaseTwoListeners
+          .stream()
+          .forEach(listener -> listener.aggregateChanged(workflowAggregateId, taskId, true));
+    }
+
+  }
+
+  @Override
   public void correlateMessagePhaseOne(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
@@ -230,6 +230,35 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
   }
 
   @Override
+  public void sendSignalPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    // like an embedded BPMS: without a two-phase commit the broadcast happens here
+    if (!needsTwoPhaseCommitForStartingWorkflows && (phaseTwoListeners != null)) {
+      phaseTwoListeners
+          .stream()
+          .forEach(listener -> listener.broadcastSignal(signalName, false));
+    }
+
+  }
+
+  @Override
+  public void sendSignalPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    if (phaseTwoListeners != null) {
+      phaseTwoListeners
+          .stream()
+          .forEach(listener -> listener.broadcastSignal(signalName, true));
+    }
+
+  }
+
+  @Override
   public void correlateMessagePhaseOne(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/RecordingPhaseTwoListener.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/RecordingPhaseTwoListener.java
@@ -234,6 +234,30 @@ public class RecordingPhaseTwoListener implements DummyPhaseTwoListener {
 
   }
 
+  /**
+   * Recorded pushes of a changed aggregate as "aggregateId:taskId:phase" (the task
+   * id may be the literal "null" - that is the workflow's global scope).
+   */
+  private final List<String> aggregateChanges = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void aggregateChanged(
+      final Object workflowAggregateId,
+      final String taskId,
+      final boolean phaseTwo) {
+
+    aggregateChanges.add("%s:%s:%s".formatted(workflowAggregateId, taskId, phaseTwo
+        ? "phase-two"
+        : "phase-one"));
+
+  }
+
+  public List<String> getAggregateChanges() {
+
+    return List.copyOf(aggregateChanges);
+
+  }
+
   public void failNextDispatches(
       final int numberOfFailures) {
 
@@ -258,6 +282,7 @@ public class RecordingPhaseTwoListener implements DummyPhaseTwoListener {
     canceledUserTasks.clear();
     correlatedMessages.clear();
     startedByMessage.clear();
+    aggregateChanges.clear();
     failuresRemaining.set(0);
 
   }

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/RecordingPhaseTwoListener.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/RecordingPhaseTwoListener.java
@@ -47,6 +47,29 @@ public class RecordingPhaseTwoListener implements DummyPhaseTwoListener {
 
   }
 
+  /**
+   * The signals broadcast so far, as "signalName/phase" - a broadcast of a remote
+   * BPMS may only happen in phase two, after the commit.
+   */
+  private final List<String> broadcastSignals = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void broadcastSignal(
+      final String signalName,
+      final boolean phaseTwo) {
+
+    broadcastSignals.add("%s/%s".formatted(signalName, phaseTwo
+        ? "phase-two"
+        : "phase-one"));
+
+  }
+
+  public List<String> getBroadcastSignals() {
+
+    return List.copyOf(broadcastSignals);
+
+  }
+
   public List<String> getStartedByAdapter() {
 
     return List.copyOf(startedByAdapter);

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/SampleExtension.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/SampleExtension.java
@@ -1,0 +1,143 @@
+package io.vanillabp.integration.test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Inject;
+
+/**
+ * Stands in for a real VanillaBP extension (e.g. the Business Cockpit) using the
+ * outbox for its own crash-safe after-commit work: it registers an operation of its
+ * own in the {@link PhaseTwoOperationRegistry} at startup and records the calls
+ * dispatched to it.
+ * <p>
+ * Everything an extension needs is used here: a namespaced operation name, an
+ * idempotency key of its own making, arguments travelling with the call and a
+ * dispatch which is NOT routed through the aggregate-to-adapter election of the
+ * core operations.
+ */
+@ApplicationScoped
+public class SampleExtension {
+
+  public static final String OPERATION_NAME = "sample-extension:NOTIFY";
+
+  public static final String ARG_EVENT = "event";
+
+  /**
+   * The operation contributed by this extension: deduplicated per workflow
+   * aggregate AND event, so the same event is published at most once while
+   * different events of the same workflow are all published.
+   */
+  public static final PhaseTwoOperation OPERATION = PhaseTwoOperation
+      .extensionOperation(
+          OPERATION_NAME,
+          call -> Optional
+              .of(
+                  "%s|%s|%s|%s".formatted(
+                      call.workflowModuleId(),
+                      call.bpmnProcessId(),
+                      call.workflowAggregateId(),
+                      call.args().get(ARG_EVENT))));
+
+  @Inject
+  PhaseTwoOperationRegistry registry;
+
+  private final List<PhaseTwoCall> dispatched = new CopyOnWriteArrayList<>();
+
+  private volatile int failNextDispatches;
+
+  void onStart(
+      @Observes final StartupEvent event) {
+
+    registry
+        .register(
+            OPERATION,
+            (
+                call,
+                previouslyAttempted) -> {
+              if (failNextDispatches > 0) {
+                failNextDispatches--;
+                throw new RuntimeException("test dispatch failure");
+              }
+              dispatched.add(call);
+            });
+
+  }
+
+  /**
+   * Builds a call of this extension's operation - what the extension would
+   * schedule inside the business transaction.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowAggregateId The aggregate's ID in serialized form
+   * @param event The event to be published
+   * @return The call to be scheduled
+   */
+  public static PhaseTwoCall call(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String event) {
+
+    return PhaseTwoCall
+        .of(
+            OPERATION, workflowModuleId, bpmnProcessId, workflowAggregateId, null, Map.of(ARG_EVENT, event));
+
+  }
+
+  public List<PhaseTwoCall> getDispatched() {
+
+    return dispatched;
+
+  }
+
+  public void reset() {
+
+    dispatched.clear();
+    failNextDispatches = 0;
+
+  }
+
+  public void failNextDispatches(
+      final int count) {
+
+    failNextDispatches = count;
+
+  }
+
+  /**
+   * Waits until the given number of calls was dispatched.
+   *
+   * @param count The number of calls awaited
+   * @param timeoutMillis The maximum time to wait
+   * @return The dispatched calls
+   * @throws InterruptedException If interrupted while waiting
+   */
+  public List<PhaseTwoCall> awaitDispatched(
+      final int count,
+      final long timeoutMillis) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + timeoutMillis;
+    while (dispatched.size() < count) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError(
+            "Only %d of %d expected extension-operation dispatches happened".formatted(
+                dispatched.size(),
+                count));
+      }
+      Thread.sleep(50);
+    }
+    return List.copyOf(dispatched);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/WorkflowService.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/WorkflowService.java
@@ -68,6 +68,21 @@ public class WorkflowService {
 
   }
 
+  public Aggregate aggregateChanged(
+      final Aggregate aggregate) {
+
+    return processService.aggregateChanged(aggregate);
+
+  }
+
+  public Aggregate aggregateChanged(
+      final Aggregate aggregate,
+      final String taskId) {
+
+    return processService.aggregateChanged(aggregate, taskId);
+
+  }
+
   public Aggregate startWorkflowByMessage(
       final String content,
       final String messageName) {

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/WorkflowService.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/main/java/io/vanillabp/integration/test/WorkflowService.java
@@ -119,4 +119,18 @@ public class WorkflowService {
 
   }
 
+
+  /**
+   * Broadcasts a signal - a broadcast is not addressed to a workflow, so no
+   * aggregate is involved.
+   *
+   * @param signalName The BPMN signal name
+   */
+  public void sendSignal(
+      final String signalName) {
+
+    processService.sendSignal(signalName);
+
+  }
+
 }

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateChangedTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateChangedTest.java
@@ -1,0 +1,170 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.SteerableTaskAwarenessSource;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * Pushing a changed workflow-aggregate on Quarkus (story 44) with the dummy adapter
+ * forced to require a two-phase commit: a REMOTE BPMS is written to after the local
+ * transaction was committed, so the push rides an outbox entry. What this pins: the
+ * task id travels in the entry's ARGS, the entry carries no idempotency key (the
+ * values are read at dispatch time) and a rollback pushes nothing at all.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregateChangedTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("aggregate-changed.yaml", "application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addClass(SteerableTaskAwarenessSource.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  private static final String COUNT_ENTRIES = "SELECT COUNT(*) FROM VANILLABP_PHASE_TWO_OUTBOX "
+      + "WHERE OPERATION = 'AGGREGATE_CHANGED'";
+
+  @Inject
+  WorkflowService workflowService;
+
+  @Inject
+  RecordingPhaseTwoListener listener;
+
+  @Inject
+  SteerableTaskAwarenessSource awareness;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  DataSource dataSource;
+
+  private long count(
+      final String query) throws Exception {
+
+    try (var connection = dataSource.getConnection(); var statement = connection
+        .createStatement(); var resultSet = statement.executeQuery(query)) {
+      resultSet.next();
+      return resultSet.getLong(1);
+    }
+
+  }
+
+  private Aggregate startedAggregate(
+      final String content) throws Exception {
+
+    awareness.answerWith(WorkflowAwareness.UNKNOWN_TO_BPMS);
+    userTransaction.begin();
+    try {
+      final var aggregate = workflowService.startWorkflow(content);
+      userTransaction.commit();
+      listener.awaitInvocations(1, 10000);
+      awareness.answerWith(WorkflowAwareness.ACTIVE);
+      return aggregate;
+    } catch (final Exception e) {
+      userTransaction.rollback();
+      throw e;
+    }
+
+  }
+
+  @Test
+  @DisplayName("Both scopes dispatch after the commit, and neither entry has an idempotency key")
+  public void bothScopesDispatchAfterTheCommit() throws Exception {
+
+    final var aggregate = startedAggregate("aggregate-changed");
+
+    userTransaction.begin();
+    try {
+      workflowService.aggregateChanged(aggregate);
+      workflowService.aggregateChanged(aggregate, "task-1");
+      // repeating the very same push writes the then-current state again - nothing
+      // is deduplicated, on purpose
+      workflowService.aggregateChanged(aggregate, "task-1");
+      assertEquals(3, count(COUNT_ENTRIES));
+      assertTrue(listener.getAggregateChanges().isEmpty(), "nothing may be pushed before the commit");
+      userTransaction.commit();
+    } catch (final Exception e) {
+      userTransaction.rollback();
+      throw e;
+    }
+
+    final var deadline = System.currentTimeMillis() + 15000;
+    while (listener.getAggregateChanges().size() < 3) {
+      assertTrue(
+          System.currentTimeMillis() < deadline,
+          "the pushes were not dispatched in time: "
+              + listener.getAggregateChanges());
+      Thread.sleep(50);
+    }
+
+    assertEquals(
+        1,
+        listener
+            .getAggregateChanges()
+            .stream()
+            .filter(entry -> entry.equals(aggregate.getId()
+                + ":null:phase-two"))
+            .count(),
+        "the global push carries no task id");
+    assertEquals(
+        2,
+        listener
+            .getAggregateChanges()
+            .stream()
+            .filter(entry -> entry.equals(aggregate.getId()
+                + ":task-1:phase-two"))
+            .count(),
+        "the task id travels, and identical pushes are not deduplicated");
+
+    assertEquals(
+        3,
+        count(
+            "SELECT COUNT(*) FROM VANILLABP_PHASE_TWO_OUTBOX WHERE OPERATION = 'AGGREGATE_CHANGED' "
+                + "AND IDEMPOTENCY_KEY IS NULL"));
+
+  }
+
+  @Test
+  @DisplayName("On rollback the entry is gone and nothing is pushed")
+  public void rollbackPushesNothing() throws Exception {
+
+    final var aggregate = startedAggregate("rolled-back");
+    final var entriesBefore = count(COUNT_ENTRIES);
+    final var pushesBefore = listener.getAggregateChanges().size();
+
+    userTransaction.begin();
+    workflowService.aggregateChanged(aggregate);
+    assertEquals(entriesBefore + 1, count(COUNT_ENTRIES));
+    userTransaction.rollback();
+
+    assertEquals(entriesBefore, count(COUNT_ENTRIES));
+
+    // wait longer than the poll interval: nothing may ever be pushed
+    Thread.sleep(1500);
+    assertEquals(pushesBefore, listener.getAggregateChanges().size());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/ExtensionOperationDispatchTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/ExtensionOperationDispatchTest.java
@@ -1,0 +1,191 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.SampleExtension;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * The outbox is open to extensions: an operation registered by
+ * {@link SampleExtension} is scheduled inside the business transaction, dispatched
+ * to the extension's own handler after the commit, deduplicated by the extension's
+ * own idempotency key and retried when the handler fails - the same guarantees the
+ * core operations get, without any core code knowing the operation.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ExtensionOperationDispatchTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          // an own database: the sibling tests of this module count rows of the
+          // outbox store they share within the JVM
+          .addAsResource("extension-operation.yaml", "application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addClass(SampleExtension.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  private static final String COUNT_ENTRIES_OF_OPERATION = "SELECT COUNT(*) FROM VANILLABP_PHASE_TWO_OUTBOX "
+      + "WHERE OPERATION = '%s'".formatted(SampleExtension.OPERATION_NAME);
+
+  @Inject
+  WorkflowService workflowService;
+
+  @Inject
+  SampleExtension extension;
+
+  @Inject
+  PhaseTwoOutbox outbox;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  DataSource dataSource;
+
+  @BeforeEach
+  public void resetExtension() {
+
+    extension.reset();
+
+  }
+
+  private long count(
+      final String query) throws Exception {
+
+    try (var connection = dataSource.getConnection(); var statement = connection
+        .createStatement(); var resultSet = statement.executeQuery(query)) {
+      resultSet.next();
+      return resultSet.getLong(1);
+    }
+
+  }
+
+  private Aggregate startWorkflowAndSchedule(
+      final String content,
+      final String event) throws Exception {
+
+    userTransaction.begin();
+    final Aggregate attached;
+    try {
+      attached = workflowService.startWorkflow(content);
+      outbox
+          .schedule(
+              SampleExtension.call("test-module", "dummy", attached.getId().toString(), event));
+    } catch (final Exception e) {
+      userTransaction.rollback();
+      throw e;
+    }
+    userTransaction.commit();
+    return attached;
+
+  }
+
+  @Test
+  @DisplayName("An extension's operation is dispatched to the extension after the commit")
+  public void extensionOperationIsDispatchedAfterCommit() throws Exception {
+
+    final var aggregate = startWorkflowAndSchedule("extension-dispatch", "created");
+    assertNotNull(aggregate.getId());
+
+    final var dispatched = extension.awaitDispatched(1, 10000);
+    final var call = dispatched.getFirst();
+    assertEquals(SampleExtension.OPERATION_NAME, call.operation());
+    assertEquals(aggregate.getId().toString(), call.workflowAggregateId());
+    // the arguments travel with the entry - the store persists them without ever
+    // interpreting them
+    assertEquals("created", call.args().get(SampleExtension.ARG_EVENT));
+
+    // the entry is stored under the extension's operation NAME (the store knows
+    // nothing else about it)
+    assertTrue(count(COUNT_ENTRIES_OF_OPERATION) > 0);
+
+  }
+
+  @Test
+  @DisplayName("The extension's own idempotency key deduplicates its entries")
+  public void extensionOperationIsDeduplicatedByItsOwnKey() throws Exception {
+
+    final var aggregate = startWorkflowAndSchedule("extension-dedup", "created");
+    extension.awaitDispatched(1, 10000);
+
+    // same aggregate, same event: the key repeats, so scheduling is a no-op
+    userTransaction.begin();
+    final var scheduledAgain = outbox
+        .schedule(
+            SampleExtension.call("test-module", "dummy", aggregate.getId().toString(), "created"));
+    userTransaction.commit();
+    assertFalse(scheduledAgain);
+
+    // a DIFFERENT event of the same workflow is a different key and is dispatched
+    userTransaction.begin();
+    outbox
+        .schedule(
+            SampleExtension.call("test-module", "dummy", aggregate.getId().toString(), "completed"));
+    userTransaction.commit();
+
+    final var dispatched = extension.awaitDispatched(2, 10000);
+    assertEquals("created", dispatched.get(0).args().get(SampleExtension.ARG_EVENT));
+    assertEquals("completed", dispatched.get(1).args().get(SampleExtension.ARG_EVENT));
+
+  }
+
+  @Test
+  @DisplayName("A failing extension dispatch is retried")
+  public void failingExtensionDispatchIsRetried() throws Exception {
+
+    extension.failNextDispatches(1);
+
+    final var aggregate = startWorkflowAndSchedule("extension-retry", "created");
+
+    // the first attempt threw, the retry succeeds
+    final var dispatched = extension.awaitDispatched(1, 10000);
+    assertEquals(aggregate.getId().toString(), dispatched.getFirst().workflowAggregateId());
+
+  }
+
+  @Test
+  @DisplayName("On rollback the extension's entry is gone and never dispatched")
+  public void rollbackLeavesNoExtensionEntry() throws Exception {
+
+    final var entriesBefore = count(COUNT_ENTRIES_OF_OPERATION);
+
+    userTransaction.begin();
+    final var attached = workflowService.startWorkflow("extension-rollback");
+    outbox
+        .schedule(
+            SampleExtension.call("test-module", "dummy", attached.getId().toString(), "rolled-back"));
+    userTransaction.rollback();
+
+    // the entry rode the rolled-back transaction
+    assertEquals(entriesBefore, count(COUNT_ENTRIES_OF_OPERATION));
+
+    // wait longer than the poll interval: nothing may ever be dispatched
+    Thread.sleep(1500);
+    assertTrue(extension.getDispatched().isEmpty());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/SendSignalTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/SendSignalTest.java
@@ -1,0 +1,127 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * Broadcasting a BPMN signal on Quarkus (story 42) with the dummy adapter forced to
+ * require a two-phase commit: the broadcast of a REMOTE BPMS may only happen after
+ * the local transaction was committed, which is what the outbox entry is for. A
+ * rolled-back transaction broadcasts nothing at all.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SendSignalTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("send-signal.yaml", "application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  private static final String COUNT_SIGNAL_ENTRIES = "SELECT COUNT(*) FROM VANILLABP_PHASE_TWO_OUTBOX "
+      + "WHERE OPERATION = 'SEND_SIGNAL'";
+
+  @Inject
+  WorkflowService workflowService;
+
+  @Inject
+  RecordingPhaseTwoListener listener;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  DataSource dataSource;
+
+  private long count(
+      final String query) throws Exception {
+
+    try (var connection = dataSource.getConnection(); var statement = connection
+        .createStatement(); var resultSet = statement.executeQuery(query)) {
+      resultSet.next();
+      return resultSet.getLong(1);
+    }
+
+  }
+
+  private List<String> awaitBroadcast(
+      final int count) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + 10_000;
+    while (listener.getBroadcastSignals().size() < count) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError(
+            "only %d of %d broadcasts happened".formatted(listener.getBroadcastSignals().size(), count));
+      }
+      Thread.sleep(50);
+    }
+    return listener.getBroadcastSignals();
+
+  }
+
+  @Test
+  @DisplayName("A remote BPMS broadcasts after the commit, through an outbox entry carrying no aggregate")
+  public void broadcastHappensAfterTheCommit() throws Exception {
+
+    userTransaction.begin();
+    workflowService.sendSignal("OrderReceived");
+    // the entry rides the transaction; nothing was broadcast yet
+    assertEquals(1, count(COUNT_SIGNAL_ENTRIES));
+    assertTrue(listener.getBroadcastSignals().isEmpty());
+    userTransaction.commit();
+
+    final var broadcast = awaitBroadcast(1);
+    assertEquals(List.of("OrderReceived/phase-two"), broadcast);
+
+    // the entry has no aggregate: a broadcast is not about one workflow
+    assertEquals(
+        1,
+        count(
+            "SELECT COUNT(*) FROM VANILLABP_PHASE_TWO_OUTBOX WHERE OPERATION = 'SEND_SIGNAL' "
+                + "AND AGGREGATE_ID IS NULL"));
+
+  }
+
+  @Test
+  @DisplayName("On rollback the entry is gone and nothing is broadcast")
+  public void rollbackBroadcastsNothing() throws Exception {
+
+    final var entriesBefore = count(COUNT_SIGNAL_ENTRIES);
+    final var broadcastsBefore = listener.getBroadcastSignals().size();
+
+    userTransaction.begin();
+    workflowService.sendSignal("RolledBack");
+    assertEquals(entriesBefore + 1, count(COUNT_SIGNAL_ENTRIES));
+    userTransaction.rollback();
+
+    assertEquals(entriesBefore, count(COUNT_SIGNAL_ENTRIES));
+
+    // wait longer than the poll interval: nothing may ever be broadcast
+    Thread.sleep(1500);
+    assertEquals(broadcastsBefore, listener.getBroadcastSignals().size());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/aggregate-changed.yaml
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/aggregate-changed.yaml
@@ -1,0 +1,20 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:outbox-aggregate-changed;DB_CLOSE_DELAY=-1
+dummy-adapter:
+  two-phase-commit: true
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  outbox:
+    poll-interval: PT0.5S
+    attempt-frequency: PT0.5S

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/extension-operation.yaml
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/extension-operation.yaml
@@ -1,0 +1,20 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:outbox-extension-operation;DB_CLOSE_DELAY=-1
+dummy-adapter:
+  two-phase-commit: true
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  outbox:
+    poll-interval: PT0.5S
+    attempt-frequency: PT0.5S

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/send-signal.yaml
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/send-signal.yaml
@@ -1,0 +1,20 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:outbox-send-signal;DB_CLOSE_DELAY=-1
+dummy-adapter:
+  two-phase-commit: true
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  outbox:
+    poll-interval: PT0.5S
+    attempt-frequency: PT0.5S

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutbox.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutbox.java
@@ -124,7 +124,7 @@ public class JdbcPhaseTwoOutbox implements PhaseTwoOutbox {
       statement.setString(1, UUID.randomUUID().toString());
       statement.setString(2, call.workflowModuleId());
       statement.setString(3, call.bpmnProcessId());
-      statement.setString(4, call.operation().name());
+      statement.setString(4, call.operation());
       statement.setString(5, call.workflowAggregateId());
       statement.setString(6, call.adapterId());
       statement.setString(7, PhaseTwoCall.serializeArgs(call.args()));

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
@@ -405,23 +405,20 @@ public class JdbcPhaseTwoOutboxDispatcher {
       final Entry entry) throws SQLException {
 
     try {
-      final PhaseTwoOperation operation;
-      try {
-        operation = PhaseTwoOperation.valueOf(entry.operation());
-      } catch (IllegalArgumentException e) {
-        throw new IllegalStateException(
-            "Unknown operation '%s' of outbox entry '%s'! Maybe it was written by a newer version of your software?"
-                .formatted(entry.operation(), entry.id()));
-      }
       // entry.attempts() holds the count BEFORE this claim - a value > 0 means the
       // entry was dispatched before (recovered/retried): the router then runs the
-      // START re-dispatch mitigation
+      // START re-dispatch mitigation. The operation travels as its persisted name -
+      // the router resolves it in the operation registry (an unknown name yields a
+      // guiding error and leaves the entry for operations)
       phaseTwoRouter
           .get()
           .dispatch(
-              new PhaseTwoCall(
-                  operation, entry.workflowModuleId(), entry.bpmnProcessId(), entry.aggregateId(), entry
-                      .adapterId(), PhaseTwoCall.deserializeArgs(entry.serializedArgs())),
+              PhaseTwoCall
+                  .forDispatch(
+                      entry.operation(), entry.workflowModuleId(), entry.bpmnProcessId(), entry
+                          .aggregateId(),
+                      entry.adapterId(), PhaseTwoCall
+                          .deserializeArgs(entry.serializedArgs())),
               entry.attempts() > 0);
     } catch (Exception e) {
       if (entry.attempts() + 1 >= properties.getBlockAfterAttempts()) {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutbox.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutbox.java
@@ -99,7 +99,7 @@ public class MongoPhaseTwoOutbox implements PhaseTwoOutbox {
         .append("_id", entryId)
         .append("workflowModuleId", call.workflowModuleId())
         .append("bpmnProcessId", call.bpmnProcessId())
-        .append("operation", call.operation().name())
+        .append("operation", call.operation())
         .append("aggregateId", call.workflowAggregateId())
         .append("adapterId", call.adapterId())
         .append("args", new Document(new java.util.LinkedHashMap<String, Object>(call.args())))

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutboxDispatcher.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutboxDispatcher.java
@@ -26,7 +26,6 @@ import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
 import io.vanillabp.integration.runtime.deployment.VanillaBpDeploymentRunner;
 import io.vanillabp.integration.spi.PhaseTwoCall;
-import io.vanillabp.integration.spi.PhaseTwoOperation;
 import jakarta.annotation.PreDestroy;
 import jakarta.annotation.Priority;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -241,14 +240,6 @@ public class MongoPhaseTwoOutboxDispatcher {
 
     final var entryId = entry.getString("_id");
     try {
-      final PhaseTwoOperation operation;
-      try {
-        operation = PhaseTwoOperation.valueOf(entry.getString("operation"));
-      } catch (final IllegalArgumentException e) {
-        throw new IllegalStateException(
-            "Unknown operation '%s' of outbox entry '%s'! Maybe it was written by a newer version of your software?"
-                .formatted(entry.getString("operation"), entryId));
-      }
       final var argsDocument = entry.get("args", Document.class);
       final Map<String, String> args = new LinkedHashMap<>();
       if (argsDocument != null) {
@@ -258,13 +249,18 @@ public class MongoPhaseTwoOutboxDispatcher {
       }
       // the document holds the attempts count BEFORE this claim - a value > 0
       // means the entry was dispatched before (recovered/retried): the router
-      // then runs the START re-dispatch mitigation
+      // then runs the START re-dispatch mitigation. The operation travels as its
+      // persisted name and is resolved by the router's operation registry
       phaseTwoRouter
           .get()
           .dispatch(
-              new PhaseTwoCall(
-                  operation, entry.getString("workflowModuleId"), entry.getString("bpmnProcessId"), entry
-                      .getString("aggregateId"), entry.getString("adapterId"), args),
+              PhaseTwoCall
+                  .forDispatch(
+                      entry.getString("operation"), entry.getString("workflowModuleId"), entry
+                          .getString("bpmnProcessId"),
+                      entry.getString("aggregateId"), entry
+                          .getString("adapterId"),
+                      args),
               entry.getInteger("attempts") > 0);
       collection.updateOne(
           Filters.eq("_id", entryId),

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
@@ -1,6 +1,7 @@
 package io.vanillabp.integration.runtime.processservice;
 
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
+import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
@@ -19,6 +20,23 @@ public class PhaseTwoRouterProducer {
   public PhaseTwoRouter phaseTwoRouter() {
 
     return new PhaseTwoRouter();
+
+  }
+
+  /**
+   * The router's registry of phase-two operations - injectable so an extension can
+   * register operations of its own (VanillaBP's core operations are registered by
+   * the router itself).
+   *
+   * @param phaseTwoRouter The router owning the registry
+   * @return The operation registry
+   */
+  @Produces
+  @Singleton
+  public PhaseTwoOperationRegistry phaseTwoOperationRegistry(
+      final PhaseTwoRouter phaseTwoRouter) {
+
+    return phaseTwoRouter.getOperations();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -336,6 +336,18 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   }
 
   @Override
+  public void sendSignal(
+      final String signalName) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionExceptionForSignal();
+    }
+
+    migrationProcessService.sendSignal(signalName);
+
+  }
+
+  @Override
   public A correlateMessage(
       final A workflowAggregate,
       final String messageName) {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -348,6 +348,38 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   }
 
   @Override
+  public A aggregateChanged(
+      final A workflowAggregate) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionException();
+    }
+
+    return migrationProcessService.aggregateChanged(workflowAggregate, null);
+
+  }
+
+  @Override
+  public A aggregateChanged(
+      final A workflowAggregate,
+      final String taskId) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionException();
+    }
+    if ((taskId == null) || taskId.isBlank()) {
+      throw new IllegalArgumentException(
+          """
+              No task-id given! Use aggregateChanged(aggregate) to push the aggregate at the \
+              workflow's global scope, or pass the task-id reported to the @TaskId parameter of the \
+              task whose scope should receive the values.""");
+    }
+
+    return migrationProcessService.aggregateChanged(workflowAggregate, taskId);
+
+  }
+
+  @Override
   public A correlateMessage(
       final A workflowAggregate,
       final String messageName) {

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.BeanRegistry;
 import org.springframework.core.env.Environment;
 
 import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyBpmsInitiatedStartSource;
 import io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource;
 import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterPhaseTwoListener;
 import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
@@ -59,7 +60,9 @@ public class DummyAdapterBeanRegistrar implements BeanRegistrar {
               DeploymentService.class,
               spec -> spec.supplier(supplierContext -> new DeploymentService(
                   adapterId, supplierContext.bean(WorkflowTaskRegistry.class), supplierContext
-                      .beanProvider(DummyTaskWiringSource.class))));
+                      .beanProvider(DummyTaskWiringSource.class), supplierContext
+                          .bean(WorkflowTaskRegistry.class), supplierContext
+                              .beanProvider(DummyBpmsInitiatedStartSource.class))));
 
         });
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
@@ -63,7 +63,9 @@ public class DummyAdapterBeanRegistrar implements BeanRegistrar {
                       .beanProvider(DummyTaskWiringSource.class), supplierContext
                           .bean(WorkflowTaskRegistry.class), supplierContext
                               .beanProvider(DummyBpmsInitiatedStartSource.class), supplierContext
-                                  .bean(WorkflowTaskRegistry.class))));
+                                  .bean(WorkflowTaskRegistry.class), supplierContext
+                                      .beanProvider(
+                                          io.vanillabp.adapter.dummy.springboot.deployment.DummyProcessVersionSource.class))));
 
         });
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
@@ -62,7 +62,8 @@ public class DummyAdapterBeanRegistrar implements BeanRegistrar {
                   adapterId, supplierContext.bean(WorkflowTaskRegistry.class), supplierContext
                       .beanProvider(DummyTaskWiringSource.class), supplierContext
                           .bean(WorkflowTaskRegistry.class), supplierContext
-                              .beanProvider(DummyBpmsInitiatedStartSource.class))));
+                              .beanProvider(DummyBpmsInitiatedStartSource.class), supplierContext
+                                  .bean(WorkflowTaskRegistry.class))));
 
         });
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
@@ -9,6 +9,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
 import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.BpmnParseException;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
@@ -45,6 +47,52 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
    * {@link DummyBpmsInitiatedStartSource}).
    */
   private final ObjectProvider<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource;
+
+  /**
+   * The core's entry point for workflows which ended, provided by the platform
+   * integration.
+   */
+  private final WorkflowEndedInvoker workflowEndedInvoker;
+
+  /**
+   * Which BPMN processes got an end listener attached - a real adapter modifies its
+   * model here, the dummy records the decision so a test can assert that a process
+   * without a handler pays nothing.
+   */
+  private final java.util.List<String> processesWithEndListener = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+  /**
+   * @return The BPMN processes an end listener was attached to
+   */
+  public java.util.List<String> getProcessesWithEndListener() {
+
+    return java.util.List.copyOf(processesWithEndListener);
+
+  }
+
+  /**
+   * Reports that a workflow ended, like a real adapter does from its process-end
+   * listener. Triggered by integration tests.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification (as a real adapter would build it)
+   */
+  public void notifyWorkflowEnded(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final WorkflowEndedContext context) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Workflow '{}' of {} ended ({})",
+        adapterId,
+        context.getWorkflowAggregateId(),
+        workflowModuleId,
+        context.getKind());
+
+    workflowEndedInvoker.workflowEnded(workflowModuleId, bpmnProcessId, context);
+
+  }
 
   @Override
   public Class<Object> getModelType() {
@@ -135,6 +183,17 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
             workflowModuleId,
             bpmnProcessId,
             source.startEventsOf(adapterId, workflowModuleId, bpmnProcessId)));
+
+    // like a real adapter: a model pays for the end notification only where the
+    // application asked for one
+    if (workflowEndedInvoker.workflowEndedHandlerExists(workflowModuleId, bpmnProcessId)) {
+      processesWithEndListener.add(bpmnProcessId);
+      log.info(
+          "Dummy-Adapter[{}]: attaching an end listener to BPMN process '{}' of {}",
+          adapterId,
+          bpmnProcessId,
+          workflowModuleId);
+    }
 
   }
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
@@ -9,6 +9,9 @@ import org.springframework.beans.factory.ObjectProvider;
 import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
 import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
 import io.vanillabp.integration.adapter.spi.BpmnParseException;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartInvoker;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
 import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
@@ -30,6 +33,18 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
    * Test hook standing in for the BPMN model (see {@link DummyTaskWiringSource}).
    */
   private final ObjectProvider<DummyTaskWiringSource> taskWiringSource;
+
+  /**
+   * The core's entry point for workflows the BPMS starts on its own, provided by the
+   * platform integration.
+   */
+  private final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker;
+
+  /**
+   * Test hook standing in for the start events of the BPMN model (see
+   * {@link DummyBpmsInitiatedStartSource}).
+   */
+  private final ObjectProvider<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource;
 
   @Override
   public Class<Object> getModelType() {
@@ -112,6 +127,39 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
             workflowModuleId,
             bpmnProcessId,
             source.tasksOf(adapterId, workflowModuleId, bpmnProcessId)));
+
+    // like a real adapter: report the start events the BPMS fires on its own, so the
+    // core can check the application's @WorkflowStartedByBpms methods against them
+    bpmsInitiatedStartSource.ifAvailable(
+        source -> bpmsInitiatedStartInvoker.validateBpmsInitiatedStarts(
+            workflowModuleId,
+            bpmnProcessId,
+            source.startEventsOf(adapterId, workflowModuleId, bpmnProcessId)));
+
+  }
+
+  /**
+   * Reports a workflow the BPMS started on its own, like a real adapter does from a
+   * process-start listener. Triggered by integration tests.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The notification (as a real adapter would build it)
+   * @return The aggregate's ID and the variables to write back into the BPMS
+   */
+  public BpmsInitiatedStartResult startWorkflowByBpms(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final BpmsInitiatedStartContext context) {
+
+    log.info(
+        "Dummy-Adapter[{}]: The BPMS started '{}' of {} by start event '{}'",
+        adapterId,
+        bpmnProcessId,
+        workflowModuleId,
+        context.getStartEventId());
+
+    return bpmsInitiatedStartInvoker.startWorkflowByBpms(workflowModuleId, bpmnProcessId, context);
 
   }
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
@@ -55,6 +55,33 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
   private final WorkflowEndedInvoker workflowEndedInvoker;
 
   /**
+   * Test hook standing in for the versions the BPMS deployed (see
+   * {@link DummyProcessVersionSource}).
+   */
+  private final ObjectProvider<DummyProcessVersionSource> processVersionSource;
+
+  /**
+   * The versions of the deployed BPMN processes, cached like a real adapter caches
+   * them - the test's {@link DummyProcessVersionSource} plays the BPMS query.
+   */
+  private final io.vanillabp.integration.adapter.spi.version.CachingProcessVersionCatalog processVersions = new io.vanillabp.integration.adapter.spi.version.CachingProcessVersionCatalog(
+      java.time.Duration.ZERO) {
+
+    @Override
+    protected List<io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion> fetchDeployedVersions(
+        final String workflowModuleId,
+        final String bpmnProcessId) {
+
+      final var source = processVersionSource.getIfAvailable();
+      return source == null
+          ? List.of()
+          : source.versionsOf(adapterId, workflowModuleId, bpmnProcessId);
+
+    }
+
+  };
+
+  /**
    * Which BPMN processes got an end listener attached - a real adapter modifies its
    * model here, the dummy records the decision so a test can assert that a process
    * without a handler pays nothing.
@@ -184,6 +211,12 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
             bpmnProcessId,
             source.startEventsOf(adapterId, workflowModuleId, bpmnProcessId)));
 
+    // like a real adapter which can be asked about its deployed versions: hand the
+    // catalog over, so version specifications naming a version tag can be resolved
+    processVersionSource.ifAvailable(
+        source -> workflowTaskInvoker
+            .registerProcessVersions(adapterId, workflowModuleId, bpmnProcessId, processVersions));
+
     // like a real adapter: a model pays for the end notification only where the
     // application asked for one
     if (workflowEndedInvoker.workflowEndedHandlerExists(workflowModuleId, bpmnProcessId)) {
@@ -253,6 +286,10 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
     // matching no task of any process are a defect (per-module check)
     taskWiringSource.ifAvailable(
         source -> workflowTaskInvoker.validateNoUnwiredWorkflowTaskMethods(workflowModuleId));
+
+    // like a real adapter: the deployment is done, so the version tags named by the
+    // application's annotations can be resolved against what the BPMS has now
+    workflowTaskInvoker.resolveProcessVersions(workflowModuleId);
 
   }
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyBpmsInitiatedStartSource.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyBpmsInitiatedStartSource.java
@@ -1,0 +1,33 @@
+package io.vanillabp.adapter.dummy.springboot.deployment;
+
+import java.util.Collection;
+
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to supply the start
+ * events a BPMS would fire on its own (timer, signal, conditional): the dummy
+ * adapter has no real BPMN model, so a bean of this type stands in for what a real
+ * adapter reads during <code>wireBpmn</code>. If a bean is present, the dummy
+ * adapter reports the start events to the core (which validates the application's
+ * <code>&#64;WorkflowStartedByBpms</code> methods against them); without a bean
+ * nothing is reported.
+ */
+@FunctionalInterface
+public interface DummyBpmsInitiatedStartSource {
+
+  /**
+   * The BPMS-initiated start events of the given BPMN process as a real adapter
+   * would read them from the BPMN model.
+   *
+   * @param adapterId The adapter ID performing the wiring
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return The start events to be reported
+   */
+  Collection<BpmsInitiatedStartSpec> startEventsOf(
+      String adapterId,
+      String workflowModuleId,
+      String bpmnProcessId);
+
+}

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyProcessVersionSource.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyProcessVersionSource.java
@@ -1,0 +1,32 @@
+package io.vanillabp.adapter.dummy.springboot.deployment;
+
+import java.util.List;
+
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to supply the deployed
+ * versions of a BPMN process: the dummy adapter has no BPMS to ask, so a bean of this
+ * type stands in for what a real adapter queries from its BPMS. If a bean is present,
+ * the dummy adapter registers a version catalog with the core
+ * ({@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#registerProcessVersions}),
+ * which is what makes <code>version = "release-2024"</code> work; without a bean the
+ * dummy adapter reports no versions at all, like a BPMS which cannot tell.
+ */
+@FunctionalInterface
+public interface DummyProcessVersionSource {
+
+  /**
+   * The deployed versions of the given BPMN process, oldest first.
+   *
+   * @param adapterId The adapter ID being asked
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @return The deployed versions
+   */
+  List<DeployedProcessVersion> versionsOf(
+      String adapterId,
+      String workflowModuleId,
+      String bpmnProcessId);
+
+}

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/DummyAdapterPhaseTwoListener.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/DummyAdapterPhaseTwoListener.java
@@ -31,6 +31,18 @@ public interface DummyAdapterPhaseTwoListener {
   }
 
   /**
+   * Called whenever a signal is broadcast - in phase one for an adapter without a
+   * two-phase commit, in phase two for one with it.
+   *
+   * @param signalName The PLAIN BPMN signal name
+   * @param phaseTwo Whether this was phase two (after the commit)
+   */
+  default void broadcastSignal(
+      final String signalName,
+      final boolean phaseTwo) {
+  }
+
+  /**
    * Called whenever phase two of canceling an asynchronous task is executed.
    *
    * @param workflowAggregateId The ID of the workflow aggregate

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/DummyAdapterPhaseTwoListener.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/DummyAdapterPhaseTwoListener.java
@@ -103,4 +103,19 @@ public interface DummyAdapterPhaseTwoListener {
       final String messageName) {
   }
 
+  /**
+   * Called whenever a changed workflow-aggregate is pushed to the BPMS - in phase
+   * one for an adapter without a two-phase commit, in phase two for one with it.
+   *
+   * @param workflowAggregateId The ID of the workflow aggregate
+   * @param taskId The task whose scope received the values, or <code>null</code>
+   *        for the workflow's global scope
+   * @param phaseTwo Whether this was phase two (after the commit)
+   */
+  default void aggregateChanged(
+      final Object workflowAggregateId,
+      final String taskId,
+      final boolean phaseTwo) {
+  }
+
 }

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
@@ -358,6 +358,53 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
   }
 
   @Override
+  public void aggregateChangedPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final A workflowAggregate,
+      final String taskId) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Pushing the changed aggregate (phase one, task '{}') of BPMN process '{}' of "
+            + "workflow module '{}'",
+        adapterId,
+        taskId,
+        bpmnProcessId,
+        workflowModuleId);
+
+    // like an embedded BPMS: without a two-phase commit the push happens here
+    if (!needsTwoPhaseCommitForStartingWorkflows && (phaseTwoListeners != null)) {
+      final var aggregateId = aggregatePersistence.getAggregateId(workflowAggregate);
+      phaseTwoListeners.forEach(listener -> listener.aggregateChanged(aggregateId, taskId, false));
+    }
+
+  }
+
+  @Override
+  public void aggregateChangedPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Pushing the changed aggregate (phase two, task '{}') of BPMN process '{}' of "
+            + "workflow module '{}' for aggregate '{}'",
+        adapterId,
+        taskId,
+        bpmnProcessId,
+        workflowModuleId,
+        workflowAggregateId);
+
+    if (phaseTwoListeners != null) {
+      phaseTwoListeners.forEach(listener -> listener.aggregateChanged(workflowAggregateId, taskId, true));
+    }
+
+  }
+
+  @Override
   public void correlateMessagePhaseOne(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
@@ -321,6 +321,43 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
   }
 
   @Override
+  public void sendSignalPhaseOne(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Broadcasting signal '{}' (phase one) of workflow module '{}'",
+        adapterId,
+        signalName,
+        workflowModuleId);
+
+    // like an embedded BPMS: without a two-phase commit the broadcast happens here
+    if (!needsTwoPhaseCommitForStartingWorkflows && (phaseTwoListeners != null)) {
+      phaseTwoListeners.forEach(listener -> listener.broadcastSignal(signalName, false));
+    }
+
+  }
+
+  @Override
+  public void sendSignalPhaseTwo(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String signalName) {
+
+    log.info(
+        "Dummy-Adapter[{}]: Broadcasting signal '{}' (phase two) of workflow module '{}'",
+        adapterId,
+        signalName,
+        workflowModuleId);
+
+    if (phaseTwoListeners != null) {
+      phaseTwoListeners.forEach(listener -> listener.broadcastSignal(signalName, true));
+    }
+
+  }
+
+  @Override
   public void correlateMessagePhaseOne(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/deployment/AggregateChangedTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/deployment/AggregateChangedTest.java
@@ -1,0 +1,292 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterPhaseTwoListener;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyTaskAwarenessSource;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.sample.Aggregate;
+import io.vanillabp.integration.test.sample.SampleWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+import io.vanillabp.spi.process.ProcessService;
+
+/**
+ * Acceptance test of pushing a changed workflow-aggregate to the BPMS (story 44)
+ * with the dummy adapter standing in for one. What it pins: both overloads reach the
+ * adapter, the task id decides the scope and travels unchanged, and a rollback takes
+ * the push with it - the dummy is configured without a two-phase commit, so it
+ * behaves like an embedded BPMS.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregateChangedTest {
+
+  /**
+   * Records what the dummy adapter was told to push.
+   */
+  static class RecordingPushes implements DummyAdapterPhaseTwoListener {
+
+    final List<String> pushed = new LinkedList<>();
+
+    @Override
+    public void startedWorkflowPhaseTwo(
+        final Object workflowAggregateId) {
+
+    }
+
+    @Override
+    public void aggregateChanged(
+        final Object workflowAggregateId,
+        final String taskId,
+        final boolean phaseTwo) {
+
+      pushed.add("%s/%s/%s".formatted(workflowAggregateId, taskId, phaseTwo
+          ? "phase-two"
+          : "phase-one"));
+
+    }
+
+  }
+
+  @Configuration
+  static class PushConfiguration {
+
+    @Bean
+    javax.sql.DataSource pushDataSource() {
+
+      return new org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder()
+          .setType(org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    org.springframework.transaction.PlatformTransactionManager transactionManager(
+        final javax.sql.DataSource pushDataSource) {
+
+      return new org.springframework.jdbc.datasource.DataSourceTransactionManager(pushDataSource);
+
+    }
+
+    @Bean
+    org.springframework.transaction.support.TransactionTemplate transactionTemplate(
+        final org.springframework.transaction.PlatformTransactionManager transactionManager) {
+
+      return new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+
+    }
+
+    @Bean
+    RecordingPushes recordingPushes() {
+
+      return new RecordingPushes();
+
+    }
+
+    /**
+     * The dummy knows the workflow - otherwise the core would refuse to push to a
+     * BPMS which never heard of it.
+     */
+    @Bean
+    DummyTaskAwarenessSource activeWorkflow() {
+
+      return (
+          adapterId,
+          workflowAggregateId,
+          taskId) -> WorkflowAwareness.ACTIVE;
+
+    }
+
+    @Bean
+    AggregatePersistenceAware<Aggregate> sampleAggregatePersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<Aggregate> getAggregateClass() {
+          return Aggregate.class;
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public Aggregate save(
+            final Aggregate workflowAggregate) {
+          return workflowAggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final Aggregate workflowAggregate) {
+          // the sample aggregate has no attributes - every test runs its own
+          // application, so one id is enough
+          return "42";
+        }
+
+      };
+
+    }
+
+  }
+
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        prioritized-adapters:
+          - test
+        adapters:
+          test:
+            type: dummy
+            resources-location: classpath*:test-module/processes/dummy
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            SampleWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            PushConfiguration.class)
+        .run();
+
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void bothScopesReachTheBpms() throws IOException {
+
+    try (var testApp = SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .addResource("test-module/processes/dummy/DummyProcess.bpmn")
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build(); var context = runTestApplication(testApp)) {
+
+      final var processService = (ProcessService<Aggregate>) context
+          .getBeanProvider(
+              ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class))
+          .getObject();
+
+      final var aggregate = new Aggregate();
+
+      context
+          .getBean(org.springframework.transaction.support.TransactionTemplate.class)
+          .executeWithoutResult(status -> {
+            processService.aggregateChanged(aggregate);
+            processService.aggregateChanged(aggregate, "task-1");
+          });
+
+      Assertions
+          .assertEquals(
+              List.of("42/null/phase-one", "42/task-1/phase-one"),
+              context.getBean(RecordingPushes.class).pushed,
+              "both overloads have to reach the BPMS, and the task id has to travel unchanged");
+
+    }
+
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void aRollbackTakesThePushWithIt() throws IOException {
+
+    try (var testApp = SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .addResource("test-module/processes/dummy/DummyProcess.bpmn")
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build(); var context = runTestApplication(testApp)) {
+
+      final var processService = (ProcessService<Aggregate>) context
+          .getBeanProvider(
+              ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class))
+          .getObject();
+
+      final var aggregate = new Aggregate();
+
+      Assertions
+          .assertThrows(
+              IllegalStateException.class,
+              () -> context
+                  .getBean(org.springframework.transaction.support.TransactionTemplate.class)
+                  .executeWithoutResult(status -> {
+                    processService.aggregateChanged(aggregate);
+                    throw new IllegalStateException("the caller changed their mind");
+                  }));
+
+      // an embedded BPMS pushed inside the caller's transaction, so the rollback
+      // undid the write in the engine as well - nothing was scheduled for later
+      Assertions
+          .assertEquals(
+              List.of("42/null/phase-one"),
+              context.getBean(RecordingPushes.class).pushed,
+              "the push happened in phase one; the rollback is the BPMS' business, not the outbox'");
+
+    }
+
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void aTaskIdHasToBeATaskId() throws IOException {
+
+    try (var testApp = SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .addResource("test-module/processes/dummy/DummyProcess.bpmn")
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build(); var context = runTestApplication(testApp)) {
+
+      final var processService = (ProcessService<Aggregate>) context
+          .getBeanProvider(
+              ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class))
+          .getObject();
+
+      final var aggregate = new Aggregate();
+
+      final var exception = Assertions
+          .assertThrows(
+              IllegalArgumentException.class,
+              () -> context
+                  .getBean(org.springframework.transaction.support.TransactionTemplate.class)
+                  .executeWithoutResult(status -> processService.aggregateChanged(aggregate, " ")));
+
+      Assertions.assertTrue(exception.getMessage().contains("aggregateChanged(aggregate)"));
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/deployment/SendSignalTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/deployment/SendSignalTest.java
@@ -1,0 +1,235 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterPhaseTwoListener;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.sample.Aggregate;
+import io.vanillabp.integration.test.sample.SampleWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+import io.vanillabp.spi.process.ProcessService;
+
+/**
+ * Acceptance test of broadcasting a BPMN signal (story 42) with the dummy adapter
+ * standing in for a BPMS. Two adapter ids are configured, one of them named at the
+ * WORKFLOW level only - the deployment union. What the test pins: the broadcast
+ * reaches BOTH of them, because during a migration the workflows waiting for the
+ * signal are spread across the BPMS.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SendSignalTest {
+
+  /**
+   * Records what the dummy adapter broadcast.
+   */
+  static class RecordingSignals implements DummyAdapterPhaseTwoListener {
+
+    final List<String> broadcast = new LinkedList<>();
+
+    @Override
+    public void startedWorkflowPhaseTwo(
+        final Object workflowAggregateId) {
+
+    }
+
+    @Override
+    public void broadcastSignal(
+        final String signalName,
+        final boolean phaseTwo) {
+
+      broadcast.add("%s/%s".formatted(signalName, phaseTwo
+          ? "phase-two"
+          : "phase-one"));
+
+    }
+
+  }
+
+  @Configuration
+  static class SignalConfiguration {
+
+    @Bean
+    javax.sql.DataSource signalDataSource() {
+
+      return new org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder()
+          .setType(org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    org.springframework.transaction.PlatformTransactionManager transactionManager(
+        final javax.sql.DataSource signalDataSource) {
+
+      return new org.springframework.jdbc.datasource.DataSourceTransactionManager(signalDataSource);
+
+    }
+
+    @Bean
+    org.springframework.transaction.support.TransactionTemplate transactionTemplate(
+        final org.springframework.transaction.PlatformTransactionManager transactionManager) {
+
+      return new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+
+    }
+
+    @Bean
+    RecordingSignals recordingSignals() {
+
+      return new RecordingSignals();
+
+    }
+
+    @Bean
+    AggregatePersistenceAware<Aggregate> sampleAggregatePersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<Aggregate> getAggregateClass() {
+          return Aggregate.class;
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+      };
+
+    }
+
+  }
+
+  /**
+   * The module prioritizes 'test', while one workflow of it uses 'test2' - so
+   * 'test2' belongs to the deployment union without being prioritized for
+   * 'DummyProcess'.
+   */
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        prioritized-adapters:
+          - test
+          - test2
+        adapters:
+          test:
+            type: dummy
+          test2:
+            type: dummy
+        workflow-modules:
+          test-module:
+            prioritized-adapters:
+              - test
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/dummy
+              test2:
+                resources-location: classpath*:test-module/processes/dummy
+            workflows:
+              SomeOtherProcess:
+                prioritized-adapters:
+                  - test2
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            SampleWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            SignalConfiguration.class)
+        .run();
+
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void aSignalReachesEveryDeployedBpms() throws IOException {
+
+    try (var testApp = SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .addResource("test-module/processes/dummy/DummyProcess.bpmn")
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build(); var context = runTestApplication(testApp)) {
+
+      final var processService = (ProcessService<Aggregate>) context
+          .getBeanProvider(
+              ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class))
+          .getObject();
+
+      context
+          .getBean(org.springframework.transaction.support.TransactionTemplate.class)
+          .executeWithoutResult(status -> processService.sendSignal("OrderReceived"));
+
+      final var broadcast = context.getBean(RecordingSignals.class).broadcast;
+      // both adapter ids of the module are asked - the dummy adapter is configured
+      // without a two-phase commit, so both broadcast inside the transaction
+      Assertions
+          .assertEquals(
+              List.of("OrderReceived/phase-one", "OrderReceived/phase-one"),
+              broadcast,
+              "the signal has to reach every BPMS the workflow module is deployed to");
+
+    }
+
+  }
+
+  @Test
+  public void aSignalWithoutATransactionFailsGuiding() throws IOException {
+
+    try (var testApp = SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .addResource("test-module/processes/dummy/DummyProcess.bpmn")
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build(); var context = runTestApplication(testApp)) {
+
+      @SuppressWarnings("unchecked")
+      final var processService = (ProcessService<Aggregate>) context
+          .getBeanProvider(
+              ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class))
+          .getObject();
+
+      final var exception = Assertions
+          .assertThrows(
+              IllegalStateException.class,
+              () -> processService.sendSignal("OrderReceived"));
+
+      // the message says why a broadcast needs a transaction of its own accord
+      Assertions.assertTrue(exception.getMessage().contains("Broadcasting a signal"), exception.getMessage());
+      Assertions.assertTrue(exception.getMessage().contains("@Transactional"), exception.getMessage());
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/BpmsInitiatedStartTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/BpmsInitiatedStartTest.java
@@ -34,6 +34,7 @@ import io.vanillabp.integration.test.utils.SuppressOutputExtension;
 import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
 import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
 import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.WorkflowEnd;
 
 /**
  * Acceptance test of workflows the BPMS starts on its own (story 41), with the dummy
@@ -331,6 +332,68 @@ public class BpmsInitiatedStartTest {
           .get(signalStart.workflowAggregateId());
       Assertions.assertEquals("SIGNAL/OrderReceived", signalAggregate.getStartedBy());
       Assertions.assertEquals("SOUTH", signalAggregate.getRegion());
+
+    }
+
+  }
+
+  @Test
+  public void theEndOfAWorkflowIsReportedToTheApplication() throws IOException {
+
+    WorkflowStartConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(
+        testApp,
+        WorkflowStartConfiguration.class,
+        StartEventsConfiguration.class)) {
+
+      final var dummyAdapter = context
+          .getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      // the model pays for the notification only where the application asked for
+      // one: the workflow service of 'TimerProcess' has a @WorkflowEnded method,
+      // the other processes of the module have none
+      Assertions
+          .assertEquals(
+              List.of(PROCESS),
+              dummyAdapter.getProcessesWithEndListener(),
+              "an end listener may only be attached where a @WorkflowEnded method exists");
+
+      final var aggregate = new WorkflowStartAggregate();
+      aggregate.setId("4711");
+      WorkflowStartConfiguration.AGGREGATES.put("4711", aggregate);
+
+      dummyAdapter
+          .notifyWorkflowEnded(
+              MODULE,
+              PROCESS,
+              new io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext() {
+
+                @Override
+                public String getWorkflowAggregateId() {
+                  return "4711";
+                }
+
+                @Override
+                public WorkflowEnd.Kind getKind() {
+                  return WorkflowEnd.Kind.COMPLETED;
+                }
+
+                @Override
+                public java.time.Instant getEndTime() {
+                  return TRIGGER_TIME;
+                }
+
+                @Override
+                public String getEndEventId() {
+                  return "Event_Done";
+                }
+
+              });
+
+      // the method ran against the loaded aggregate and its change was saved
+      Assertions
+          .assertEquals("COMPLETED/Event_Done", WorkflowStartConfiguration.AGGREGATES.get("4711").getRegion());
 
     }
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/BpmsInitiatedStartTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/BpmsInitiatedStartTest.java
@@ -1,0 +1,375 @@
+package io.vanillabp.integration.test.workflowstart;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyBpmsInitiatedStartSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
+import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+
+/**
+ * Acceptance test of workflows the BPMS starts on its own (story 41), with the dummy
+ * adapter standing in for a BPMS reporting a timer, signal or conditional start. It
+ * covers what an application gets without writing a line of code (the aggregate is
+ * built, the timer's trigger time is its ID, the process variables land in it), that
+ * a repeated notification creates nothing twice, and what an optional
+ * <code>&#64;WorkflowStartedByBpms</code> method adds on top.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class BpmsInitiatedStartTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TimerProcess";
+
+  private static final String TIMER_EVENT = "DailyTimer";
+
+  private static final String SIGNAL_EVENT = "SignalStart";
+
+  private static final Instant TRIGGER_TIME = Instant.parse("2026-08-12T04:00:00Z");
+
+  @Configuration
+  static class WorkflowStartConfiguration {
+
+    static final Map<String, WorkflowStartAggregate> AGGREGATES = new ConcurrentHashMap<>();
+
+    @Bean
+    AggregatePersistenceAware<WorkflowStartAggregate> workflowStartPersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<WorkflowStartAggregate> getAggregateClass() {
+          return WorkflowStartAggregate.class;
+        }
+
+        @Override
+        public String getAggregateIdName() {
+          return "id";
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final WorkflowStartAggregate aggregate) {
+          return aggregate.getId();
+        }
+
+        @Override
+        public WorkflowStartAggregate save(
+            final WorkflowStartAggregate aggregate) {
+          AGGREGATES.put(aggregate.getId(), copyOf(aggregate));
+          return aggregate;
+        }
+
+        @Override
+        public WorkflowStartAggregate loadById(
+            final Object aggregateId) {
+          final var stored = AGGREGATES.get(aggregateId);
+          return stored != null
+              ? copyOf(stored)
+              : null;
+        }
+
+      };
+
+    }
+
+    private static WorkflowStartAggregate copyOf(
+        final WorkflowStartAggregate aggregate) {
+
+      final var copy = new WorkflowStartAggregate();
+      copy.setId(aggregate.getId());
+      copy.setRegion(aggregate.getRegion());
+      copy.setAmount(aggregate.getAmount());
+      copy.setStartedBy(aggregate.getStartedBy());
+      return copy;
+
+    }
+
+    @Bean
+    DataSource workflowStartDataSource() {
+
+      return new EmbeddedDatabaseBuilder()
+          .setType(EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager(
+        final DataSource workflowStartDataSource) {
+
+      return new DataSourceTransactionManager(workflowStartDataSource);
+
+    }
+
+  }
+
+  /**
+   * Stands in for the BPMN model: 'TimerProcess' has a timer and a signal start
+   * event, every other process of the module has none.
+   */
+  @Configuration
+  static class StartEventsConfiguration {
+
+    @Bean
+    DummyBpmsInitiatedStartSource bpmsInitiatedStartSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> PROCESS.equals(bpmnProcessId)
+              ? List
+                  .of(
+                      BpmsInitiatedStartSpec.of(TIMER_EVENT, BpmsStartTrigger.Kind.TIMER),
+                      new BpmsInitiatedStartSpec(
+                          SIGNAL_EVENT, BpmsStartTrigger.Kind.SIGNAL, "OrderReceived", null))
+              : List.of();
+
+    }
+
+  }
+
+  /**
+   * The same application, but its BPMN model has no start event the BPMS fires on
+   * its own - which makes the workflow service's method unservable.
+   */
+  @Configuration
+  static class NoStartEventConfiguration {
+
+    @Bean
+    DummyBpmsInitiatedStartSource emptyBpmsInitiatedStartSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> List.of();
+
+    }
+
+  }
+
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        adapters:
+          test:
+            type: dummy
+            test: 1
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/workflowstart
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp,
+      final Class<?>... additionalClasses) {
+
+    final var classes = new java.util.LinkedList<Class<?>>(
+        List
+            .of(
+                DummyAdapterConfiguration.class,
+                DummyAdapterProcessServiceConfiguration.class,
+                WorkflowModuleAutoConfiguration.class,
+                SpringBootMigrationAdapterAutoConfiguration.class,
+                TestPersistenceConfiguration.class,
+                WorkflowStartWorkflowService.class,
+                WorkflowModuleConfiguration.class,
+                DeploymentTest.TestConfig.class));
+    classes.addAll(List.of(additionalClasses));
+    return testApp.applicationBuilder(classes.toArray(Class[]::new)).run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp() throws IOException {
+
+    return SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  private BpmsInitiatedStartContext context(
+      final BpmsStartTrigger.Kind kind,
+      final String startEventId,
+      final Map<String, Object> variables) {
+
+    return new BpmsInitiatedStartContext() {
+
+      @Override
+      public String getStartEventId() {
+        return startEventId;
+      }
+
+      @Override
+      public BpmsStartTrigger.Kind getKind() {
+        return kind;
+      }
+
+      @Override
+      public Instant getTriggerTime() {
+        return TRIGGER_TIME;
+      }
+
+      @Override
+      public String getSignalName() {
+        return kind == BpmsStartTrigger.Kind.SIGNAL
+            ? "OrderReceived"
+            : null;
+      }
+
+      @Override
+      public Map<String, Object> getVariables() {
+        return variables;
+      }
+
+    };
+
+  }
+
+  @Test
+  public void bpmsInitiatedStartsBuildTheirAggregate() throws IOException {
+
+    WorkflowStartConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(
+        testApp,
+        WorkflowStartConfiguration.class,
+        StartEventsConfiguration.class)) {
+
+      final var dummyAdapter = context
+          .getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      // (a) a timer start without any application code: the aggregate is built, the
+      // trigger time is its ID and the variables the model set land in it
+      final var timerStart = dummyAdapter
+          .startWorkflowByBpms(
+              MODULE,
+              PROCESS,
+              context(
+                  BpmsStartTrigger.Kind.TIMER,
+                  TIMER_EVENT,
+                  Map.of("region", "north", "amount", 42, "notModelled", "ignored")));
+
+      Assertions.assertTrue(timerStart.created());
+      Assertions.assertEquals(TRIGGER_TIME.toString(), timerStart.workflowAggregateId());
+      Assertions.assertEquals("id", timerStart.workflowAggregateIdName());
+      Assertions
+          .assertEquals(TRIGGER_TIME.toString(), timerStart.variables().get("id"));
+
+      final var timerAggregate = WorkflowStartConfiguration.AGGREGATES.get(TRIGGER_TIME.toString());
+      Assertions.assertNotNull(timerAggregate);
+      Assertions.assertEquals("north", timerAggregate.getRegion());
+      Assertions.assertEquals(42, timerAggregate.getAmount());
+      // the method of the workflow service serves the SIGNAL start event only
+      Assertions.assertNull(timerAggregate.getStartedBy());
+
+      // (b) the same timer time reported again (a retried notification): nothing is
+      // created twice and business data written meanwhile survives
+      timerAggregate.setRegion("changed meanwhile");
+      WorkflowStartConfiguration.AGGREGATES.put(TRIGGER_TIME.toString(), timerAggregate);
+      final var repeated = dummyAdapter
+          .startWorkflowByBpms(
+              MODULE, PROCESS, context(BpmsStartTrigger.Kind.TIMER, TIMER_EVENT, Map.of("region", "north")));
+      Assertions.assertFalse(repeated.created());
+      Assertions.assertEquals(TRIGGER_TIME.toString(), repeated.workflowAggregateId());
+      Assertions.assertEquals(1, WorkflowStartConfiguration.AGGREGATES.size());
+      Assertions
+          .assertEquals(
+              "changed meanwhile",
+              WorkflowStartConfiguration.AGGREGATES.get(TRIGGER_TIME.toString()).getRegion());
+
+      // (c) the signal start passes through the application's method, which sees the
+      // trigger and the variables
+      final var signalStart = dummyAdapter
+          .startWorkflowByBpms(
+              MODULE, PROCESS, context(BpmsStartTrigger.Kind.SIGNAL, SIGNAL_EVENT, Map.of("region", "south")));
+
+      Assertions.assertTrue(signalStart.created());
+      // a signal has no natural identity, so the ID is generated
+      Assertions.assertNotEquals(TRIGGER_TIME.toString(), signalStart.workflowAggregateId());
+      final var signalAggregate = WorkflowStartConfiguration.AGGREGATES
+          .get(signalStart.workflowAggregateId());
+      Assertions.assertEquals("SIGNAL/OrderReceived", signalAggregate.getStartedBy());
+      Assertions.assertEquals("SOUTH", signalAggregate.getRegion());
+
+    }
+
+  }
+
+  @Test
+  public void aMethodWithoutSuchAStartEventFailsTheBoot() throws IOException {
+
+    WorkflowStartConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp()) {
+
+      final var failure = Assertions
+          .assertThrows(
+              Exception.class,
+              () -> runTestApplication(
+                  testApp,
+                  WorkflowStartConfiguration.class,
+                  NoStartEventConfiguration.class).close());
+
+      // the guiding message names the method, the process and what to do about it
+      final var message = rootCauseMessage(failure);
+      Assertions.assertTrue(message.contains(WorkflowStartWorkflowService.class.getName()), message);
+      Assertions.assertTrue(message.contains(PROCESS), message);
+      Assertions.assertTrue(message.contains("startWorkflow"), message);
+
+    }
+
+  }
+
+  private String rootCauseMessage(
+      final Throwable failure) {
+
+    var cause = failure;
+    while (cause.getCause() != null) {
+      cause = cause.getCause();
+    }
+    return String.valueOf(cause.getMessage());
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartAggregate.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartAggregate.java
@@ -1,0 +1,26 @@
+package io.vanillabp.integration.test.workflowstart;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The aggregate of the acceptance test of workflows the BPMS starts on its own. Its
+ * ID is a String, so a timer's trigger time can be its identity.
+ */
+@Getter
+@Setter
+public class WorkflowStartAggregate {
+
+  private String id;
+
+  private String region;
+
+  private int amount;
+
+  /**
+   * Set by the <code>&#64;WorkflowStartedByBpms</code> method, so a test can tell
+   * whether the application had its say or VanillaBP built the aggregate alone.
+   */
+  private String startedBy;
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartWorkflowService.java
@@ -1,0 +1,33 @@
+package io.vanillabp.integration.test.workflowstart;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.BpmsStartTrigger;
+import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowStartedByBpms;
+
+/**
+ * The workflow service of the acceptance test of BPMS-initiated starts. It serves
+ * ONE of the two start events of its process, which is what proves both paths at
+ * once: the timer start is built by VanillaBP alone, the signal start passes through
+ * the application's method.
+ */
+@WorkflowService(
+    workflowAggregateClass = WorkflowStartAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TimerProcess"))
+public class WorkflowStartWorkflowService {
+
+  @WorkflowStartedByBpms(id = "SignalStart")
+  public void aggregateOfSignalStart(
+      final WorkflowStartAggregate aggregate,
+      final BpmsStartTrigger trigger,
+      @TaskParam("region") final String region) {
+
+    aggregate.setStartedBy("%s/%s".formatted(trigger.kind(), trigger.signalName()));
+    aggregate.setRegion(region == null
+        ? null
+        : region.toUpperCase());
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowstart/WorkflowStartWorkflowService.java
@@ -3,6 +3,8 @@ package io.vanillabp.integration.test.workflowstart;
 import io.vanillabp.spi.service.BpmnProcess;
 import io.vanillabp.spi.service.BpmsStartTrigger;
 import io.vanillabp.spi.service.TaskParam;
+import io.vanillabp.spi.service.WorkflowEnd;
+import io.vanillabp.spi.service.WorkflowEnded;
 import io.vanillabp.spi.service.WorkflowService;
 import io.vanillabp.spi.service.WorkflowStartedByBpms;
 
@@ -16,6 +18,18 @@ import io.vanillabp.spi.service.WorkflowStartedByBpms;
     workflowAggregateClass = WorkflowStartAggregate.class,
     bpmnProcess = @BpmnProcess(bpmnProcessId = "TimerProcess"))
 public class WorkflowStartWorkflowService {
+
+  /**
+   * Story 43: the same workflow service also wants to know when a workflow ended.
+   */
+  @WorkflowEnded
+  public void workflowEnded(
+      final WorkflowStartAggregate aggregate,
+      final WorkflowEnd end) {
+
+    aggregate.setRegion("%s/%s".formatted(end.kind(), end.endEventId()));
+
+  }
 
   @WorkflowStartedByBpms(id = "SignalStart")
   public void aggregateOfSignalStart(

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/ProcessVersionsTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/ProcessVersionsTest.java
@@ -1,0 +1,289 @@
+package io.vanillabp.integration.test.workflowversion;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyProcessVersionSource;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+
+/**
+ * Acceptance test of <code>&#64;WorkflowTask(version = ...)</code> (story 48) with the
+ * dummy adapter standing in for a BPMS: the version the adapter reports decides which
+ * method serves a delivered task, ranges made of numbers are compared without asking
+ * the BPMS, and a range naming a version TAG is resolved through the catalog the
+ * adapter registered - including the query for a version this application never
+ * deployed itself (another cluster node did, during a rolling deployment).
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ProcessVersionsTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "VersionedProcess";
+
+  @Configuration
+  static class VersionsConfiguration {
+
+    static final Map<String, VersionedAggregate> AGGREGATES = new ConcurrentHashMap<>();
+
+    /**
+     * The versions the "BPMS" has - a test may add one while the application runs.
+     */
+    static final List<DeployedProcessVersion> VERSIONS = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    /**
+     * How often the "BPMS" was asked - the query must not run per task delivery.
+     */
+    static final AtomicInteger QUERIES = new AtomicInteger();
+
+    @Bean
+    AggregatePersistenceAware<VersionedAggregate> versionedPersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<VersionedAggregate> getAggregateClass() {
+          return VersionedAggregate.class;
+        }
+
+        @Override
+        public VersionedAggregate save(
+            final VersionedAggregate aggregate) {
+          AGGREGATES.put(aggregate.getId(), aggregate);
+          return aggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final VersionedAggregate aggregate) {
+          return aggregate.getId();
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public VersionedAggregate loadById(
+            final Object aggregateId) {
+          return AGGREGATES.get(aggregateId);
+        }
+
+      };
+
+    }
+
+    @Bean
+    DataSource versionedDataSource() {
+
+      return new EmbeddedDatabaseBuilder()
+          .setType(EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager(
+        final DataSource versionedDataSource) {
+
+      return new DataSourceTransactionManager(versionedDataSource);
+
+    }
+
+    /**
+     * Stands in for the BPMN model: the one task all three methods are wired to.
+     */
+    @Bean
+    DummyTaskWiringSource taskWiringSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> PROCESS.equals(bpmnProcessId)
+              ? List.of(new BpmnTaskSpec("Activity_Versioned", "versionedTask"))
+              : List.of();
+
+    }
+
+    /**
+     * Stands in for the BPMS query a real adapter runs to learn its version tags.
+     */
+    @Bean
+    DummyProcessVersionSource processVersionSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> {
+        QUERIES.incrementAndGet();
+        return List.copyOf(VERSIONS);
+      };
+
+    }
+
+  }
+
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        adapters:
+          test:
+            type: dummy
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/workflowversion
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            VersionedWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            VersionsConfiguration.class,
+            DeploymentTest.TestConfig.class)
+        .run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp() throws IOException {
+
+    return SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  private TaskInvocationContext context(
+      final String aggregateId,
+      final String processVersion) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return "versionedTask";
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getProcessVersion() {
+        return processVersion;
+      }
+
+    };
+
+  }
+
+  private void storeAggregate(
+      final String id) {
+
+    final var aggregate = new VersionedAggregate();
+    aggregate.setId(id);
+    VersionsConfiguration.AGGREGATES.put(id, aggregate);
+
+  }
+
+  @Test
+  public void theProcessVersionDecidesWhichMethodServesTheTask() throws IOException {
+
+    VersionsConfiguration.AGGREGATES.clear();
+    VersionsConfiguration.VERSIONS.clear();
+    VersionsConfiguration.QUERIES.set(0);
+    VersionsConfiguration.VERSIONS.add(DeployedProcessVersion.of("1", null));
+    VersionsConfiguration.VERSIONS.add(DeployedProcessVersion.of("2", null));
+    VersionsConfiguration.VERSIONS.add(DeployedProcessVersion.of("3", null));
+    VersionsConfiguration.VERSIONS.add(DeployedProcessVersion.of("4", "release-2026"));
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      // the version tag was resolved while the application booted, once
+      Assertions.assertEquals(1, VersionsConfiguration.QUERIES.get());
+
+      storeAggregate("4711");
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", "2"));
+      Assertions.assertEquals("upToTwo", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", "3"));
+      Assertions.assertEquals("three", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+
+      // the version carrying the tag - and no further BPMS query for it
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", "4"));
+      Assertions.assertEquals("tagged", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+      Assertions.assertEquals(1, VersionsConfiguration.QUERIES.get());
+
+      // a BPMS which cannot report a version is served by the first method - what
+      // every application not using the attribute relies on
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", null));
+      Assertions.assertEquals("upToTwo", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+
+      // ANOTHER cluster node deploys version 5 and moves the tag to it: this node
+      // has never seen that version, so it asks the BPMS while the task is dispatched
+      VersionsConfiguration.VERSIONS.set(3, DeployedProcessVersion.of("4", null));
+      VersionsConfiguration.VERSIONS.add(DeployedProcessVersion.of("5", "release-2026"));
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", "5"));
+      Assertions.assertEquals("tagged", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+      Assertions.assertTrue(
+          VersionsConfiguration.QUERIES.get() > 1,
+          "the version deployed by another node was looked up on demand");
+
+      // a version no method serves is a defect naming the version
+      final var unmatched = Assertions.assertThrows(
+          IllegalStateException.class,
+          () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", "4")));
+      Assertions.assertTrue(unmatched.getMessage().contains("process version '4'"), unmatched.getMessage());
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/VersionedAggregate.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/VersionedAggregate.java
@@ -1,0 +1,23 @@
+package io.vanillabp.integration.test.workflowversion;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The aggregate of the process-version acceptance test (story 48). Lives in its own
+ * package for the same classpath-scan reason as the other test aggregates:
+ * {@code @WorkflowService} classes are found by scanning, so every test of this Maven
+ * module sees this one as well.
+ */
+@Getter
+@Setter
+public class VersionedAggregate {
+
+  private String id;
+
+  /**
+   * Which method served the task - the version decides it.
+   */
+  private String servedBy;
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/VersionedWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/VersionedWorkflowService.java
@@ -1,0 +1,41 @@
+package io.vanillabp.integration.test.workflowversion;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * The workflow service of the process-version acceptance test (story 48): one BPMN
+ * task served by three methods, told apart by the version of the deployed process -
+ * two version ranges made of numbers and one naming a version tag.
+ */
+@WorkflowService(
+    workflowAggregateClass = VersionedAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "VersionedProcess"))
+public class VersionedWorkflowService {
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "1-2")
+  public void upToTwo(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("upToTwo");
+
+  }
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "3")
+  public void three(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("three");
+
+  }
+
+  @WorkflowTask(taskDefinition = "versionedTask", version = "release-2026")
+  public void tagged(
+      final VersionedAggregate aggregate) {
+
+    aggregate.setServedBy("tagged");
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/workflowstart/TimerProcess.bpmn
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/workflowstart/TimerProcess.bpmn
@@ -1,0 +1,1 @@
+not parsed by the dummy adapter - the process id is derived from the filename

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/workflowversion/VersionedProcess.bpmn
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/workflowversion/VersionedProcess.bpmn
@@ -1,0 +1,1 @@
+not parsed by the dummy adapter

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/ExtensionOperationDispatchTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/ExtensionOperationDispatchTest.java
@@ -1,0 +1,153 @@
+package io.vanillabp.integration.test.outbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.process.ProcessService;
+
+/**
+ * The outbox is open to extensions: an operation registered by
+ * {@link SampleExtension} is scheduled inside the business transaction, dispatched
+ * to the extension's own handler after the commit, deduplicated by the extension's
+ * own idempotency key and retried when the handler fails - the same guarantees the
+ * core operations get, without any core code knowing the operation.
+ */
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(SuppressOutputExtension.class)
+@SuppressOutputExtension.SuppressBackgroundOutput
+public class ExtensionOperationDispatchTest {
+
+  @Autowired
+  private ProcessService<Aggregate> processService;
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  private PhaseTwoOutbox outbox;
+
+  @Autowired
+  private SampleExtension extension;
+
+  @BeforeEach
+  public void resetExtension() {
+
+    extension.reset();
+
+  }
+
+  private Aggregate startWorkflowAndSchedule(
+      final String content,
+      final String event) {
+
+    return transactionTemplate.execute(status -> {
+      final var aggregate = new Aggregate();
+      aggregate.setContent(content);
+      final var attached = processService.startWorkflow(aggregate);
+      outbox
+          .schedule(
+              SampleExtension
+                  .call("test-module", "dummy", attached.getId().toString(), event));
+      return attached;
+    });
+
+  }
+
+  @Test
+  @DisplayName("An extension's operation is dispatched to the extension after the commit")
+  public void extensionOperationIsDispatchedAfterCommit() throws Exception {
+
+    final var aggregate = startWorkflowAndSchedule("extension-dispatch", "created");
+    assertNotNull(aggregate);
+
+    final var dispatched = extension.awaitDispatched(1, 10000);
+    final var call = dispatched.getFirst();
+    assertEquals(SampleExtension.OPERATION_NAME, call.operation());
+    assertEquals(aggregate.getId().toString(), call.workflowAggregateId());
+    // the arguments travel with the entry - the store persists them without ever
+    // interpreting them
+    assertEquals("created", call.args().get(SampleExtension.ARG_EVENT));
+
+  }
+
+  @Test
+  @DisplayName("The extension's own idempotency key deduplicates its entries")
+  public void extensionOperationIsDeduplicatedByItsOwnKey() throws Exception {
+
+    final var aggregate = startWorkflowAndSchedule("extension-dedup", "created");
+    assertNotNull(aggregate);
+    extension.awaitDispatched(1, 10000);
+
+    // same aggregate, same event: the key repeats, so scheduling is a no-op
+    final var scheduledAgain = transactionTemplate.execute(status -> outbox
+        .schedule(
+            SampleExtension
+                .call("test-module", "dummy", aggregate.getId().toString(), "created")));
+    assertFalse(scheduledAgain);
+
+    // a DIFFERENT event of the same workflow is a different key and is dispatched
+    transactionTemplate.execute(status -> outbox
+        .schedule(
+            SampleExtension
+                .call("test-module", "dummy", aggregate.getId().toString(), "completed")));
+
+    final var dispatched = extension.awaitDispatched(2, 10000);
+    assertEquals("created", dispatched.get(0).args().get(SampleExtension.ARG_EVENT));
+    assertEquals("completed", dispatched.get(1).args().get(SampleExtension.ARG_EVENT));
+
+  }
+
+  @Test
+  @DisplayName("A failing extension dispatch is retried")
+  public void failingExtensionDispatchIsRetried() throws Exception {
+
+    extension.failNextDispatches(1);
+
+    final var aggregate = startWorkflowAndSchedule("extension-retry", "created");
+    assertNotNull(aggregate);
+
+    // the first attempt threw, the retry succeeds
+    final var dispatched = extension.awaitDispatched(1, 10000);
+    assertEquals(aggregate.getId().toString(), dispatched.getFirst().workflowAggregateId());
+
+  }
+
+  @Test
+  @DisplayName("On rollback the extension's entry is gone and never dispatched")
+  public void rollbackLeavesNoExtensionEntry() throws Exception {
+
+    try {
+      transactionTemplate.execute(status -> {
+        final var aggregate = new Aggregate();
+        aggregate.setContent("extension-rollback");
+        final var attached = processService.startWorkflow(aggregate);
+        outbox
+            .schedule(
+                SampleExtension
+                    .call("test-module", "dummy", attached.getId().toString(), "created"));
+        throw new RuntimeException("test rollback");
+      });
+    } catch (final RuntimeException e) {
+      assertEquals("test rollback", e.getMessage());
+    }
+
+    // wait longer than the poll interval: the entry rode the rolled-back
+    // transaction, so nothing may ever be dispatched
+    Thread.sleep(1500);
+    assertTrue(extension.getDispatched().isEmpty());
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/SampleExtension.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/SampleExtension.java
@@ -1,0 +1,140 @@
+package io.vanillabp.integration.test.outbox;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.vanillabp.integration.spi.PhaseTwoCall;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * Stands in for a real VanillaBP extension (e.g. the Business Cockpit) using the
+ * outbox for its own crash-safe after-commit work: it registers an operation of its
+ * own in the {@link PhaseTwoOperationRegistry} and records the calls dispatched to
+ * it.
+ * <p>
+ * Everything an extension needs is used here: a namespaced operation name, an
+ * idempotency key of its own making, arguments travelling with the call and a
+ * dispatch which is NOT routed through the aggregate-to-adapter election of the
+ * core operations.
+ */
+@RequiredArgsConstructor
+public class SampleExtension {
+
+  public static final String OPERATION_NAME = "sample-extension:NOTIFY";
+
+  public static final String ARG_EVENT = "event";
+
+  private final PhaseTwoOperationRegistry registry;
+
+  private final List<PhaseTwoCall> dispatched = new CopyOnWriteArrayList<>();
+
+  private volatile int failNextDispatches;
+
+  /**
+   * The operation contributed by this extension: deduplicated per workflow
+   * aggregate AND event, so the same event is published at most once while
+   * different events of the same workflow are all published.
+   */
+  public static final PhaseTwoOperation OPERATION = PhaseTwoOperation
+      .extensionOperation(
+          OPERATION_NAME,
+          call -> Optional
+              .of(
+                  "%s|%s|%s|%s".formatted(
+                      call.workflowModuleId(),
+                      call.bpmnProcessId(),
+                      call.workflowAggregateId(),
+                      call.args().get(ARG_EVENT))));
+
+  @PostConstruct
+  public void registerOperation() {
+
+    registry
+        .register(
+            OPERATION,
+            (
+                call,
+                previouslyAttempted) -> {
+              if (failNextDispatches > 0) {
+                failNextDispatches--;
+                throw new RuntimeException("test dispatch failure");
+              }
+              dispatched.add(call);
+            });
+
+  }
+
+  /**
+   * Builds a call of this extension's operation - what the extension would
+   * schedule inside the business transaction.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowAggregateId The aggregate's ID in serialized form
+   * @param event The event to be published
+   * @return The call to be scheduled
+   */
+  public static PhaseTwoCall call(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String event) {
+
+    return PhaseTwoCall
+        .of(
+            OPERATION, workflowModuleId, bpmnProcessId, workflowAggregateId, null, Map.of(ARG_EVENT, event));
+
+  }
+
+  public List<PhaseTwoCall> getDispatched() {
+
+    return dispatched;
+
+  }
+
+  public void reset() {
+
+    dispatched.clear();
+    failNextDispatches = 0;
+
+  }
+
+  public void failNextDispatches(
+      final int count) {
+
+    failNextDispatches = count;
+
+  }
+
+  /**
+   * Waits until the given number of calls was dispatched.
+   *
+   * @param count The number of calls awaited
+   * @param timeoutMillis The maximum time to wait
+   * @return The dispatched calls
+   * @throws InterruptedException If interrupted while waiting
+   */
+  public List<PhaseTwoCall> awaitDispatched(
+      final int count,
+      final long timeoutMillis) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + timeoutMillis;
+    while (dispatched.size() < count) {
+      if (System.currentTimeMillis() > deadline) {
+        throw new AssertionError(
+            "Only %d of %d expected extension-operation dispatches happened".formatted(
+                dispatched.size(),
+                count));
+      }
+      Thread.sleep(50);
+    }
+    return List.copyOf(dispatched);
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TestApplication.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TestApplication.java
@@ -26,4 +26,18 @@ public class TestApplication {
 
   }
 
+  /**
+   * Stands in for an extension contributing an operation of its own to the outbox.
+   *
+   * @param registry The core's operation registry
+   * @return The sample extension
+   */
+  @Bean
+  public SampleExtension sampleExtension(
+      final io.vanillabp.integration.spi.PhaseTwoOperationRegistry registry) {
+
+    return new SampleExtension(registry);
+
+  }
+
 }

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutbox.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutbox.java
@@ -40,7 +40,7 @@ public class GruelboxPhaseTwoOutbox implements PhaseTwoOutbox {
               .orElse(null))
           .schedule(GruelboxPhaseTwoDispatch.class)
           .dispatch(
-              call.operation().name(),
+              call.operation(),
               call.workflowModuleId(),
               call.bpmnProcessId(),
               call.workflowAggregateId(),

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
@@ -29,7 +29,6 @@ import com.gruelbox.transactionoutbox.spring.SpringTransactionManager;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
 import io.vanillabp.integration.config.VanillaBpConfigurationProperties;
 import io.vanillabp.integration.spi.PhaseTwoCall;
-import io.vanillabp.integration.spi.PhaseTwoOperation;
 import io.vanillabp.integration.spi.PhaseTwoOutbox;
 import io.vanillabp.integration.utils.config.JpaSpringDataUtilConfiguration;
 import jakarta.persistence.EntityManagerFactory;
@@ -60,8 +59,9 @@ import jakarta.persistence.EntityManagerFactory;
  * request ID (<code>vanillabp.outbox.retention</code> maps to gruelbox's retention
  * threshold; expired entries are deleted by the background flush), and blocking after
  * <code>vanillabp.outbox.block-after-attempts</code> failed attempts is gruelbox's
- * native blocklisting. The {@link PhaseTwoCall#args()} map is NOT transported (empty
- * for all operations existing today - see {@link GruelboxPhaseTwoDispatch}).
+ * native blocklisting. The {@link PhaseTwoCall#args()} map travels in its serialized
+ * form because gruelbox's invocation serializer only accepts scalar parameter types
+ * (see {@link GruelboxPhaseTwoDispatch}).
  */
 @AutoConfiguration(
     after = JpaSpringDataUtilConfiguration.class,
@@ -180,11 +180,10 @@ public class GruelboxPhaseTwoOutboxAutoConfiguration {
         serializedArgs) -> phaseTwoRouter
             .getObject()
             .dispatch(
-                new PhaseTwoCall(
-                    PhaseTwoOperation
-                        .valueOf(
-                            operation), workflowModuleId, bpmnProcessId, workflowAggregateId, adapterId, PhaseTwoCall
-                                .deserializeArgs(serializedArgs)),
+                PhaseTwoCall
+                    .forDispatch(
+                        operation, workflowModuleId, bpmnProcessId, workflowAggregateId, adapterId, PhaseTwoCall
+                            .deserializeArgs(serializedArgs)),
                 // set by the submitter wrapper on this thread - a retried entry
                 // runs the START re-dispatch mitigation
                 GruelboxRedispatchAwareSubmitter.isPreviouslyAttempted());

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutbox.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutbox.java
@@ -75,9 +75,8 @@ public class MongoPhaseTwoOutbox implements PhaseTwoOutbox {
     final var now = Instant.now();
     final var entry = new PhaseTwoOutboxEntry(
         UUID.randomUUID()
-            .toString(), call.workflowModuleId(), call.bpmnProcessId(), call
-                .operation()
-                .name(), call.workflowAggregateId(), call.adapterId(), call
+            .toString(), call.workflowModuleId(), call.bpmnProcessId(), call.operation(), call
+                .workflowAggregateId(), call.adapterId(), call
                     .args(), idempotencyKey, PhaseTwoOutboxEntry.STATUS_OPEN, now, 0, now, null);
 
     try {

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutboxDispatcher.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutboxDispatcher.java
@@ -17,7 +17,6 @@ import org.springframework.data.mongodb.core.query.Update;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
 import io.vanillabp.integration.spi.PhaseTwoCall;
-import io.vanillabp.integration.spi.PhaseTwoOperation;
 import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -158,23 +157,18 @@ public class MongoPhaseTwoOutboxDispatcher {
       final PhaseTwoOutboxEntry entry) {
 
     try {
-      final PhaseTwoOperation operation;
-      try {
-        operation = PhaseTwoOperation.valueOf(entry.getOperation());
-      } catch (IllegalArgumentException e) {
-        throw new IllegalStateException(
-            "Unknown operation '%s' of outbox entry '%s'! Maybe it was written by a newer version of your software?"
-                .formatted(entry.getOperation(), entry.getId()));
-      }
       // the entry holds the attempts count BEFORE this claim - a value > 0 means
       // the entry was dispatched before (recovered/retried): the router then runs
-      // the START re-dispatch mitigation
+      // the START re-dispatch mitigation. The operation travels as its persisted
+      // name and is resolved by the router's operation registry
       phaseTwoRouter
           .getObject()
           .dispatch(
-              new PhaseTwoCall(
-                  operation, entry.getWorkflowModuleId(), entry.getBpmnProcessId(), entry.getAggregateId(), entry
-                      .getAdapterId(), entry.getArgs()),
+              PhaseTwoCall
+                  .forDispatch(
+                      entry.getOperation(), entry.getWorkflowModuleId(), entry.getBpmnProcessId(), entry
+                          .getAggregateId(),
+                      entry.getAdapterId(), entry.getArgs()),
               entry.getAttempts() > 0);
       mongoTemplate.updateFirst(
           Query.query(Criteria.where("_id").is(entry.getId())),

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
@@ -140,6 +140,18 @@ public class ProcessServiceSpringBean<A> extends ProcessServiceBase<A> {
   }
 
   @Override
+  public void sendSignal(
+      final String signalName) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionExceptionForSignal();
+    }
+
+    migrationProcessService.sendSignal(signalName);
+
+  }
+
+  @Override
   public A correlateMessage(
       final A workflowAggregate,
       final String messageName) {

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
@@ -152,6 +152,38 @@ public class ProcessServiceSpringBean<A> extends ProcessServiceBase<A> {
   }
 
   @Override
+  public A aggregateChanged(
+      final A workflowAggregate) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionException();
+    }
+
+    return migrationProcessService.aggregateChanged(workflowAggregate, null);
+
+  }
+
+  @Override
+  public A aggregateChanged(
+      final A workflowAggregate,
+      final String taskId) {
+
+    if (noTransactionIsActive()) {
+      throw newMissingTransactionException();
+    }
+    if ((taskId == null) || taskId.isBlank()) {
+      throw new IllegalArgumentException(
+          """
+              No task-id given! Use aggregateChanged(aggregate) to push the aggregate at the \
+              workflow's global scope, or pass the task-id reported to the @TaskId parameter of the \
+              task whose scope should receive the values.""");
+    }
+
+    return migrationProcessService.aggregateChanged(workflowAggregate, taskId);
+
+  }
+
+  @Override
   public A correlateMessage(
       final A workflowAggregate,
       final String messageName) {

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -218,6 +218,27 @@ public class SpringBootMigrationAdapterAutoConfiguration {
   }
 
   /**
+   * The router's registry of phase-two operations - injectable so an extension can
+   * register operations of its own (VanillaBP's core operations are registered by
+   * the router itself).
+   * <p>
+   * Deliberately NOT conditional on a missing bean: the registry an extension
+   * registers in has to be the one the router dispatches from. An application
+   * wanting its own registry gives it to its own {@link PhaseTwoRouter} bean, and
+   * this bean follows.
+   *
+   * @param phaseTwoRouter The router owning the registry
+   * @return The operation registry
+   */
+  @Bean
+  public io.vanillabp.integration.spi.PhaseTwoOperationRegistry vanillaBpPhaseTwoOperationRegistry(
+      final PhaseTwoRouter phaseTwoRouter) {
+
+    return phaseTwoRouter.getOperations();
+
+  }
+
+  /**
    * The cache of workflow&rarr;adapter associations consulted by the BPMS election
    * for operations on existing workflows (complete/cancel task, user task, message
    * correlation): a bounded, expiring in-memory default. Cluster setups wanting

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/PhaseTwoAggregateIdConverterTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/PhaseTwoAggregateIdConverterTest.java
@@ -73,9 +73,10 @@ public class PhaseTwoAggregateIdConverterTest {
   private PhaseTwoCall startWorkflowCall(
       final String serializedAggregateId) {
 
-    return new PhaseTwoCall(
-        PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", serializedAggregateId, "test-adapter", Map
-            .of());
+    return PhaseTwoCall
+        .of(
+            PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", serializedAggregateId, "test-adapter", Map
+                .of());
 
   }
 


### PR DESCRIPTION
The platform half of the stories 41 to 48, plus the Camunda 8 defect of story 52.

- **BPMS-initiated starts (41):** a workflow the BPMS starts on its own (timer, signal,
  conditional) gets its aggregate built by the core, with an optional
  `@WorkflowStartedByBpms` method having a say. New adapter SPI package `workflowstart`.
- **Signals (42):** `ProcessService.sendSignal` as a broadcast over the deployment union
  of a workflow module.
- **Workflow end (43):** `@WorkflowEnded` and the adapter SPI package `workflowend`; a
  model pays for the listener only where a method exists.
- **aggregateChanged (44):** pushes the shared values at the workflow's scope or at the
  scope a task runs in, as an outbox operation for remote BPMS.
- **Outbox operation registry (45):** extensions register their own operations.
- **Process versions (48):** the `version` attribute of all three annotations is
  evaluated now - numbers against what the adapter reports, version tags through the new
  `ProcessVersionCatalog` an adapter registers per process. Two defects of the duplicate
  detection repaired (it filtered by `matchesVersion(null)`, and two methods of one class
  were never compared).

Everything additive for applications: methods without `version` keep serving every
version, and an adapter registering no catalog keeps working. What changes for
applications already carrying the attribute is written down in `UPGRADE.md`.

Coverage: Quarkus 90.8%, Spring Boot 90.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JfGxTzh2x1suKFoJJv5aXS