### PR TITLE
Story 58: size the election cache, and say when it is too small

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,43 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## The election cache can be sized and watched (2026-08-14)
+
+Story 58. Everything here is additive - an application configuring nothing behaves
+exactly as before.
+
+**New properties.** The bounds of the default election cache were fixed constants and
+became properties of the platform:
+
+|                    Property                     | Default |
+|-------------------------------------------------|---------|
+| `vanillabp.workflow-adapter-cache.max-entries`  | `10000` |
+| `vanillabp.workflow-adapter-cache.time-to-live` | `PT1H`  |
+
+Both are validated at startup: a cache holding no entry, or an entry expiring
+immediately, fails the boot with a message naming the property. Raise `max-entries` if
+the application keeps more workflows in flight than the cache holds - a record costs
+roughly 300 bytes, so 100.000 of them are about 30 MB. The bound stays hard; why it is
+not a soft reference is written down in `migration-adapter/README.md`.
+
+**New metrics, only with Micrometer.** If the application brings Micrometer (Spring
+Boot: the Actuator's metrics; Quarkus: the `quarkus-micrometer` extension), VanillaBP
+publishes `vanillabp.workflow.adapter.cache.size`, `.hits`, `.misses`, `.evictions`,
+`.evictions.unused` and `.lost.hints`. Micrometer is an optional dependency: without
+it the application boots unchanged and publishes nothing. Hits and misses are counted
+for an application-provided `WorkflowAdapterCache` bean as well, size and evictions
+are not - only the implementation itself knows them.
+
+**A new warning.** Once ten cached elections were dropped for lack of space AND looked
+up again within an hour, one WARN per hour names the number, the observation period
+and the property to raise. A cache which is merely full is not warned about.
+
+**Only relevant for code compiling against the platform:** the constants
+`InMemoryWorkflowAdapterCache.MAX_ENTRIES` and `.TIME_TO_LIVE` are gone (the defaults
+live in `WorkflowAdapterCacheProperties` now), and the cache's preferred constructor
+takes the properties plus the application's `WorkflowAdapterCacheStatistics`. The
+no-arg constructor still exists and still means "the defaults, uncounted".
+
 ## An operation right after a start waits for the BPMS to catch up (2026-08-13)
 
 Story 54. Two changes, one of them a defect that made Camunda 8 unusable on any cluster

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -88,9 +88,54 @@ not truth: a stale hit (the adapter answers `UNKNOWN_TO_BPMS`) falls through to 
 full walk and repairs the entry; `BPMS_UNAVAILABLE` on a cached adapter follows the
 retry-never-fallback contract. The platform integrations provide a bounded,
 expiring in-memory default (`InMemoryWorkflowAdapterCache`, 10&nbsp;000 entries /
-1&nbsp;h TTL, fixed); an application bean implementing `WorkflowAdapterCache`
-replaces it — cluster setups plug their own shared cache infrastructure this way
-(VanillaBP deliberately ships no distributed implementation).
+1&nbsp;h TTL by default, both configurable — see below); an application bean
+implementing `WorkflowAdapterCache` replaces it — cluster setups plug their own
+shared cache infrastructure this way (VanillaBP deliberately ships no distributed
+implementation).
+
+### Sizing the election cache, and knowing when to (story 58)
+
+Both bounds are properties of the platform, not of an adapter:
+`vanillabp.workflow-adapter-cache.max-entries` and `.time-to-live`
+(`WorkflowAdapterCacheProperties`, validated at startup like everything else, today's
+values as defaults). An application running several thousand workflows of one process
+at the same time does not run out of memory — the map is bounded, a full cache costs
+about 3&nbsp;MB. It runs into EVICTION PRESSURE instead: more hot workflows than
+places, so entries are dropped before they are read.
+
+**Why the bound is a number and not a soft reference.** Soft references were
+considered and rejected: the JVM clears them only when it is nearly out of heap, so
+the cache would grow into the old generation and be reclaimed exactly when the
+application is under pressure anyway; every soft reference is visited by full GCs,
+which lengthens the pauses this kind of application cares about most; it would trade a
+deterministic bound for one depending on GC tuning
+(`-XX:SoftRefLRUPolicyMSPerMB`), for a cache whose loss is cheap by design; and the
+numbers do not call for it, since 100.000 entries are roughly 30&nbsp;MB and raising
+the bound is the cheaper answer. An application which really wants soft or off-heap
+semantics has the SPI bean for it.
+
+**What is measured.** `WorkflowAdapterCacheStatistics` (one per application) counts
+hits, misses, evictions, evictions before an entry was ever read, and LOST HINTS. The
+process services wrap WHATEVER cache is in use into an
+`InstrumentedWorkflowAdapterCache` reporting there, so hits and misses exist for an
+application-provided cache as well. A number which disappears once somebody plugs in
+their own cache would surprise exactly the operator who needs it. Size and evictions
+are different: only the implementation knows them, so the in-memory default reports
+them itself and an application's cache reports none (the size gauge is NaN, not a
+wrong zero). `WorkflowAdapterCacheMeters` publishes all of it as Micrometer meters
+under `vanillabp.workflow.adapter.cache.*`; Micrometer is OPTIONAL and both platforms
+apply `MeterBinder` beans to their registries by themselves, so an application without
+it boots unchanged and reports nothing.
+
+**The warning is about lost hints, not about a full cache.** A cache which is merely
+full is healthy, and an entry evicted unread is not by itself a defect (a workflow
+which is started and never operated on afterwards leaves exactly such an entry
+behind). It becomes one when that workflow IS looked up later: then the bound, not the
+workflow, decided the outcome. The keys of unused evictions are therefore remembered
+(hash codes, bounded like the cache), and a later miss on such a key is a lost hint.
+Ten of them within an hour produce ONE guiding WARN naming the observed number, the
+observation period and the property to raise. Heap pressure is deliberately not the
+trigger, because the cache cannot see the old generation and the JVM does not tell it.
 
 The workflow probe takes the aggregate's persistence because a BPMS without a business
 key finds the workflow by the process variable carrying the aggregate's ID, and that

--- a/migration-adapter/runtime/pom.xml
+++ b/migration-adapter/runtime/pom.xml
@@ -38,6 +38,14 @@
       <artifactId>migration-adapter-spi</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- optional: the election cache publishes its statistics as Micrometer meters
+         if the application brings Micrometer (both platforms apply MeterBinder
+         beans by themselves); without it nothing of this is loaded -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>test-utils</artifactId>

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -71,6 +71,14 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
   private PhaseTwoOutboxProperties outbox = new PhaseTwoOutboxProperties();
 
   /**
+   * Configuration of the default election cache
+   * {@link io.vanillabp.integration.spi.WorkflowAdapterCache} (properties section
+   * <code>vanillabp.workflow-adapter-cache</code>).
+   */
+  @Builder.Default
+  private WorkflowAdapterCacheProperties workflowAdapterCache = new WorkflowAdapterCacheProperties();
+
+  /**
    * Derived view of {@link #getAdapters()}: adapter ID mapped to the adapter's type.
    * An adapter entry without an explicit {@link AdapterConfigProperties#getType()
    * type} defaults to its ID being the type.
@@ -748,6 +756,11 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
     normalize(facts);
     validateAndLink();
     validateWorkflowModuleIdsAgainstPrefixing();
+    if (workflowAdapterCache == null) {
+      // a binder mapping an absent section onto null must not cost the defaults
+      workflowAdapterCache = new WorkflowAdapterCacheProperties();
+    }
+    workflowAdapterCache.validate();
 
     if (knownWorkflowModuleIds.isEmpty()) {
       throw new IllegalStateException("No workflow-modules where given!");

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowAdapterCacheProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowAdapterCacheProperties.java
@@ -1,0 +1,89 @@
+package io.vanillabp.integration.adapter.migration.config;
+
+import java.time.Duration;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Configuration of the default election cache
+ * ({@link io.vanillabp.integration.spi.WorkflowAdapterCache}, properties section
+ * <code>vanillabp.workflow-adapter-cache</code>) - the single source of truth for
+ * keys, defaults and documentation, used by both platform integrations.
+ * <p>
+ * The bounds are hard on purpose: entries are hints, so losing one costs an extra
+ * probing walk (and, on an eventually consistent BPMS, the visibility window of
+ * story 54) but never correctness. An application with more workflows in flight
+ * than the cache holds raises {@link #maxEntries} - roughly 300 bytes per entry, so
+ * 100.000 entries cost about 30 MB. Why the bound is not a soft reference is
+ * written down in <code>migration-adapter/README.md</code>.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class WorkflowAdapterCacheProperties {
+
+  public static final String SECTION = MigrationAdapterProperties.PREFIX
+      + ".workflow-adapter-cache";
+
+  public static final String MAX_ENTRIES_PROPERTY = SECTION
+      + ".max-entries";
+
+  public static final String TIME_TO_LIVE_PROPERTY = SECTION
+      + ".time-to-live";
+
+  public static final int DEFAULT_MAX_ENTRIES = 10_000;
+
+  public static final Duration DEFAULT_TIME_TO_LIVE = Duration.ofHours(1);
+
+  /**
+   * The maximum number of entries the in-memory default cache holds - the least
+   * recently used entry is dropped beyond that. Raise it if an application keeps
+   * more workflows hot than the cache holds (see the eviction-pressure warning of
+   * {@code WorkflowAdapterCacheStatistics}).
+   */
+  @Builder.Default
+  private int maxEntries = DEFAULT_MAX_ENTRIES;
+
+  /**
+   * How long an entry of the in-memory default cache is kept (counted from the
+   * moment it was stored). Expiry is not a defect: the hint is only a shortcut of
+   * the probing walk which re-elects and re-populates it.
+   */
+  @Builder.Default
+  private Duration timeToLive = DEFAULT_TIME_TO_LIVE;
+
+  /**
+   * Validates the bounds at startup like every other property - an unconfigured
+   * application boots with the defaults.
+   *
+   * @throws IllegalStateException Naming the offending property, its value and the
+   *           default
+   */
+  public void validate() {
+
+    if (maxEntries < 1) {
+      throw new IllegalStateException(
+          """
+              The property '%s' is %d but has to be at least 1! The election cache is bounded on \
+              purpose (a full cache of the default %d entries costs about 3 MB of heap). Remove the \
+              property to use the default or set the number of workflows the application keeps hot."""
+              .formatted(MAX_ENTRIES_PROPERTY, maxEntries, DEFAULT_MAX_ENTRIES));
+    }
+
+    if ((timeToLive == null) || timeToLive.isZero() || timeToLive.isNegative()) {
+      throw new IllegalStateException(
+          """
+              The property '%s' is '%s' but has to be a positive duration (e.g. 'PT1H' or '30m')! \
+              An entry which expires immediately would turn every election into a full probing walk. \
+              Remove the property to use the default of %s."""
+              .formatted(TIME_TO_LIVE_PROPERTY, timeToLive, DEFAULT_TIME_TO_LIVE));
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/InMemoryWorkflowAdapterCache.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/InMemoryWorkflowAdapterCache.java
@@ -5,31 +5,29 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
 import io.vanillabp.integration.spi.WorkflowAdapterCache;
 
 /**
  * The default {@link WorkflowAdapterCache}: a bounded, expiring in-memory
- * LRU-cache. The bounds are fixed, sensible defaults (deliberately no
- * configuration knob - &quot;optimize late&quot;; entries are hints, so an
- * eviction or expiry only costs an extra probe, never correctness). Cluster
- * setups wanting instances to share elections define their own bean implementing
- * {@link WorkflowAdapterCache} backed by their cache infrastructure instead.
+ * LRU-cache. Both bounds are configurable
+ * (<code>vanillabp.workflow-adapter-cache.max-entries</code> and
+ * <code>.time-to-live</code>, see {@link WorkflowAdapterCacheProperties}) and both
+ * are HARD - entries are hints, so an eviction or expiry only costs an extra probe,
+ * never correctness, which is why the bound is a number and not a soft reference
+ * (the reasoning is written down in <code>migration-adapter/README.md</code>).
+ * Cluster setups wanting instances to share elections define their own bean
+ * implementing {@link WorkflowAdapterCache} backed by their cache infrastructure
+ * instead.
  * <p>
  * One instance is shared by all process services of the application (the key
  * includes workflow module and BPMN process, the size bound applies globally).
+ * <p>
+ * The cache reports its size and its evictions to the application's
+ * {@link WorkflowAdapterCacheStatistics}, including whether an evicted entry had
+ * ever been read - that is what the eviction-pressure warning is made of.
  */
 public class InMemoryWorkflowAdapterCache implements WorkflowAdapterCache {
-
-  /**
-   * Maximum number of entries held - the least recently used entry is evicted
-   * beyond that.
-   */
-  public static final int MAX_ENTRIES = 10_000;
-
-  /**
-   * Time after which an entry expires (counted from its last {@link #put}).
-   */
-  public static final Duration TIME_TO_LIVE = Duration.ofHours(1);
 
   private record Key(
                      String workflowModuleId,
@@ -37,41 +35,114 @@ public class InMemoryWorkflowAdapterCache implements WorkflowAdapterCache {
                      String workflowAggregateId) {
   }
 
-  private record Entry(
-                       String adapterId,
-                       long expiresAtMillis) {
+  /**
+   * Not a record: whether the entry was ever read decides whether its eviction is
+   * counted as pressure.
+   */
+  private static final class Entry {
+
+    private final String adapterId;
+
+    private final long expiresAtMillis;
+
+    private boolean used;
+
+    private Entry(
+        final String adapterId,
+        final long expiresAtMillis) {
+
+      this.adapterId = adapterId;
+      this.expiresAtMillis = expiresAtMillis;
+
+    }
+
   }
 
   private final int maxEntries;
 
   private final long timeToLiveMillis;
 
+  private final WorkflowAdapterCacheStatistics statistics;
+
   private final Map<Key, Entry> entries;
 
   public InMemoryWorkflowAdapterCache() {
 
-    this(MAX_ENTRIES, TIME_TO_LIVE);
+    this(new WorkflowAdapterCacheProperties(), null);
+
+  }
+
+  public InMemoryWorkflowAdapterCache(
+      final WorkflowAdapterCacheProperties properties,
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    this(properties.getMaxEntries(), properties.getTimeToLive(), statistics);
 
   }
 
   /**
-   * Visible for tests - production code uses the fixed defaults of the no-arg
-   * constructor.
+   * Visible for tests - production code passes the configured
+   * {@link WorkflowAdapterCacheProperties}.
    */
   public InMemoryWorkflowAdapterCache(
       final int maxEntries,
       final Duration timeToLive) {
 
+    this(maxEntries, timeToLive, null);
+
+  }
+
+  public InMemoryWorkflowAdapterCache(
+      final int maxEntries,
+      final Duration timeToLive,
+      final WorkflowAdapterCacheStatistics statistics) {
+
     this.maxEntries = maxEntries;
     this.timeToLiveMillis = timeToLive.toMillis();
+    this.statistics = statistics;
     // access-ordered LinkedHashMap = LRU; all access synchronized on it
     this.entries = new LinkedHashMap<>(16, 0.75f, true) {
       @Override
       protected boolean removeEldestEntry(
           final Map.Entry<Key, Entry> eldest) {
-        return size() > InMemoryWorkflowAdapterCache.this.maxEntries;
+        if (size() <= InMemoryWorkflowAdapterCache.this.maxEntries) {
+          return false;
+        }
+        InMemoryWorkflowAdapterCache.this.reportEviction(eldest.getKey(), eldest.getValue());
+        return true;
       }
     };
+    if (statistics != null) {
+      statistics.registerSize(this::size);
+    }
+
+  }
+
+  /**
+   * The number of entries currently held - reported as a metric.
+   *
+   * @return The number of entries
+   */
+  public int size() {
+
+    synchronized (entries) {
+      return entries.size();
+    }
+
+  }
+
+  private void reportEviction(
+      final Key key,
+      final Entry entry) {
+
+    if (statistics == null) {
+      return;
+    }
+    statistics.recordEviction(
+        key.workflowModuleId(),
+        key.bpmnProcessId(),
+        key.workflowAggregateId(),
+        entry.used);
 
   }
 
@@ -87,11 +158,13 @@ public class InMemoryWorkflowAdapterCache implements WorkflowAdapterCache {
       if (entry == null) {
         return Optional.empty();
       }
-      if (entry.expiresAtMillis() < System.currentTimeMillis()) {
+      if (entry.expiresAtMillis < System.currentTimeMillis()) {
+        // expiry is not eviction pressure: the entry lived its full time-to-live
         entries.remove(key);
         return Optional.empty();
       }
-      return Optional.of(entry.adapterId());
+      entry.used = true;
+      return Optional.of(entry.adapterId);
     }
 
   }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/InstrumentedWorkflowAdapterCache.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/InstrumentedWorkflowAdapterCache.java
@@ -1,0 +1,92 @@
+package io.vanillabp.integration.adapter.migration.processservice;
+
+import java.util.Optional;
+
+import io.vanillabp.integration.spi.WorkflowAdapterCache;
+
+/**
+ * Counts what the BPMS election asks of the cache and passes every call on
+ * unchanged. EVERY implementation is wrapped, VanillaBP's in-memory default as well
+ * as an application-provided bean, so hits and misses are reported whatever cache is
+ * in use - a metric which disappears once an application plugs in its own cache
+ * would surprise exactly the operator who needs it. Size and evictions are a
+ * different matter: only the implementation itself knows them, so the in-memory
+ * default reports them directly to the same {@link WorkflowAdapterCacheStatistics}
+ * and an application-provided cache reports none.
+ * <p>
+ * The decorator is created per process service while the statistics are one per
+ * application - the numbers are of the cache, not of a workflow.
+ */
+public class InstrumentedWorkflowAdapterCache implements WorkflowAdapterCache {
+
+  private final WorkflowAdapterCache delegate;
+
+  private final WorkflowAdapterCacheStatistics statistics;
+
+  /**
+   * Wraps a cache for counting, tolerating both parts being absent: without a cache
+   * there is nothing to count (the election probes every time), and without
+   * statistics the cache is used as it is.
+   *
+   * @param cache The cache in use or <code>null</code>
+   * @param statistics The application's statistics or <code>null</code>
+   * @return The cache to hand to the election
+   */
+  public static WorkflowAdapterCache instrument(
+      final WorkflowAdapterCache cache,
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    if ((cache == null) || (statistics == null)) {
+      return cache;
+    }
+    return new InstrumentedWorkflowAdapterCache(cache, statistics);
+
+  }
+
+  public InstrumentedWorkflowAdapterCache(
+      final WorkflowAdapterCache delegate,
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    this.delegate = delegate;
+    this.statistics = statistics;
+
+  }
+
+  @Override
+  public Optional<String> get(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    final var adapterId = delegate.get(workflowModuleId, bpmnProcessId, workflowAggregateId);
+    if (adapterId.isPresent()) {
+      statistics.recordHit();
+    } else {
+      statistics.recordMiss(workflowModuleId, bpmnProcessId, workflowAggregateId);
+    }
+    return adapterId;
+
+  }
+
+  @Override
+  public void put(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String adapterId) {
+
+    delegate.put(workflowModuleId, bpmnProcessId, workflowAggregateId, adapterId);
+
+  }
+
+  @Override
+  public void invalidate(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    delegate.invalidate(workflowModuleId, bpmnProcessId, workflowAggregateId);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/WorkflowAdapterCacheMeters.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/WorkflowAdapterCacheMeters.java
@@ -1,0 +1,94 @@
+package io.vanillabp.integration.adapter.migration.processservice;
+
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Publishes the {@link WorkflowAdapterCacheStatistics} as Micrometer meters. Both
+ * platforms apply {@link MeterBinder} beans to their registries by themselves
+ * (Spring Boot through the Actuator's metrics auto-configuration, Quarkus through
+ * the Micrometer extension), so the binding is the same class on both.
+ * <p>
+ * Micrometer is OPTIONAL: this class is loaded only where the platform integration
+ * found Micrometer in the classpath - an application without it runs unchanged and
+ * simply reports no metrics.
+ * <p>
+ * The size gauge reports NaN as long as the cache in use does not know its size,
+ * which is every implementation but VanillaBP's in-memory default (Micrometer
+ * treats NaN as "no measurement" and most backends skip it). The eviction counters
+ * stay at zero for the same reason - an application-provided cache manages its own
+ * bounds.
+ */
+public class WorkflowAdapterCacheMeters implements MeterBinder {
+
+  private final WorkflowAdapterCacheStatistics statistics;
+
+  public WorkflowAdapterCacheMeters(
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    this.statistics = statistics;
+
+  }
+
+  @Override
+  public void bindTo(
+      final MeterRegistry registry) {
+
+    Gauge
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_SIZE,
+            statistics,
+            currentStatistics -> currentStatistics
+                .getSize()
+                .stream()
+                .mapToDouble(size -> size)
+                .findFirst()
+                .orElse(Double.NaN))
+        .description("Number of BPMS elections currently cached")
+        .register(registry);
+
+    FunctionCounter
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_HITS,
+            statistics,
+            WorkflowAdapterCacheStatistics::getHits)
+        .description("Elections answered from the cache")
+        .register(registry);
+
+    FunctionCounter
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_MISSES,
+            statistics,
+            WorkflowAdapterCacheStatistics::getMisses)
+        .description("Elections which had to probe the prioritized adapters")
+        .register(registry);
+
+    FunctionCounter
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_EVICTIONS,
+            statistics,
+            WorkflowAdapterCacheStatistics::getEvictions)
+        .description("Entries dropped because the size bound was reached")
+        .register(registry);
+
+    FunctionCounter
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_EVICTIONS_UNUSED,
+            statistics,
+            WorkflowAdapterCacheStatistics::getEvictionsBeforeFirstUse)
+        .description("Entries dropped for lack of space before they were ever read")
+        .register(registry);
+
+    FunctionCounter
+        .builder(
+            WorkflowAdapterCacheStatistics.METER_LOST_HINTS,
+            statistics,
+            WorkflowAdapterCacheStatistics::getLostHints)
+        .description("Lookups which would have been a hit with a bigger cache")
+        .register(registry);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/WorkflowAdapterCacheStatistics.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/WorkflowAdapterCacheStatistics.java
@@ -1,0 +1,298 @@
+package io.vanillabp.integration.adapter.migration.processservice;
+
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.OptionalInt;
+import java.util.concurrent.atomic.LongAdder;
+import java.util.function.IntSupplier;
+
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * What the BPMS election's cache did for this application: hits, misses, evictions
+ * and - the number worth acting on - the hints which were dropped for lack of space
+ * and looked up again afterwards.
+ * <p>
+ * One instance per application, shared by the
+ * {@link InstrumentedWorkflowAdapterCache} decorators of all process services (they
+ * count the lookups) and by the {@link InMemoryWorkflowAdapterCache} (which is the
+ * only implementation knowing its size and its evictions). An
+ * application-provided cache bean is counted as well, but reports neither size nor
+ * evictions - its bounds are the application's business.
+ * <p>
+ * <b>Lost hints.</b> An entry evicted before it was ever read is not by itself a
+ * defect: a workflow which is started and never operated on afterwards leaves
+ * exactly such an entry behind. It becomes one when that same workflow IS looked up
+ * later, because then the bound - not the workflow - decided the outcome. The keys
+ * of unused evictions are therefore remembered (their hash codes, bounded like the
+ * cache itself) and a later miss on such a key is counted as a LOST HINT: a lookup
+ * which would have been a hit with a bigger cache. That is the signal the
+ * eviction-pressure warning is based on, so a healthy application never sees it.
+ * <p>
+ * Metric names are declared here and registered by whoever binds them to a metrics
+ * backend (see {@code WorkflowAdapterCacheMeters} for the Micrometer binding).
+ */
+@Slf4j
+public class WorkflowAdapterCacheStatistics {
+
+  public static final String METER_PREFIX = "vanillabp.workflow.adapter.cache";
+
+  public static final String METER_SIZE = METER_PREFIX
+      + ".size";
+
+  public static final String METER_HITS = METER_PREFIX
+      + ".hits";
+
+  public static final String METER_MISSES = METER_PREFIX
+      + ".misses";
+
+  public static final String METER_EVICTIONS = METER_PREFIX
+      + ".evictions";
+
+  public static final String METER_EVICTIONS_UNUSED = METER_PREFIX
+      + ".evictions.unused";
+
+  public static final String METER_LOST_HINTS = METER_PREFIX
+      + ".lost.hints";
+
+  /**
+   * How many lost hints have to pile up before the eviction-pressure warning is
+   * logged. A single lost hint is a real loss but a poor reason to shout - it may
+   * be the tail of a load peak.
+   */
+  public static final int LOST_HINTS_WARNING_THRESHOLD = 10;
+
+  /**
+   * How often the eviction-pressure warning is logged at most.
+   */
+  public static final Duration WARNING_INTERVAL = Duration.ofHours(1);
+
+  private final WorkflowAdapterCacheProperties properties;
+
+  private final LongAdder hits = new LongAdder();
+
+  private final LongAdder misses = new LongAdder();
+
+  private final LongAdder evictions = new LongAdder();
+
+  private final LongAdder evictionsBeforeFirstUse = new LongAdder();
+
+  private final LongAdder lostHints = new LongAdder();
+
+  /**
+   * The key hashes of entries evicted before they were ever read, bounded exactly
+   * like the cache itself: an eviction older than a full turn of the cache says
+   * nothing about the current load. Hash collisions are possible and acceptable -
+   * they can only add to a warning which is about an order of magnitude, never to a
+   * decision.
+   */
+  private final Map<Integer, Boolean> evictedUnused;
+
+  /**
+   * Reports the current number of entries, registered by the cache implementation
+   * knowing it (the in-memory default) or <code>null</code>.
+   */
+  private volatile IntSupplier sizeSupplier;
+
+  private long lostHintsSinceLastWarning;
+
+  private long observationStartedAtMillis = System.currentTimeMillis();
+
+  private boolean warned;
+
+  public WorkflowAdapterCacheStatistics() {
+
+    this(new WorkflowAdapterCacheProperties());
+
+  }
+
+  public WorkflowAdapterCacheStatistics(
+      final WorkflowAdapterCacheProperties properties) {
+
+    this.properties = properties;
+    final var ghostEntries = properties.getMaxEntries();
+    this.evictedUnused = new LinkedHashMap<>(16, 0.75f, false) {
+      @Override
+      protected boolean removeEldestEntry(
+          final Map.Entry<Integer, Boolean> eldest) {
+        return size() > ghostEntries;
+      }
+    };
+
+  }
+
+  /**
+   * Registers where the current number of entries is read from - called by a cache
+   * implementation which knows it.
+   *
+   * @param sizeSupplier Reports the current number of entries
+   */
+  public void registerSize(
+      final IntSupplier sizeSupplier) {
+
+    this.sizeSupplier = sizeSupplier;
+
+  }
+
+  /**
+   * The current number of entries, or {@link OptionalInt#empty()} if the cache in
+   * use does not report it (every implementation but VanillaBP's in-memory
+   * default).
+   *
+   * @return The number of entries held
+   */
+  public OptionalInt getSize() {
+
+    final var supplier = sizeSupplier;
+    return supplier == null
+        ? OptionalInt.empty()
+        : OptionalInt.of(supplier.getAsInt());
+
+  }
+
+  public long getHits() {
+
+    return hits.sum();
+
+  }
+
+  public long getMisses() {
+
+    return misses.sum();
+
+  }
+
+  public long getEvictions() {
+
+    return evictions.sum();
+
+  }
+
+  public long getEvictionsBeforeFirstUse() {
+
+    return evictionsBeforeFirstUse.sum();
+
+  }
+
+  public long getLostHints() {
+
+    return lostHints.sum();
+
+  }
+
+  /**
+   * Counts a lookup which found a hint.
+   */
+  public void recordHit() {
+
+    hits.increment();
+
+  }
+
+  /**
+   * Counts a lookup which found nothing - and checks whether the missing entry was
+   * one dropped for lack of space (a lost hint).
+   *
+   * @param workflowModuleId The ID of the workflow module
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param workflowAggregateId The workflow-aggregate ID in serialized form
+   */
+  public void recordMiss(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    misses.increment();
+
+    final var key = keyOf(workflowModuleId, bpmnProcessId, workflowAggregateId);
+    final boolean lost;
+    synchronized (evictedUnused) {
+      lost = evictedUnused.remove(key) != null;
+    }
+    if (lost) {
+      lostHints.increment();
+      warnAboutEvictionPressure();
+    }
+
+  }
+
+  /**
+   * Counts an entry dropped because the size bound was reached (expiry is NOT an
+   * eviction: the entry did its job for a full time-to-live).
+   *
+   * @param workflowModuleId The ID of the workflow module
+   * @param bpmnProcessId The BPMN process ID of the workflow
+   * @param workflowAggregateId The workflow-aggregate ID in serialized form
+   * @param used Whether the entry was read at least once before it was dropped
+   */
+  public void recordEviction(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final boolean used) {
+
+    evictions.increment();
+    if (used) {
+      return;
+    }
+
+    evictionsBeforeFirstUse.increment();
+    final var key = keyOf(workflowModuleId, bpmnProcessId, workflowAggregateId);
+    synchronized (evictedUnused) {
+      evictedUnused.put(key, Boolean.TRUE);
+    }
+
+  }
+
+  private static Integer keyOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    return Objects.hash(workflowModuleId, bpmnProcessId, workflowAggregateId);
+
+  }
+
+  /**
+   * Logs at most one warning per {@link #WARNING_INTERVAL}, and only once enough
+   * hints were lost to make the load - not a single unlucky workflow - the reason.
+   * The observation period is reported with the number, so the rate is readable.
+   */
+  private void warnAboutEvictionPressure() {
+
+    final String message;
+    synchronized (this) {
+      ++lostHintsSinceLastWarning;
+      if (lostHintsSinceLastWarning < LOST_HINTS_WARNING_THRESHOLD) {
+        return;
+      }
+      final var now = System.currentTimeMillis();
+      final var observedForMillis = now - observationStartedAtMillis;
+      if (warned && (observedForMillis < WARNING_INTERVAL.toMillis())) {
+        return;
+      }
+      message = """
+          The election cache is too small for this application's load: %d cached BPMS elections were \
+          dropped for lack of space within the last %d minutes and looked up again afterwards. Each of \
+          them costs an extra probe of all prioritized adapters and, on a BPMS answering from an \
+          eventually consistent read model, the waiting period a workflow needs right after its start.
+          Raise the property '%s' (currently %d entries; about 300 bytes per entry, so 100.000 entries \
+          cost roughly 30 MB of heap). If the application runs as a cluster, a shared cache serves \
+          the same purpose - provide a bean implementing io.vanillabp.integration.spi.WorkflowAdapterCache."""
+          .formatted(
+              lostHintsSinceLastWarning,
+              Math.max(1, observedForMillis / 60_000),
+              WorkflowAdapterCacheProperties.MAX_ENTRIES_PROPERTY,
+              properties.getMaxEntries());
+      lostHintsSinceLastWarning = 0;
+      observationStartedAtMillis = now;
+      warned = true;
+    }
+    log.warn(message);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/WorkflowAdapterCachePropertiesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/WorkflowAdapterCachePropertiesTest.java
@@ -1,0 +1,120 @@
+package io.vanillabp.migration.test.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Pins the election cache's defaults and its startup validation (story 58): what was
+ * a fixed 10.000 entries / 1 hour became configurable WITHOUT changing what an
+ * unconfigured application gets.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCachePropertiesTest {
+
+  @Test
+  @DisplayName("The defaults are 10.000 entries and one hour")
+  public void defaultsArePinned() {
+
+    final var properties = new WorkflowAdapterCacheProperties();
+
+    assertEquals(10_000, properties.getMaxEntries());
+    assertEquals(Duration.ofHours(1), properties.getTimeToLive());
+
+  }
+
+  @Test
+  @DisplayName("An unconfigured section yields the defaults")
+  public void unconfiguredSectionYieldsDefaults() {
+
+    final var properties = new MigrationAdapterProperties();
+
+    assertNotNull(properties.getWorkflowAdapterCache());
+    assertEquals(10_000, properties.getWorkflowAdapterCache().getMaxEntries());
+
+  }
+
+  @Test
+  @DisplayName("A cache holding no entry is rejected, naming the property")
+  public void maxEntriesHasToBePositive() {
+
+    final var message = assertThrows(
+        IllegalStateException.class,
+        () -> WorkflowAdapterCacheProperties
+            .builder()
+            .maxEntries(0)
+            .build()
+            .validate())
+        .getMessage();
+
+    assertTrue(
+        message.contains(WorkflowAdapterCacheProperties.MAX_ENTRIES_PROPERTY),
+        "the message has to name the property but got: "
+            + message);
+    assertTrue(
+        message.contains("at least 1"),
+        "the message has to name the fix but got: "
+            + message);
+
+  }
+
+  @Test
+  @DisplayName("An entry expiring immediately is rejected, naming the property")
+  public void timeToLiveHasToBePositive() {
+
+    final var message = assertThrows(
+        IllegalStateException.class,
+        () -> WorkflowAdapterCacheProperties
+            .builder()
+            .timeToLive(Duration.ZERO)
+            .build()
+            .validate())
+        .getMessage();
+
+    assertTrue(
+        message.contains(WorkflowAdapterCacheProperties.TIME_TO_LIVE_PROPERTY),
+        "the message has to name the property but got: "
+            + message);
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> WorkflowAdapterCacheProperties
+            .builder()
+            .timeToLive(null)
+            .build()
+            .validate());
+    assertThrows(
+        IllegalStateException.class,
+        () -> WorkflowAdapterCacheProperties
+            .builder()
+            .timeToLive(Duration.ofSeconds(-1))
+            .build()
+            .validate());
+
+  }
+
+  @Test
+  @DisplayName("Configured bounds pass the validation")
+  public void configuredBoundsAreAccepted() {
+
+    WorkflowAdapterCacheProperties
+        .builder()
+        .maxEntries(100_000)
+        .timeToLive(Duration.ofMinutes(30))
+        .build()
+        .validate();
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/WorkflowAdapterCacheMetersTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/WorkflowAdapterCacheMetersTest.java
@@ -1,0 +1,89 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
+import io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The Micrometer binding of the election cache's statistics (story 58): every number
+ * VanillaBP reports arrives in the registry, and the size of a cache which does not
+ * report one is NaN instead of a wrong zero.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCacheMetersTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  @Test
+  @DisplayName("Hits, misses, evictions and size arrive in the registry")
+  public void statisticsArriveInTheRegistry() {
+
+    final var properties = WorkflowAdapterCacheProperties
+        .builder()
+        .maxEntries(1)
+        .timeToLive(Duration.ofHours(1))
+        .build();
+    final var statistics = new WorkflowAdapterCacheStatistics(properties);
+    final var cache = InstrumentedWorkflowAdapterCache.instrument(
+        new InMemoryWorkflowAdapterCache(properties, statistics), statistics);
+
+    final var registry = new SimpleMeterRegistry();
+    new WorkflowAdapterCacheMeters(statistics).bindTo(registry);
+
+    cache.put(MODULE, PROCESS, "1", "adapter-a");
+    cache.put(MODULE, PROCESS, "2", "adapter-a");
+    assertTrue(cache.get(MODULE, PROCESS, "2").isPresent());
+    assertTrue(cache.get(MODULE, PROCESS, "1").isEmpty());
+
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_SIZE).gauge().value());
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_HITS).functionCounter().count());
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_MISSES).functionCounter().count());
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_EVICTIONS).functionCounter().count());
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_EVICTIONS_UNUSED).functionCounter().count());
+    assertEquals(
+        1.0,
+        registry.get(WorkflowAdapterCacheStatistics.METER_LOST_HINTS).functionCounter().count());
+
+  }
+
+  @Test
+  @DisplayName("A cache not reporting its size gauges NaN, not zero")
+  public void unknownSizeIsNaN() {
+
+    final var statistics = new WorkflowAdapterCacheStatistics();
+
+    final var registry = new SimpleMeterRegistry();
+    new WorkflowAdapterCacheMeters(statistics).bindTo(registry);
+
+    assertTrue(
+        Double.isNaN(registry.get(WorkflowAdapterCacheStatistics.METER_SIZE).gauge().value()),
+        "an application-provided cache does not report a size");
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/WorkflowAdapterCacheStatisticsTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/WorkflowAdapterCacheStatisticsTest.java
@@ -1,0 +1,284 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
+import io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * What the election cache reports about itself (story 58): the bounds come from the
+ * configuration, an entry dropped for lack of space before it was ever read is told
+ * apart from one which did its job, and the warning about eviction pressure appears
+ * only where hints were really lost - and then at most once per hour.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCacheStatisticsTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static WorkflowAdapterCacheProperties boundedTo(
+      final int maxEntries) {
+
+    return WorkflowAdapterCacheProperties
+        .builder()
+        .maxEntries(maxEntries)
+        .timeToLive(Duration.ofHours(1))
+        .build();
+
+  }
+
+  @Test
+  @DisplayName("The bounds of the in-memory cache come from the configuration")
+  public void boundsComeFromConfiguration() {
+
+    final var statistics = new WorkflowAdapterCacheStatistics(boundedTo(2));
+    final var cache = new InMemoryWorkflowAdapterCache(boundedTo(2), statistics);
+
+    cache.put(MODULE, PROCESS, "1", "adapter-a");
+    cache.put(MODULE, PROCESS, "2", "adapter-a");
+    assertEquals(2, statistics.getSize().orElseThrow());
+    assertEquals(0, statistics.getEvictions());
+
+    cache.put(MODULE, PROCESS, "3", "adapter-a");
+
+    assertEquals(2, statistics.getSize().orElseThrow(), "the configured bound is honored");
+    assertEquals(1, statistics.getEvictions());
+
+  }
+
+  @Test
+  @DisplayName("Only an entry evicted before its first read counts towards the pressure")
+  public void onlyUnusedEvictionsCountTowardsThePressure() {
+
+    final var statistics = new WorkflowAdapterCacheStatistics(boundedTo(2));
+    final var cache = InstrumentedWorkflowAdapterCache.instrument(
+        new InMemoryWorkflowAdapterCache(boundedTo(2), statistics), statistics);
+
+    cache.put(MODULE, PROCESS, "used", "adapter-a");
+    cache.put(MODULE, PROCESS, "unused", "adapter-a");
+    // read "used" - it did its job AND becomes the most recently used entry, so the
+    // next put evicts "unused"
+    assertTrue(cache.get(MODULE, PROCESS, "used").isPresent());
+    cache.put(MODULE, PROCESS, "another", "adapter-a");
+
+    assertEquals(1, statistics.getEvictions());
+    assertEquals(1, statistics.getEvictionsBeforeFirstUse());
+    assertEquals(0, statistics.getLostHints(), "nobody asked for the evicted entry yet");
+
+    // now "used" is the least recently used entry and IS evicted having been read
+    cache.put(MODULE, PROCESS, "yet-another", "adapter-a");
+
+    assertEquals(2, statistics.getEvictions());
+    assertEquals(1, statistics.getEvictionsBeforeFirstUse(), "a used entry is no pressure");
+
+  }
+
+  @Test
+  @DisplayName("A lookup of an entry evicted unused is counted as a lost hint")
+  public void lookupOfAnEvictedEntryIsALostHint() {
+
+    final var statistics = new WorkflowAdapterCacheStatistics(boundedTo(1));
+    final var cache = InstrumentedWorkflowAdapterCache.instrument(
+        new InMemoryWorkflowAdapterCache(boundedTo(1), statistics), statistics);
+
+    cache.put(MODULE, PROCESS, "1", "adapter-a");
+    cache.put(MODULE, PROCESS, "2", "adapter-a");
+
+    assertTrue(cache.get(MODULE, PROCESS, "1").isEmpty());
+    assertEquals(1, statistics.getMisses());
+    assertEquals(1, statistics.getLostHints(), "the bound decided this outcome, not the workflow");
+
+    // a workflow nobody ever cached is a plain miss
+    assertTrue(cache.get(MODULE, PROCESS, "never-seen").isEmpty());
+    assertEquals(2, statistics.getMisses());
+    assertEquals(1, statistics.getLostHints());
+
+    // and a hit stays a hit
+    assertTrue(cache.get(MODULE, PROCESS, "2").isPresent());
+    assertEquals(1, statistics.getHits());
+
+  }
+
+  @Test
+  @DisplayName("Eviction pressure is warned about at most once per hour, naming the property")
+  public void evictionPressureIsWarnedAboutOncePerHour() {
+
+    final var warnings = captureWarnings();
+    try {
+
+      final var statistics = new WorkflowAdapterCacheStatistics(boundedTo(1));
+      final var cache = InstrumentedWorkflowAdapterCache.instrument(
+          new InMemoryWorkflowAdapterCache(boundedTo(1), statistics), statistics);
+
+      // fewer lost hints than the threshold: a single unlucky workflow is no reason
+      // to shout
+      loseHints(cache, 0, WorkflowAdapterCacheStatistics.LOST_HINTS_WARNING_THRESHOLD - 1);
+      assertTrue(warnings.list.isEmpty(), "a few lost hints must not produce a warning");
+
+      loseHints(cache, 100, WorkflowAdapterCacheStatistics.LOST_HINTS_WARNING_THRESHOLD);
+      assertEquals(1, warnings.list.size(), "expected exactly one warning");
+      final var warning = warnings.list.getFirst().getFormattedMessage();
+      assertTrue(
+          warning.contains(WorkflowAdapterCacheProperties.MAX_ENTRIES_PROPERTY),
+          "the warning has to name the property to raise but got: "
+              + warning);
+      assertTrue(
+          warning.contains("too small for this application's load"),
+          "the warning has to say what is wrong but got: "
+              + warning);
+
+      // the next hour's worth of losses stays silent
+      loseHints(cache, 1000, 10 * WorkflowAdapterCacheStatistics.LOST_HINTS_WARNING_THRESHOLD);
+      assertEquals(1, warnings.list.size(), "at most one warning per hour");
+
+    } finally {
+      warnings.detach();
+    }
+
+  }
+
+  @Test
+  @DisplayName("Without statistics the cache works exactly as before")
+  public void statisticsAreOptional() {
+
+    final var cache = InstrumentedWorkflowAdapterCache.instrument(
+        new InMemoryWorkflowAdapterCache(), null);
+
+    cache.put(MODULE, PROCESS, "42", "adapter-a");
+    assertEquals("adapter-a", cache.get(MODULE, PROCESS, "42").orElseThrow());
+
+    // nothing to instrument at all
+    org.junit.jupiter.api.Assertions.assertNull(
+        InstrumentedWorkflowAdapterCache.instrument(null, new WorkflowAdapterCacheStatistics()));
+
+  }
+
+  @Test
+  @DisplayName("A cache which does not report its size says so")
+  public void sizeIsUnknownForAnApplicationProvidedCache() {
+
+    final var statistics = new WorkflowAdapterCacheStatistics();
+    final var cache = InstrumentedWorkflowAdapterCache.instrument(
+        new RecordingCache(), statistics);
+
+    cache.put(MODULE, PROCESS, "42", "adapter-a");
+    assertTrue(cache.get(MODULE, PROCESS, "42").isPresent());
+    cache.invalidate(MODULE, PROCESS, "42");
+    assertTrue(cache.get(MODULE, PROCESS, "42").isEmpty());
+
+    assertTrue(statistics.getSize().isEmpty(), "only the in-memory default knows its size");
+    assertEquals(1, statistics.getHits(), "lookups are counted whatever cache is in use");
+    assertEquals(1, statistics.getMisses());
+    assertEquals(0, statistics.getEvictions(), "an application's cache manages its own bounds");
+
+  }
+
+  /**
+   * Fills and overflows a cache bounded to one entry, then asks for the entry which
+   * was dropped - each round is one lost hint.
+   */
+  private static void loseHints(
+      final io.vanillabp.integration.spi.WorkflowAdapterCache cache,
+      final int firstAggregateId,
+      final int hints) {
+
+    for (var i = 0; i < hints; ++i) {
+      final var lost = String.valueOf(firstAggregateId + i);
+      cache.put(MODULE, PROCESS, lost, "adapter-a");
+      cache.put(MODULE, PROCESS, "evicts-"
+          + lost, "adapter-a");
+      cache.get(MODULE, PROCESS, lost);
+    }
+
+  }
+
+  /**
+   * Attaches an appender to the statistics' logger - the core's test setup writes
+   * no log output at all, so the warning is asserted where it is emitted.
+   */
+  private static CapturedWarnings captureWarnings() {
+
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+        .getLogger(WorkflowAdapterCacheStatistics.class);
+    final var appender = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    appender.start();
+    logger.addAppender(appender);
+    return new CapturedWarnings(appender.list, () -> logger.detachAppender(appender));
+
+  }
+
+  private record CapturedWarnings(
+                                  java.util.List<ch.qos.logback.classic.spi.ILoggingEvent> list,
+                                  Runnable detachAppender) {
+
+    private void detach() {
+
+      detachAppender.run();
+
+    }
+
+  }
+
+  /**
+   * An application-provided cache: it knows neither size nor evictions.
+   */
+  private static class RecordingCache implements io.vanillabp.integration.spi.WorkflowAdapterCache {
+
+    private final java.util.Map<String, String> entries = new java.util.concurrent.ConcurrentHashMap<>();
+
+    private static String key(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      return "%s|%s|%s".formatted(workflowModuleId, bpmnProcessId, workflowAggregateId);
+
+    }
+
+    @Override
+    public java.util.Optional<String> get(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      return java.util.Optional.ofNullable(
+          entries.get(key(workflowModuleId, bpmnProcessId, workflowAggregateId)));
+
+    }
+
+    @Override
+    public void put(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId,
+        final String adapterId) {
+
+      entries.put(key(workflowModuleId, bpmnProcessId, workflowAggregateId), adapterId);
+
+    }
+
+    @Override
+    public void invalidate(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      entries.remove(key(workflowModuleId, bpmnProcessId, workflowAggregateId));
+
+    }
+
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,12 @@
         <plugin>
           <artifactId>maven-failsafe-plugin</artifactId>
           <version>3.5.2</version>
+          <configuration>
+            <!-- deterministic order: the default 'filesystem' differs between a
+                 developer machine and the GitHub runner, which hid an order-dependent
+                 test for a day (see prompts/bugfix-flaky-test.md) -->
+            <runOrder>alphabetical</runOrder>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
@@ -143,6 +149,8 @@
             <!-- see https://javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/Mockito.html#mockito-instrumentation -->
             <!-- property 'jacoco.agent' is filled by jacoco-maven-plugin blow in this file -->
             <argLine>@{jacoco.agent} -Xshare:off -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+            <!-- deterministic order, see the failsafe configuration above -->
+            <runOrder>alphabetical</runOrder>
           </configuration>
           <dependencies>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
     <transaction-outbox.version>7.0.707</transaction-outbox.version>
     <jacoco.version>0.8.15</jacoco.version>
     <mockito.version>5.23.0</mockito.version>
+    <!-- optional: metrics of the election cache are published if the application
+         brings Micrometer; compiled against the OLDER of both platforms (Quarkus
+         3.37.1 manages 1.16.6, Spring Boot 4.1.0 manages 1.17.0) -->
+    <micrometer.version>1.16.6</micrometer.version>
     <testcontainers.version>2.0.5</testcontainers.version>
   </properties>
 
@@ -86,6 +90,11 @@
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>2.0.17</version>
+      </dependency>
+      <dependency>
+        <groupId>io.micrometer</groupId>
+        <artifactId>micrometer-core</artifactId>
+        <version>${micrometer.version}</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/WorkflowAdapterCacheMetricsBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/WorkflowAdapterCacheMetricsBuildStepProcessor.java
@@ -1,0 +1,65 @@
+package io.vanillabp.integration.deployment.processservice;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.vanillabp.integration.runtime.processservice.WorkflowAdapterCacheMetricsProducer;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Publishes the election cache's numbers as Micrometer meters - but only for an
+ * application which uses Micrometer. VanillaBP does not bring it: metrics are the
+ * application's decision, and an application without them has to boot unchanged.
+ * <p>
+ * The signal is the Micrometer extension's build-step class on the DEPLOYMENT
+ * classpath, present exactly when the application depends on the extension. The
+ * presence of Micrometer's own classes would not do - they can be dragged in
+ * transitively without the extension, and then nothing produces the
+ * {@code MeterRegistry} bean our producer needs.
+ */
+@Slf4j
+public class WorkflowAdapterCacheMetricsBuildStepProcessor {
+
+  private static final String MICROMETER_EXTENSION_PROCESSOR = "io.quarkus.micrometer.deployment.MicrometerProcessor";
+
+  /**
+   * @param additionalBeans Producer used to register the meter binder's producer
+   */
+  @BuildStep
+  void registerWorkflowAdapterCacheMeters(
+      final BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+    if (!isMicrometerExtensionPresent()) {
+      return;
+    }
+
+    log.debug(
+        "Micrometer found: the election cache reports its statistics as meters '{}.*'",
+        io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics.METER_PREFIX);
+
+    additionalBeans
+        .produce(AdditionalBeanBuildItem
+            .builder()
+            .addBeanClass(WorkflowAdapterCacheMetricsProducer.class)
+            .setUnremovable() // applied by Micrometer's own startup, never injected
+            .build());
+
+  }
+
+  private static boolean isMicrometerExtensionPresent() {
+
+    try {
+      Class.forName(
+          MICROMETER_EXTENSION_PROCESSOR,
+          false,
+          Thread
+              .currentThread()
+              .getContextClassLoader());
+      return true;
+    } catch (final ClassNotFoundException | LinkageError e) {
+      return false;
+    }
+
+  }
+
+}

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/InvalidWorkflowAdapterCacheConfigurationTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/InvalidWorkflowAdapterCacheConfigurationTest.java
@@ -1,0 +1,52 @@
+package io.vanillabp.integration.test.processservice;
+
+import static io.vanillabp.integration.test.utils.AssertException.exceptionHavingMessage;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.runtime.workflowmodule.WorkflowModule;
+import io.vanillabp.integration.test.adapter.DummyAdapters;
+import io.vanillabp.integration.test.adapter.TestAdapterDeploymentService;
+import io.vanillabp.integration.test.adapter.TestAdapterDeploymentServiceProducer;
+import io.vanillabp.integration.test.adapter.TestMigratableProcessService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Same-config-same-outcome matrix (core validation on all platforms): a cache which
+ * cannot hold a single entry is rejected at startup with a guiding message.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class InvalidWorkflowAdapterCacheConfigurationTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .setArchiveProducer(() -> ShrinkWrap
+          .create(JavaArchive.class)
+          .addPackage("io.vanillabp.integration.test.samples.sample")
+          .addAsResource("workflow-adapter-cache-invalid/application.yaml", "application.yaml")
+          .addAsResource("workflow-module-descriptor/workflow-module", WorkflowModule.METAINF_WORKFLOWMODULE)
+          .addClass(DummyAdapters.class)
+          .addClass(TestAdapterDeploymentService.class)
+          .addClass(TestAdapterDeploymentServiceProducer.class)
+          .addClass(TestMigratableProcessService.class))
+      .addBuildChainCustomizer(DummyAdapters.oneDummyAdapter())
+      .assertException(
+          exceptionHavingMessage(
+              IllegalStateException.class,
+              """
+                  The property 'vanillabp.workflow-adapter-cache.max-entries' is 0 but has to be at least 1! \
+                  The election cache is bounded on purpose (a full cache of the default 10000 entries costs about \
+                  3 MB of heap). Remove the property to use the default or set the number of workflows the \
+                  application keeps hot."""));
+
+  @Test
+  public void testInvalidBound() {
+    // should never be executed due to the expected startup exception
+  }
+
+}

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/WorkflowAdapterCacheConfigurationTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/WorkflowAdapterCacheConfigurationTest.java
@@ -1,0 +1,107 @@
+package io.vanillabp.integration.test.processservice;
+
+import java.time.Duration;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.runtime.workflowmodule.WorkflowModule;
+import io.vanillabp.integration.spi.WorkflowAdapterCache;
+import io.vanillabp.integration.test.adapter.DummyAdapters;
+import io.vanillabp.integration.test.adapter.TestAdapterDeploymentService;
+import io.vanillabp.integration.test.adapter.TestAdapterDeploymentServiceProducer;
+import io.vanillabp.integration.test.adapter.TestMigratableProcessService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * The election cache's bounds are configurable (story 58) and reach the in-memory
+ * default. This application does NOT use the Micrometer extension, which is the
+ * other half of the story: it boots exactly as before and publishes no meters.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCacheConfigurationTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .setArchiveProducer(() -> ShrinkWrap
+          .create(JavaArchive.class)
+          .addPackage("io.vanillabp.integration.test.samples.sample")
+          .addAsResource("workflow-adapter-cache/application.yaml", "application.yaml")
+          .addAsResource("workflow-module-descriptor/workflow-module", WorkflowModule.METAINF_WORKFLOWMODULE)
+          .addClass(DummyAdapters.class)
+          .addClass(TestAdapterDeploymentService.class)
+          .addClass(TestAdapterDeploymentServiceProducer.class)
+          .addClass(TestMigratableProcessService.class))
+      .addBuildChainCustomizer(DummyAdapters.oneDummyAdapter());
+
+  @Inject
+  MigrationAdapterProperties properties;
+
+  @Inject
+  WorkflowAdapterCache cache;
+
+  @Inject
+  WorkflowAdapterCacheStatistics statistics;
+
+  @Test
+  @DisplayName("The configured bounds reach the in-memory cache")
+  public void configuredBoundsReachTheCache() {
+
+    Assertions.assertEquals(2, properties.getWorkflowAdapterCache().getMaxEntries());
+    Assertions.assertEquals(
+        Duration.ofMinutes(30),
+        properties.getWorkflowAdapterCache().getTimeToLive());
+
+    Assertions.assertInstanceOf(InMemoryWorkflowAdapterCache.class, cache);
+
+    cache.put(MODULE, PROCESS, "1", "test");
+    cache.put(MODULE, PROCESS, "2", "test");
+    cache.put(MODULE, PROCESS, "3", "test");
+
+    Assertions.assertEquals(
+        2,
+        statistics.getSize().orElseThrow(),
+        "the configured bound has to be the cache's bound");
+    Assertions.assertEquals(1, statistics.getEvictions());
+
+  }
+
+  @Test
+  @DisplayName("Without the Micrometer extension no meters are published")
+  public void noMetersWithoutMicrometer() {
+
+    // the meters themselves cannot even be NAMED here: their class implements
+    // Micrometer's MeterBinder, which this application does not have
+    final var beansPublishingMeters = io.quarkus.arc.Arc
+        .container()
+        .beanManager()
+        .getBeans(Object.class, jakarta.enterprise.inject.Any.Literal.INSTANCE)
+        .stream()
+        .filter(bean -> bean
+            .getBeanClass()
+            .getName()
+            .contains("WorkflowAdapterCacheMetrics"))
+        .toList();
+
+    Assertions.assertTrue(
+        beansPublishingMeters.isEmpty(),
+        "metrics are the application's decision - VanillaBP does not bring Micrometer, but got: "
+            + beansPublishingMeters);
+
+  }
+
+}

--- a/quarkus-integration/deployment/src/test/resources/workflow-adapter-cache-invalid/application.yaml
+++ b/quarkus-integration/deployment/src/test/resources/workflow-adapter-cache-invalid/application.yaml
@@ -1,0 +1,11 @@
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  workflow-adapter-cache:
+    max-entries: 0

--- a/quarkus-integration/deployment/src/test/resources/workflow-adapter-cache/application.yaml
+++ b/quarkus-integration/deployment/src/test/resources/workflow-adapter-cache/application.yaml
@@ -1,0 +1,12 @@
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  workflow-adapter-cache:
+    max-entries: 2
+    time-to-live: 30m

--- a/quarkus-integration/integration-tests/outbox-integration-tests/pom.xml
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/pom.xml
@@ -49,6 +49,12 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-h2</artifactId>
     </dependency>
+    <!-- the election cache's meters are published only for an application using
+         the Micrometer extension (the deployment module's tests cover its absence) -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/CacheOverrideTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/CacheOverrideTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
 import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
 import io.vanillabp.integration.test.Aggregate;
 import io.vanillabp.integration.test.AggregatePersistence;
@@ -28,7 +29,7 @@ import jakarta.transaction.UserTransaction;
  * {@code WorkflowAdapterCache} bean replaces VanillaBP's in-memory
  * {@code @DefaultBean} - the election consults AND populates the application's
  * bean (this is how cluster setups share elections via their own cache
- * infrastructure).
+ * infrastructure) - and its lookups are counted like every other cache's.
  */
 @ExtendWith(SuppressOutputExtension.class)
 public class CacheOverrideTest {
@@ -54,6 +55,9 @@ public class CacheOverrideTest {
 
   @Inject
   PerAdapterAwarenessSource awareness;
+
+  @Inject
+  WorkflowAdapterCacheStatistics statistics;
 
   @Inject
   UserTransaction userTransaction;
@@ -87,6 +91,20 @@ public class CacheOverrideTest {
                 + "->test"),
         "the successful election must be stored in the application's cache but got: "
             + cache.getPuts());
+
+    // its lookups are counted like every other cache's (story 58) - a metric which
+    // disappeared once an application plugs in its own cache would surprise exactly
+    // the operator who needs it
+    assertTrue(
+        (statistics.getHits() + statistics.getMisses()) > 0,
+        "the lookups of an application-provided cache are counted, too");
+    assertTrue(
+        statistics.getSize().isEmpty(),
+        "but only VanillaBP's in-memory default knows its size");
+    assertEquals(
+        0,
+        statistics.getEvictions(),
+        "and an application's cache manages its own bounds");
 
   }
 

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/TestMeterRegistryProducer.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/TestMeterRegistryProducer.java
@@ -1,0 +1,23 @@
+package io.vanillabp.integration.it;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+/**
+ * A registry backend for the test: Quarkus adds every {@code MeterRegistry} bean to
+ * its composite, and only a composite WITH a child actually records measurements.
+ */
+@ApplicationScoped
+public class TestMeterRegistryProducer {
+
+  @Produces
+  @Singleton
+  public SimpleMeterRegistry simpleMeterRegistry() {
+
+    return new SimpleMeterRegistry();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/WorkflowAdapterCacheMetricsTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/WorkflowAdapterCacheMetricsTest.java
@@ -1,0 +1,102 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.spi.WorkflowAdapterCache;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.PerAdapterAwarenessSource;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * Sizing and observing the election cache on Quarkus (story 58): the bounds come
+ * from <code>vanillabp.workflow-adapter-cache.*</code>, and an application using the
+ * Micrometer extension gets the cache's numbers as meters - Quarkus applies every
+ * {@code MeterBinder} bean to its registry, so nothing but the bean is needed.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCacheMetricsTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .setArchiveProducer(() -> ShrinkWrap
+          .create(JavaArchive.class)
+          .addAsResource("cache-metrics.yaml", "application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(PerAdapterAwarenessSource.class)
+          .addClass(TestMeterRegistryProducer.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  MigrationAdapterProperties properties;
+
+  @Inject
+  WorkflowAdapterCache cache;
+
+  @Inject
+  WorkflowAdapterCacheStatistics statistics;
+
+  /**
+   * Quarkus' own {@code MeterRegistry} bean is a composite without any backend in
+   * this test, and a composite without children reports nothing - this registry is
+   * added to it as a child, so the values are readable.
+   */
+  @Inject
+  SimpleMeterRegistry meterRegistry;
+
+  @Test
+  @DisplayName("The configured bounds reach the cache and its numbers reach Micrometer")
+  public void boundsAndMetersAreInPlace() {
+
+    assertEquals(2, properties.getWorkflowAdapterCache().getMaxEntries());
+    assertEquals(Duration.ofMinutes(30), properties.getWorkflowAdapterCache().getTimeToLive());
+
+    cache.put(MODULE, PROCESS, "1", "test");
+    cache.put(MODULE, PROCESS, "2", "test");
+    assertTrue(cache.get(MODULE, PROCESS, "2").isPresent());
+    cache.put(MODULE, PROCESS, "3", "test");
+
+    assertEquals(2, statistics.getSize().orElseThrow(), "the configured bound is the cache's bound");
+    assertEquals(1, statistics.getEvictions());
+
+    assertEquals(
+        2.0,
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_SIZE).gauge().value());
+    assertEquals(
+        1.0,
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_EVICTIONS).functionCounter().count());
+    assertNotNull(
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_HITS).functionCounter());
+    assertNotNull(
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_MISSES).functionCounter());
+    assertNotNull(
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_EVICTIONS_UNUSED).functionCounter());
+    assertNotNull(
+        meterRegistry.get(WorkflowAdapterCacheStatistics.METER_LOST_HINTS).functionCounter());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/cache-metrics.yaml
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/resources/cache-metrics.yaml
@@ -1,0 +1,19 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:outbox-cache-metrics;DB_CLOSE_DELAY=-1
+dummy-adapter:
+  two-phase-commit: true
+vanillabp:
+  adapters:
+    test:
+      type: dummy
+  workflow-modules:
+    test-module:
+      adapters:
+        test:
+          resources-location: classpath:test-module/processes/dummy
+  workflow-adapter-cache:
+    max-entries: 2
+    time-to-live: 30m

--- a/quarkus-integration/runtime/pom.xml
+++ b/quarkus-integration/runtime/pom.xml
@@ -17,6 +17,13 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-arc</artifactId>
     </dependency>
+    <!-- optional: the election cache's meters are produced only for an application
+         using the Micrometer extension (see WorkflowAdapterCacheMetricsProducer) -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-narayana-jta</artifactId>

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -68,6 +68,14 @@ public interface QuarkusMigrationAdapterProperties {
   PhaseTwoOutboxProperties outbox();
 
   /**
+   * The configuration of the election cache consulted for operations on existing
+   * workflows (see {@link io.vanillabp.integration.spi.WorkflowAdapterCache}).
+   *
+   * @return The election cache's configuration
+   */
+  WorkflowAdapterCacheProperties workflowAdapterCache();
+
+  /**
    * The adapter configuration. The properties in detail are defined by the
    * respective VanillaBP adapter Quarkus extension.
    */
@@ -286,6 +294,33 @@ public interface QuarkusMigrationAdapterProperties {
      */
     @WithDefault("vanillabp-phase-two-outbox")
     String collection();
+
+  }
+
+  /**
+   * The configuration of the election cache's in-memory default implementation.
+   * Both bounds are hard on purpose - entries are hints, so losing one costs an
+   * extra probing walk but never correctness.
+   */
+  interface WorkflowAdapterCacheProperties {
+
+    /**
+     * The maximum number of entries held - the least recently used entry is dropped
+     * beyond that. Raise it if the application keeps more workflows hot than the
+     * cache holds (VanillaBP warns about it).
+     *
+     * @return The maximum number of entries
+     */
+    @WithDefault("10000")
+    int maxEntries();
+
+    /**
+     * How long an entry is kept, counted from the moment it was stored.
+     *
+     * @return The time-to-live of an entry
+     */
+    @WithDefault("PT1H")
+    Duration timeToLive();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
@@ -14,6 +14,7 @@ import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
 import io.vanillabp.integration.adapter.migration.config.TaskAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
 import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
 
@@ -61,6 +62,9 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
 
   PhaseTwoOutboxProperties.MongoOutboxProperties toCore(
       QuarkusMigrationAdapterProperties.MongoOutboxProperties mongoOutboxProperties);
+
+  WorkflowAdapterCacheProperties toCore(
+      QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCacheProperties);
 
   AdapterConfigProperties toCore(
       QuarkusMigrationAdapterProperties.AdapterConfiguration adapterConfiguration);

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -106,6 +106,13 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   @Inject
   Instance<io.vanillabp.integration.spi.WorkflowAdapterCache> workflowAdapterCache;
 
+  /**
+   * The application-wide numbers of the election cache - every lookup of whatever
+   * cache is in use is counted into this one instance.
+   */
+  @Inject
+  Instance<io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics> workflowAdapterCacheStatistics;
+
   @Getter
   MigrationProcessService<A> migrationProcessService;
 
@@ -152,9 +159,14 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
             .enabled(), outboxProperties
                 .mongo()
                 .enabled());
-    final var electionCache = workflowAdapterCache.isResolvable()
-        ? workflowAdapterCache.get()
-        : null;
+    final var electionCache = io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache
+        .instrument(
+            workflowAdapterCache.isResolvable()
+                ? workflowAdapterCache.get()
+                : null,
+            workflowAdapterCacheStatistics.isResolvable()
+                ? workflowAdapterCacheStatistics.get()
+                : null);
     this.migrationProcessService = new MigrationProcessService<>(
         getWorkflowModuleId(), getBpmnProcessId(), getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache);
 
@@ -166,7 +178,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
           .register(migrationProcessService);
     }
 
-    registerWorkflowTaskHandlers(processServices, phaseTwoOutboxResolver);
+    registerWorkflowTaskHandlers(processServices, phaseTwoOutboxResolver, electionCache);
 
   }
 
@@ -179,7 +191,8 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
    */
   private void registerWorkflowTaskHandlers(
       final List<io.vanillabp.integration.adapter.spi.MigratableProcessService<A>> processServices,
-      final QuarkusPhaseTwoOutboxResolver phaseTwoOutboxResolver) {
+      final QuarkusPhaseTwoOutboxResolver phaseTwoOutboxResolver,
+      final io.vanillabp.integration.spi.WorkflowAdapterCache electionCache) {
 
     if (!workflowTaskRegistry.isResolvable()) {
       return;
@@ -209,10 +222,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
           "%s|%s".formatted(moduleId, bpmnProcessId),
           key -> {
             final var secondaryProcessService = new MigrationProcessService<>(
-                moduleId, bpmnProcessId, getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, workflowAdapterCache
-                    .isResolvable()
-                        ? workflowAdapterCache.get()
-                        : null);
+                moduleId, bpmnProcessId, getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache);
             if (phaseTwoRouter.isResolvable()) {
               phaseTwoRouter
                   .get()

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/WorkflowAdapterCacheMetricsProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/WorkflowAdapterCacheMetricsProducer.java
@@ -1,0 +1,30 @@
+package io.vanillabp.integration.runtime.processservice;
+
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+/**
+ * Publishes the election cache's statistics as Micrometer meters. Quarkus applies
+ * every {@code MeterBinder} bean to its registry, so producing the binder is all it
+ * takes.
+ * <p>
+ * This class is registered as a bean ONLY if the application uses the Micrometer
+ * extension (see {@code WorkflowAdapterCacheMetricsBuildStepProcessor}) - it
+ * references Micrometer types and must not be loaded otherwise.
+ */
+@ApplicationScoped
+public class WorkflowAdapterCacheMetricsProducer {
+
+  @Produces
+  @Singleton
+  public WorkflowAdapterCacheMeters workflowAdapterCacheMeters(
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    return new WorkflowAdapterCacheMeters(statistics);
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/WorkflowAdapterCacheProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/WorkflowAdapterCacheProducer.java
@@ -1,7 +1,14 @@
 package io.vanillabp.integration.runtime.processservice;
 
+import org.eclipse.microprofile.config.ConfigProvider;
+
 import io.quarkus.arc.DefaultBean;
+import io.smallrye.config.SmallRyeConfig;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
 import io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
 import io.vanillabp.integration.spi.WorkflowAdapterCache;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
@@ -9,21 +16,52 @@ import jakarta.inject.Singleton;
 
 /**
  * Produces the default {@link WorkflowAdapterCache} consulted by the BPMS election
- * for operations on existing workflows: a bounded, expiring in-memory cache.
- * Cluster setups wanting instances to share elections define their own bean
- * implementing {@link WorkflowAdapterCache} backed by their own cache
- * infrastructure - it replaces this default ({@link DefaultBean}; entries are
- * hints: a stale entry costs an extra probe, never correctness).
+ * for operations on existing workflows: a bounded, expiring in-memory cache sized by
+ * <code>vanillabp.workflow-adapter-cache.*</code>. Cluster setups wanting instances
+ * to share elections define their own bean implementing {@link WorkflowAdapterCache}
+ * backed by their own cache infrastructure - it replaces this default
+ * ({@link DefaultBean}; entries are hints: a stale entry costs an extra probe, never
+ * correctness).
+ * <p>
+ * The cache's statistics are produced here as well and belong to the application,
+ * not to a cache: the process services count the lookups of WHATEVER cache is in use
+ * into this one instance (see
+ * {@code io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache}).
+ * <p>
+ * The configuration is READ, not injected: injecting the config mapping would make
+ * it a static-init mapping, and SmallRye would then validate the shared
+ * <code>vanillabp.*</code> tree before the adapter extensions registered their
+ * run-time overlays - every adapter-specific key would fail the startup as unknown.
  */
 @ApplicationScoped
 public class WorkflowAdapterCacheProducer {
 
   @Produces
   @Singleton
-  @DefaultBean
-  public WorkflowAdapterCache workflowAdapterCache() {
+  public WorkflowAdapterCacheStatistics workflowAdapterCacheStatistics() {
 
-    return new InMemoryWorkflowAdapterCache();
+    return new WorkflowAdapterCacheStatistics(cacheProperties());
+
+  }
+
+  @Produces
+  @Singleton
+  @DefaultBean
+  public WorkflowAdapterCache workflowAdapterCache(
+      final WorkflowAdapterCacheStatistics statistics) {
+
+    return new InMemoryWorkflowAdapterCache(cacheProperties(), statistics);
+
+  }
+
+  private WorkflowAdapterCacheProperties cacheProperties() {
+
+    return QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(
+        ConfigProvider
+            .getConfig()
+            .unwrap(SmallRyeConfig.class)
+            .getConfigMapping(QuarkusMigrationAdapterProperties.class)
+            .workflowAdapterCache());
 
   }
 

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -82,12 +82,18 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                   QuarkusMigrationAdapterProperties.MongoOutboxProperties mongo) implements QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties {
   }
 
+  private record WorkflowAdapterCacheProperties(
+                                                int maxEntries,
+                                                Duration timeToLive) implements QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties {
+  }
+
   private record Properties(
                             Optional<List<String>> prioritizedAdapters,
                             Optional<String> resourcesLocation,
                             Map<String, QuarkusMigrationAdapterProperties.AdapterConfiguration> adapters,
                             Map<String, QuarkusMigrationAdapterProperties.WorkflowModuleProperties> workflowModules,
-                            QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox) implements QuarkusMigrationAdapterProperties {
+                            QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
+                            QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache) implements QuarkusMigrationAdapterProperties {
   }
 
   @Test
@@ -122,7 +128,10 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                                                                         .ofDays(
                                                                                             1), new JdbcOutboxProperties(false, Optional
                                                                                                 .of("HOT_OUTBOX")), new MongoOutboxProperties(
-                                                                                                    false, "hot-outbox")));
+                                                                                                    false, "hot-outbox")), new WorkflowAdapterCacheProperties(
+                                                                                                        50_000, Duration
+                                                                                                            .ofMinutes(
+                                                                                                                30)));
 
     final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
 
@@ -156,6 +165,27 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
     assertEquals("HOT_OUTBOX", core.getOutbox().getJdbc().getTable());
     assertFalse(core.getOutbox().getMongo().isEnabled());
     assertEquals("hot-outbox", core.getOutbox().getMongo().getCollection());
+
+    assertEquals(50_000, core.getWorkflowAdapterCache().getMaxEntries());
+    assertEquals(Duration.ofMinutes(30), core.getWorkflowAdapterCache().getTimeToLive());
+
+  }
+
+  @Test
+  @DisplayName("The interface's @WithDefault election-cache values equal the core defaults")
+  public void workflowAdapterCacheDefaultsMatchCoreDefaults() {
+
+    final var config = new SmallRyeConfigBuilder()
+        .withMapping(QuarkusMigrationAdapterProperties.class)
+        .build();
+    final var mappedDefaults = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(
+        config
+            .getConfigMapping(QuarkusMigrationAdapterProperties.class)
+            .workflowAdapterCache());
+
+    final var coreDefaults = new io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties();
+    assertEquals(coreDefaults.getMaxEntries(), mappedDefaults.getMaxEntries());
+    assertEquals(coreDefaults.getTimeToLive(), mappedDefaults.getTimeToLive());
 
   }
 
@@ -192,7 +222,7 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
   public void emptyOptionalsMapToDefaults() {
 
     final var properties = new Properties(
-        Optional.empty(), Optional.empty(), Map.of(), Map.of(), null);
+        Optional.empty(), Optional.empty(), Map.of(), Map.of(), null, null);
 
     final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
 

--- a/spring-boot-integration/integration-tests/main-integration-test/pom.xml
+++ b/spring-boot-integration/integration-tests/main-integration-test/pom.xml
@@ -62,6 +62,13 @@
       <artifactId>dummy-extension</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <!-- the election cache's meters are published only if the application brings
+         Micrometer - the test proves both halves (present and filtered out) -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>test-utils</artifactId>

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/processservice/WorkflowAdapterCacheConfigurationTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/processservice/WorkflowAdapterCacheConfigurationTest.java
@@ -1,0 +1,361 @@
+package io.vanillabp.integration.test.processservice;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.ResolvableType;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties;
+import io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters;
+import io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics;
+import io.vanillabp.integration.processservice.ProcessServiceSpringBean;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.WorkflowAdapterCache;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.sample.Aggregate;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+import io.vanillabp.spi.process.ProcessService;
+
+/**
+ * Sizing and observing the election cache on Spring Boot (story 58): the bounds are
+ * bound from <code>vanillabp.workflow-adapter-cache.*</code> and validated at
+ * startup, the statistics are published as Micrometer meters where the application
+ * brings Micrometer, and an application-provided cache still replaces the default
+ * while its lookups are counted like every other cache's.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class WorkflowAdapterCacheConfigurationTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private ApplicationContextRunner contextRunner() {
+
+    return new ApplicationContextRunner()
+        .withPropertyValues("spring.config.location=classpath:application.yaml")
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withUserConfiguration(WorkflowModuleConfiguration.class, TestPersistenceConfiguration.class)
+        .withConfiguration(
+            AutoConfigurations.of(
+                DummyAdapterConfiguration.class, DummyAdapterProcessServiceConfiguration.class,
+                WorkflowModuleAutoConfiguration.class,
+                SpringBootMigrationAdapterAutoConfiguration.class));
+
+  }
+
+  @Test
+  @DisplayName("The configured bounds reach the in-memory cache")
+  public void configuredBoundsReachTheCache() {
+
+    contextRunner()
+        .withPropertyValues(
+            "vanillabp.workflow-adapter-cache.max-entries=2",
+            "vanillabp.workflow-adapter-cache.time-to-live=30m")
+        .run(context -> {
+
+          final var properties = context.getBean(MigrationAdapterProperties.class);
+          Assertions.assertEquals(2, properties.getWorkflowAdapterCache().getMaxEntries());
+          Assertions.assertEquals(
+              Duration.ofMinutes(30),
+              properties.getWorkflowAdapterCache().getTimeToLive());
+
+          final var cache = context.getBean(WorkflowAdapterCache.class);
+          Assertions.assertInstanceOf(InMemoryWorkflowAdapterCache.class, cache);
+          final var statistics = context.getBean(WorkflowAdapterCacheStatistics.class);
+
+          cache.put(MODULE, PROCESS, "1", "test");
+          cache.put(MODULE, PROCESS, "2", "test");
+          cache.put(MODULE, PROCESS, "3", "test");
+
+          Assertions.assertEquals(
+              2,
+              statistics.getSize().orElseThrow(),
+              "the configured bound has to be the cache's bound");
+          Assertions.assertEquals(1, statistics.getEvictions());
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("An unconfigured application keeps the defaults")
+  public void defaultsApplyWithoutConfiguration() {
+
+    contextRunner()
+        .run(context -> {
+
+          final var properties = context.getBean(MigrationAdapterProperties.class);
+          Assertions.assertEquals(
+              WorkflowAdapterCacheProperties.DEFAULT_MAX_ENTRIES,
+              properties.getWorkflowAdapterCache().getMaxEntries());
+          Assertions.assertEquals(
+              WorkflowAdapterCacheProperties.DEFAULT_TIME_TO_LIVE,
+              properties.getWorkflowAdapterCache().getTimeToLive());
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("A cache holding no entry fails the startup, naming the property")
+  public void invalidBoundFailsTheStartup() {
+
+    contextRunner()
+        .withPropertyValues("vanillabp.workflow-adapter-cache.max-entries=0")
+        .run(context -> {
+
+          final var failure = context.getStartupFailure();
+          Assertions.assertNotNull(failure, "the startup has to fail");
+          final var message = messagesOf(failure);
+          Assertions.assertTrue(
+              message.contains(WorkflowAdapterCacheProperties.MAX_ENTRIES_PROPERTY),
+              "the failure has to name the property but got: "
+                  + message);
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("The statistics are published as Micrometer meters")
+  public void statisticsArePublishedAsMeters() {
+
+    contextRunner()
+        .run(context -> {
+
+          final var meters = context.getBean(WorkflowAdapterCacheMeters.class);
+          final var registry = new SimpleMeterRegistry();
+          meters.bindTo(registry);
+
+          final var cache = context.getBean(WorkflowAdapterCache.class);
+          final var processService = processServiceOf(context);
+          Assertions.assertNotNull(processService, "the process service uses the same statistics");
+          cache.put(MODULE, PROCESS, "42", "test");
+
+          Assertions.assertEquals(
+              1.0,
+              registry.get(WorkflowAdapterCacheStatistics.METER_SIZE).gauge().value());
+          Assertions.assertNotNull(
+              registry.get(WorkflowAdapterCacheStatistics.METER_HITS).functionCounter());
+          Assertions.assertNotNull(
+              registry.get(WorkflowAdapterCacheStatistics.METER_LOST_HINTS).functionCounter());
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("Without Micrometer the application boots and reports no metrics")
+  public void withoutMicrometerNoMeters() {
+
+    contextRunner()
+        .withClassLoader(
+            new org.springframework.boot.test.context.FilteredClassLoader(MeterRegistry.class))
+        .run(context -> {
+
+          Assertions.assertNull(context.getStartupFailure(), "the application has to boot");
+          Assertions.assertTrue(
+              context
+                  .getBeanNamesForType(WorkflowAdapterCacheStatistics.class).length > 0,
+              "the numbers are collected in any case - the eviction warning needs them");
+          Assertions.assertEquals(
+              0,
+              countMeterBeans(context),
+              "no meter binder without Micrometer");
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("An application-provided cache replaces the default and is counted")
+  public void applicationProvidedCacheIsCounted() {
+
+    contextRunner()
+        .withUserConfiguration(ApplicationCacheConfiguration.class)
+        .run(context -> {
+
+          Assertions.assertEquals(
+              1,
+              context.getBeanNamesForType(WorkflowAdapterCache.class).length,
+              "the application's bean replaces VanillaBP's default");
+
+          final var processService = processServiceOf(context);
+          final var statistics = context.getBean(WorkflowAdapterCacheStatistics.class);
+          final var cache = context.getBean(ApplicationCache.class);
+
+          // the process services wrap the application's cache - the election of an
+          // unknown workflow is a miss counted here
+          Assertions.assertNotNull(processService);
+          org.springframework.transaction.support.TransactionSynchronizationManager
+              .setActualTransactionActive(true);
+          try {
+            Assertions.assertThrows(
+                Exception.class,
+                () -> processService.completeTask(new Aggregate(), "task-unknown"));
+          } finally {
+            org.springframework.transaction.support.TransactionSynchronizationManager
+                .setActualTransactionActive(false);
+          }
+
+          Assertions.assertFalse(cache.gets.isEmpty(), "the election consults the application's cache");
+          Assertions.assertTrue(statistics.getMisses() > 0, "its lookups are counted like any other");
+          Assertions.assertTrue(
+              statistics.getSize().isEmpty(),
+              "an application's cache reports no size");
+
+        });
+
+  }
+
+  private static int countMeterBeans(
+      final org.springframework.boot.test.context.assertj.AssertableApplicationContext context) {
+
+    return (int) java.util.Arrays
+        .stream(context.getBeanDefinitionNames())
+        .filter(name -> name.toLowerCase().contains("workflowadaptercachemeters"))
+        .count();
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private static ProcessService<Aggregate> processServiceOf(
+      final org.springframework.boot.test.context.assertj.AssertableApplicationContext context) {
+
+    final var names = context.getBeanNamesForType(
+        ResolvableType.forClassWithGenerics(ProcessService.class, Aggregate.class));
+    return names.length == 0
+        ? null
+        : ((ProcessServiceSpringBean<Aggregate>) context.getBean(names[0], ProcessService.class));
+
+  }
+
+  private static String messagesOf(
+      final Throwable failure) {
+
+    final var messages = new StringBuilder();
+    for (var cause = failure; cause != null; cause = cause.getCause()) {
+      messages
+          .append(cause.getMessage())
+          .append('\n');
+    }
+    return messages.toString();
+
+  }
+
+  @Configuration(proxyBeanMethods = false)
+  static class ApplicationCacheConfiguration {
+
+    @Bean
+    ApplicationCache applicationCache() {
+
+      return new ApplicationCache();
+
+    }
+
+    /**
+     * A persistence reporting a stable aggregate ID - the election caches per
+     * aggregate ID, so an aggregate without one is never cached.
+     */
+    @Bean
+    io.vanillabp.integration.spi.AggregatePersistenceAware<Aggregate> testAggregatePersistence() {
+
+      return new io.vanillabp.integration.spi.AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<Aggregate> getAggregateClass() {
+          return Aggregate.class;
+        }
+
+        @Override
+        public Aggregate save(
+            final Aggregate aggregate) {
+          return aggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final Aggregate aggregate) {
+          return "4711";
+        }
+
+      };
+
+    }
+
+  }
+
+  /**
+   * An application-provided election cache (e.g. backed by a cluster-shared cache).
+   */
+  static class ApplicationCache implements WorkflowAdapterCache {
+
+    final Map<String, String> entries = new ConcurrentHashMap<>();
+
+    final java.util.List<String> gets = new java.util.concurrent.CopyOnWriteArrayList<>();
+
+    private static String key(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      return "%s|%s|%s".formatted(workflowModuleId, bpmnProcessId, workflowAggregateId);
+
+    }
+
+    @Override
+    public Optional<String> get(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      final var cacheKey = key(workflowModuleId, bpmnProcessId, workflowAggregateId);
+      gets.add(cacheKey);
+      return Optional.ofNullable(entries.get(cacheKey));
+
+    }
+
+    @Override
+    public void put(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId,
+        final String adapterId) {
+
+      entries.put(key(workflowModuleId, bpmnProcessId, workflowAggregateId), adapterId);
+
+    }
+
+    @Override
+    public void invalidate(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId) {
+
+      entries.remove(key(workflowModuleId, bpmnProcessId, workflowAggregateId));
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TaskOperationsDispatchTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TaskOperationsDispatchTest.java
@@ -53,6 +53,10 @@ public class TaskOperationsDispatchTest {
 
     listener.reset();
     awareness.answerWith(WorkflowAwareness.UNKNOWN_TO_BPMS);
+    // the awareness source is a bean of the cached context this module's test classes
+    // share, so start from "the workflow is visible" instead of whatever the class
+    // running before left behind
+    awareness.alwaysVisible();
 
   }
 

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/WorkflowVisibilityDelayTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/WorkflowVisibilityDelayTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.Duration;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,6 +57,20 @@ public class WorkflowVisibilityDelayTest {
     listener.reset();
     awareness.alwaysVisible();
     awareness.answerWith(WorkflowAwareness.ACTIVE);
+
+  }
+
+  /**
+   * The window and the "invisible for the next N probes" counter are state of a bean in
+   * the CACHED Spring context, which every test class of this module shares. Leaving them
+   * behind made every workflow probe of the class running next answer "unknown" and wait
+   * five minutes for nothing - three tests of {@code TaskOperationsDispatchTest} timed out
+   * that way in the GitHub build, where the classes run in a different order than locally.
+   */
+  @AfterEach
+  public void leaveNoWindowBehind() {
+
+    awareness.alwaysVisible();
 
   }
 

--- a/spring-boot-integration/runtime/pom.xml
+++ b/spring-boot-integration/runtime/pom.xml
@@ -55,6 +55,13 @@
       <artifactId>spring-boot-autoconfigure-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- optional: the election cache's meters are registered only if the
+         application brings Micrometer (see WorkflowAdapterCacheMeters) -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
@@ -244,13 +244,17 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
                   .bean(PhaseTwoRouter.class);
 
               // the election cache (in-memory default or the application's own
-              // bean, e.g. cluster-shared)
-              final var workflowAdapterCache = selectWorkflowAdapterCache(
-                  supplierContext
-                      .beanProvider(io.vanillabp.integration.spi.WorkflowAdapterCache.class)
-                      .stream()
-                      .map(io.vanillabp.integration.spi.WorkflowAdapterCache.class::cast)
-                      .toList());
+              // bean, e.g. cluster-shared), counted by the application's statistics
+              final var workflowAdapterCache = io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache
+                  .instrument(
+                      selectWorkflowAdapterCache(
+                          supplierContext
+                              .beanProvider(io.vanillabp.integration.spi.WorkflowAdapterCache.class)
+                              .stream()
+                              .map(io.vanillabp.integration.spi.WorkflowAdapterCache.class::cast)
+                              .toList()),
+                      supplierContext.bean(
+                          io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics.class));
 
               final var processServiceBean = new ProcessServiceSpringBean<A>(
                   workflowModuleId, bpmnProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, phaseTwoRouter, workflowAdapterCache);

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -241,19 +241,78 @@ public class SpringBootMigrationAdapterAutoConfiguration {
   /**
    * The cache of workflow&rarr;adapter associations consulted by the BPMS election
    * for operations on existing workflows (complete/cancel task, user task, message
-   * correlation): a bounded, expiring in-memory default. Cluster setups wanting
+   * correlation): a bounded, expiring in-memory default, sized by
+   * <code>vanillabp.workflow-adapter-cache.*</code>. Cluster setups wanting
    * instances to share elections define their own bean implementing
    * {@link io.vanillabp.integration.spi.WorkflowAdapterCache} backed by their own
    * cache infrastructure - it replaces this default (entries are hints: a stale
    * entry costs an extra probe, never correctness).
    *
+   * @param properties The VanillaBP configuration (the cache's bounds)
+   * @param statistics The application's cache statistics (evictions and size are
+   *          reported by the cache itself)
    * @return The default in-memory cache
    */
   @Bean
   @ConditionalOnMissingBean(io.vanillabp.integration.spi.WorkflowAdapterCache.class)
-  public io.vanillabp.integration.spi.WorkflowAdapterCache vanillaBpWorkflowAdapterCache() {
+  public io.vanillabp.integration.spi.WorkflowAdapterCache vanillaBpWorkflowAdapterCache(
+      final MigrationAdapterProperties properties,
+      final io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics statistics) {
 
-    return new io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache();
+    return new io.vanillabp.integration.adapter.migration.processservice.InMemoryWorkflowAdapterCache(
+        properties.getWorkflowAdapterCache(), statistics);
+
+  }
+
+  /**
+   * The numbers of the election cache - hits and misses of every implementation,
+   * plus size and evictions of the in-memory default. One instance per application:
+   * the process services wrap whatever cache is in use into an
+   * {@code InstrumentedWorkflowAdapterCache} reporting here, so the numbers stay
+   * comparable when an application plugs in its own cache.
+   *
+   * @param properties The VanillaBP configuration (the bound named by the
+   *          eviction-pressure warning)
+   * @return The statistics
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics vanillaBpWorkflowAdapterCacheStatistics(
+      final MigrationAdapterProperties properties) {
+
+    return new io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics(
+        properties.getWorkflowAdapterCache());
+
+  }
+
+  /**
+   * Publishes the election cache's statistics as Micrometer meters, if the
+   * application brings Micrometer. The Actuator's metrics auto-configuration
+   * applies {@link io.micrometer.core.instrument.binder.MeterBinder} beans to every
+   * registry, so no endpoint of our own is needed; an application without
+   * Micrometer boots unchanged and reports no metrics.
+   */
+  @org.springframework.context.annotation.Configuration(proxyBeanMethods = false)
+  // by NAME, not by class literal: the annotation of a nested configuration class is
+  // read reflectively, so a class literal of an absent optional dependency would
+  // fail before the condition is ever evaluated
+  @org.springframework.boot.autoconfigure.condition.ConditionalOnClass(
+      name = "io.micrometer.core.instrument.MeterRegistry")
+  public static class WorkflowAdapterCacheMetricsConfiguration {
+
+    /**
+     * @param statistics The application's cache statistics
+     * @return The meter binder of the election cache
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters vanillaBpWorkflowAdapterCacheMeters(
+        final io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics statistics) {
+
+      return new io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters(
+          statistics);
+
+    }
 
   }
 


### PR DESCRIPTION
The bounds of the in-memory election cache are properties now
(`vanillabp.workflow-adapter-cache.max-entries` and `.time-to-live`, today's
values as defaults, validated at startup). They stay hard bounds; why soft
references were rejected is written down in `migration-adapter/README.md`.

Hits, misses, evictions and lost hints are counted for whatever cache is in use,
VanillaBP's default as well as an application's own bean, and published as
Micrometer meters where the application brings Micrometer. Both platforms apply
`MeterBinder` beans to their registries by themselves, so the binder is one class
in the core; Micrometer stays optional and an application without it boots
unchanged.

The warning is about lost hints, not about a full cache: the keys of entries
evicted before they were ever read are remembered, and a later lookup of such a
key proves the bound decided the outcome. Ten within an hour produce one guiding
WARN naming the number, the period and the property to raise.

Learned along the way: a `@ConfigMapping` interface must not be injected on
Quarkus. Injecting it turns the mapping into a static-init mapping, and SmallRye
then validates the whole `vanillabp.*` tree before the adapter extensions
register their run-time overlays, so every adapter-specific key fails the startup
as unknown.

All four repos build green; coverage 91.01 % Spring Boot / 91.15 % Quarkus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)