### PR TITLE
Story 51: remember what was delivered, and answer a redelivery from the record

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,42 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## A redelivered task no longer runs the handler twice (2026-08-14)
+
+Story 51. This is a behaviour change of the inbound direction, and it is on by default.
+
+A remote BPMS delivers a task at least once: it hands the task out again whenever it did
+not learn the result, for instance after a crash between the commit of the local
+transaction and the report to the BPMS. Until now that ran the `@WorkflowTask` method a
+second time, and the wiki's rule "write handlers idempotently, keyed on aggregate state"
+was all there was to it. VanillaBP now records every processed delivery in the
+transaction of the handler and answers a repeated delivery with the recorded outcome
+instead of invoking the method again.
+
+**A new store, without new configuration.** The records live in the database the workflow
+aggregates live in: a table `VANILLABP_TASK_DELIVERY` respectively a collection
+`vanillabp-task-deliveries`, created at startup unless
+`vanillabp.outbox.create-schema` is disabled, cleaned up per `vanillabp.outbox.retention`.
+An application managing its schema manually creates the table itself; the DDL is in
+`JdbcTaskDeliveryStore` of the migration adapter, and the only structural requirement is
+a unique `DELIVERY_KEY`.
+
+**A new property.** `vanillabp.adapters.<id>.deduplicate-deliveries` (default `true`)
+switches it off, per workflow module, workflow and task as well. Turning it off restores
+the previous behaviour exactly.
+
+**A new warning.** An application whose aggregates live in a persistence VanillaBP brings
+no store for logs one WARN per BPMN process naming the `TaskDeliveryLog` bean to provide
+and the property to set. It boots and behaves as before.
+
+**Only relevant for adapters:** `TaskInvocationContext.getDeliveryId()` and
+`MigratableProcessService.deliversTasksAtLeastOnce()` are new `default` methods, so an
+adapter compiled against the previous version keeps working - and keeps invoking handlers
+per delivery, since VanillaBP cannot tell two deliveries apart without an identity.
+Camunda 8 reports the job key, the Process-Engine-API adapter the task id, Camunda 7
+nothing at all: it delivers inside the engine's transaction, where a redelivery proves
+that nothing was committed.
+
 ## The election cache can be sized and watched (2026-08-14)
 
 Story 58. Everything here is additive - an application configuring nothing behaves

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -363,6 +363,45 @@ and that adapter does not process workflows). A failure of the first-priority ad
 always fails the boot, regardless of the policy, because new workflows could not be
 started otherwise.
 
+#### Deliveries VanillaBP already processed (`TaskDeliveryLog` SPI, story 51)
+
+The inbound counterpart of the outbox. A remote BPMS reports the outcome AFTER the
+local transaction was committed, so a crash in between makes it deliver the same task
+again - which used to run the `@WorkflowTask` method a second time. The core now
+remembers a processed delivery and answers a repeated one from the record:
+
+- The identity of a delivery comes from the adapter:
+  `TaskInvocationContext.getDeliveryId()` (Camunda 8: the job key; Process-Engine-API:
+  the task ID; Camunda 7: none, see below). `TaskDeliveryKey` (package `workflowtask`)
+  qualifies it with adapter ID, workflow module, BPMN process and event, so an ID only
+  has to be unique within its own BPMS, and hashes the result where it would outgrow
+  what a store can index (512 characters, MySQL's unique-key limit with utf8mb4).
+- The record is written in the handler's own transaction
+  (`MigrationProcessService.executeWorkflowTask`): read before the aggregate is loaded,
+  written after it was saved, and it carries the OUTCOME (`WorkflowTaskOutcome.Kind`
+  plus BPMN error code and name). A repeated delivery therefore reports the recorded
+  outcome again - skipping both handler and answer would leave the task open forever.
+  A handler which threw leaves no record: the rollback took it, and the BPMS' retry
+  runs the handler again.
+- `TaskDeliveryLog` and `TaskDeliveryLogAware` live in the business SPI next to
+  `PhaseTwoOutbox`, with the same per-aggregate resolution
+  (`TaskDeliveryLogResolver`, implemented per platform): a record has to ride the
+  aggregate's own transaction. `JdbcTaskDeliveryStore` and
+  `TaskDeliveryRetentionCleanup` (package `delivery`) hold the SQL respectively the
+  cleanup schedule both platforms share; the connection comes from
+  `JdbcConnectionAccess`, the one piece which cannot be platform-neutral.
+- The switch is the adapter-scoped `deduplicate-deliveries` (default `true`),
+  resolvable per workflow module, workflow and task like every adapter-scoped key.
+- An adapter says whether it needs this at all:
+  `MigratableProcessService.deliversTasksAtLeastOnce()` (default `false`). It decides
+  the startup report only - at runtime nothing is remembered where no delivery ID
+  arrives. Camunda 7 answers `false` on purpose: it delivers tasks inside its own
+  transaction, so a redelivery proves that nothing was committed.
+- Without a store there is a guiding WARN at startup
+  (`validateTaskDeliveryLogAtStartup`, once per process service) instead of a failed
+  boot. Unlike the outbox, nothing is broken without a log - the behaviour is the one
+  every VanillaBP had before, and the wiki's rule about idempotent handlers covers it.
+
 #### Process versions (`version` attribute)
 
 The `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
@@ -1,0 +1,42 @@
+package io.vanillabp.integration.spi;
+
+/**
+ * What VanillaBP remembers about a task delivery it processed: the delivery's
+ * identity plus the outcome reported to the BPMS. Written by the core through the
+ * {@link TaskDeliveryLog} within the transaction which also persists the workflow
+ * aggregate, and read again when the BPMS delivers the same task a second time (see
+ * the deduplication contract of {@link TaskDeliveryLog}).
+ * <p>
+ * Everything besides {@link #deliveryKey()} and {@link #outcome()} is context: it
+ * makes a record readable for whoever looks into the store while investigating a
+ * workflow, and it is what a store may index by. Stores persist the values as they
+ * are and never interpret them - the meaning of an outcome is the core's business.
+ *
+ * @param deliveryKey The identity of the delivery, unique within the store: built by
+ *          the core from the delivering adapter, the workflow module, the BPMN
+ *          process, the event and the delivery ID the adapter reported. A
+ *          redelivery of the same task yields the same key, a genuinely new task
+ *          instance a different one
+ * @param workflowModuleId The ID of the workflow module the workflow belongs to
+ * @param bpmnProcessId The BPMN process ID of the workflow
+ * @param workflowAggregateId The workflow aggregate's ID in serialized form
+ * @param taskDefinition The task definition (or BPMN activity ID) delivered
+ * @param outcome The outcome reported to the BPMS, as the core names it - a
+ *          redelivery is answered with exactly this outcome instead of running the
+ *          business code again
+ * @param bpmnErrorCode The BPMN error code of an outcome carrying one, otherwise
+ *          <code>null</code>
+ * @param bpmnErrorName The BPMN error name of an outcome carrying one, otherwise
+ *          <code>null</code>
+ */
+public record TaskDelivery(
+                           String deliveryKey,
+                           String workflowModuleId,
+                           String bpmnProcessId,
+                           String workflowAggregateId,
+                           String taskDefinition,
+                           String outcome,
+                           String bpmnErrorCode,
+                           String bpmnErrorName) {
+
+}

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
@@ -1,0 +1,68 @@
+package io.vanillabp.integration.spi;
+
+import java.util.Optional;
+
+/**
+ * Durable memory of the task deliveries VanillaBP already processed - the inbound
+ * counterpart of the {@link PhaseTwoOutbox}. A remote BPMS delivers a task AT LEAST
+ * ONCE: it repeats a delivery whenever it did not learn the result, e.g. after a
+ * crash between the commit of the local transaction and the report to the BPMS.
+ * Without a memory the <code>&#64;WorkflowTask</code> method runs a second time; with
+ * one the core skips the business code and reports the recorded outcome again.
+ * <p>
+ * <strong>Recording contract:</strong> {@link #record(TaskDelivery)} MUST be invoked
+ * within the still-running transaction which persists the workflow aggregate, and the
+ * implementation MUST enlist the record in exactly that transaction: the record
+ * becomes visible if and only if the transaction commits. Work without a record would
+ * run the business code twice, a record without the work would skip it although
+ * nothing happened - both are worse than no deduplication at all. A rolled-back
+ * delivery therefore leaves NO record and is processed again, which is what makes the
+ * BPMS' retry work.
+ * <p>
+ * <strong>Uniqueness:</strong> the {@link TaskDelivery#deliveryKey()} is unique in the
+ * store, enforced by the store's own mechanism (unique index/constraint). A second
+ * {@link #record(TaskDelivery)} of the same key is a no-op returning
+ * <code>false</code> - two nodes processing the same delivery concurrently (both
+ * having read no record) end up with one record, and the loser's transaction fails
+ * respectively is ignored.
+ * <p>
+ * <strong>Retention:</strong> records are deleted asynchronously once
+ * <code>vanillabp.outbox.retention</code> passed (default 7 days) - the same
+ * retention the outbox uses, since both keep a deduplication window open. A BPMS
+ * redelivering a task later than that runs the business code again; a task open for
+ * longer than the retention is a workflow waiting for something, not a delivery in
+ * flight.
+ * <p>
+ * Implementations are provided by the platform integrations (JDBC/JPA and MongoDB) or
+ * by the application itself, since the platform-neutral core must not depend on any
+ * particular persistence technology. Which log serves a workflow aggregate is decided
+ * per aggregate - see {@link TaskDeliveryLogAware}.
+ */
+public interface TaskDeliveryLog {
+
+  /**
+   * The record of the given delivery, if VanillaBP processed it before. Read within
+   * the transaction the delivery is processed in.
+   *
+   * @param deliveryKey The delivery's identity (see
+   *          {@link TaskDelivery#deliveryKey()})
+   * @return The record or {@link Optional#empty()} if this delivery was not
+   *         processed (or its record was cleaned up after the retention period)
+   */
+  Optional<TaskDelivery> recordedDelivery(
+      String deliveryKey);
+
+  /**
+   * Records a processed delivery. MUST be invoked within the still-running
+   * transaction that persists the workflow aggregate, and MUST enlist in that
+   * transaction.
+   *
+   * @param delivery What was processed, and with which outcome
+   * @return <code>true</code> if the record was written, <code>false</code> if a
+   *         record of the same {@link TaskDelivery#deliveryKey()} already existed
+   *         (no-op)
+   */
+  boolean record(
+      TaskDelivery delivery);
+
+}

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLogAware.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLogAware.java
@@ -1,0 +1,62 @@
+package io.vanillabp.integration.spi;
+
+/**
+ * Selects the {@link TaskDeliveryLog} used for aggregates of the given type.
+ * <p>
+ * A delivery record MUST be enlisted in the same transaction which persists the
+ * workflow aggregate (see the recording contract of {@link TaskDeliveryLog}), so which
+ * log to use is determined by the aggregate's persistence - PER AGGREGATE, not per
+ * application: a JPA-persisted aggregate and a MongoDB-persisted aggregate in the same
+ * application use different logs, each riding its own aggregate's transaction. This
+ * mirrors {@link PhaseTwoOutboxAware}, and an application providing its own store for
+ * one of the two directions usually provides both.
+ * <p>
+ * Implementations are CDI/Spring beans. The implementation with the most specific
+ * aggregate class is chosen, taking superclasses and implemented interfaces into
+ * account - the same selection semantics as {@link AggregatePersistenceAware}. Without
+ * any matching implementation the platform integration falls back to its default
+ * selection (the log matching the persistence technology managing the aggregate, or
+ * the single available log).
+ * <p>
+ * All methods are <code>default</code> methods throwing an
+ * {@link UnsupportedOperationException} with a guiding message: this keeps
+ * hand-written implementations source-compatible when methods are added to this
+ * interface.
+ *
+ * @param <A> The aggregate type
+ */
+public interface TaskDeliveryLogAware<A> {
+
+  /**
+   * @return The aggregate class this delivery-log selection applies to.
+   */
+  default Class<A> getAggregateClass() {
+
+    throw new UnsupportedOperationException(
+        """
+            getAggregateClass is not implemented by '%s'! VanillaBP uses it to select the \
+            TaskDeliveryLogAware implementation responsible for a workflow aggregate - implement \
+            getAggregateClass in your TaskDeliveryLogAware implementation."""
+            .formatted(getClass().getName()));
+
+  }
+
+  /**
+   * The delivery log used for aggregates of {@link #getAggregateClass()}. The
+   * returned log MUST enlist records in the same transaction which persists these
+   * aggregates.
+   *
+   * @return The delivery log to use
+   */
+  default TaskDeliveryLog getTaskDeliveryLog() {
+
+    throw new UnsupportedOperationException(
+        """
+            getTaskDeliveryLog is not implemented by '%s'! VanillaBP uses it to determine the task \
+            delivery log for workflow aggregates of the class returned by getAggregateClass - \
+            implement getTaskDeliveryLog in your TaskDeliveryLogAware implementation."""
+            .formatted(getClass().getName()));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
@@ -37,4 +37,20 @@ public class AdapterProperties {
    */
   private Boolean prefixTaskDefinitionsPerProcess;
 
+  /**
+   * Whether VanillaBP remembers the task deliveries of this BPMS, so a repeated
+   * delivery does not run the <code>&#64;WorkflowTask</code> method again but reports
+   * the recorded outcome once more (see
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLog}). Adapter-scoped and
+   * therefore resolvable per workflow module, workflow and task - a single task doing
+   * something expensive twice may be treated differently from the rest.
+   * <p>
+   * Defaults to <code>true</code>: not running business code twice is the safer
+   * behaviour. It has an effect only where the BPMS may repeat a delivery at all
+   * ({@link io.vanillabp.integration.adapter.spi.MigratableProcessService#deliversTasksAtLeastOnce()})
+   * and the adapter reports a delivery identity. <code>null</code> means "not
+   * configured at this level".
+   */
+  private Boolean deduplicateDeliveries;
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcConnectionAccess.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcConnectionAccess.java
@@ -1,0 +1,38 @@
+package io.vanillabp.integration.adapter.migration.delivery;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+
+/**
+ * How a platform hands out a JDBC connection which takes part in the transaction
+ * currently running - the one piece of {@link JdbcTaskDeliveryStore} which cannot be
+ * platform-neutral: Spring Boot binds connections to the transaction through
+ * {@code DataSourceUtils}, Quarkus enlists an Agroal connection in the active JTA
+ * transaction when it is acquired.
+ */
+public interface JdbcConnectionAccess {
+
+  /**
+   * A connection enlisted in the transaction currently running on this thread.
+   *
+   * @return The connection
+   * @throws SQLException If no connection can be acquired
+   */
+  Connection acquire() throws SQLException;
+
+  /**
+   * Returns the connection. The default closes it, which is right wherever the
+   * connection pool hands out transaction-bound handles; a platform holding the
+   * connection for the transaction's lifetime overrides this.
+   *
+   * @param connection The connection acquired before
+   * @throws SQLException If the connection cannot be returned
+   */
+  default void release(
+      final Connection connection) throws SQLException {
+
+    connection.close();
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -1,0 +1,330 @@
+package io.vanillabp.integration.adapter.migration.delivery;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+import io.vanillabp.integration.spi.TaskDelivery;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The SQL behind the JDBC-based {@link io.vanillabp.integration.spi.TaskDeliveryLog}
+ * implementations of both platforms: reading, writing and cleaning up the records of
+ * processed task deliveries. Everything platform-specific is behind
+ * {@link JdbcConnectionAccess} - the connection has to belong to the transaction which
+ * persists the workflow aggregate, otherwise the record and the aggregate would not
+ * commit together.
+ * <p>
+ * A record is INSERTed once and never updated: the delivery key is the primary key, so
+ * two nodes processing the same delivery concurrently end up with one record and the
+ * loser learns it from the constraint violation ({@link #record(TaskDelivery)} returns
+ * <code>false</code> then, exactly like a duplicate outbox entry).
+ * <p>
+ * The DDL is kept portable the same way the Quarkus outbox does it: table existence is
+ * checked via JDBC metadata (<code>CREATE TABLE IF NOT EXISTS</code> is not supported
+ * by Oracle and SQL Server), the timestamp type is chosen per database and the delivery
+ * key is limited to {@value io.vanillabp.integration.adapter.migration.workflowtask.TaskDeliveryKey#MAX_LENGTH}
+ * characters so MySQL's key-length limit (3072 bytes with utf8mb4) is respected - the
+ * core hashes longer keys before they ever reach a store.
+ */
+@Slf4j
+public class JdbcTaskDeliveryStore {
+
+  /**
+   * The default name of the table holding the records.
+   */
+  public static final String DEFAULT_TABLE_NAME = "VANILLABP_TASK_DELIVERY";
+
+  private static final String SELECT_DELIVERY = """
+      SELECT WORKFLOW_MODULE_ID, BPMN_PROCESS_ID, AGGREGATE_ID, TASK_DEFINITION, OUTCOME, \
+      BPMN_ERROR_CODE, BPMN_ERROR_NAME \
+      FROM %s \
+      WHERE DELIVERY_KEY = ?""";
+
+  private static final String INSERT_DELIVERY = """
+      INSERT INTO %s \
+      (DELIVERY_KEY, WORKFLOW_MODULE_ID, BPMN_PROCESS_ID, AGGREGATE_ID, TASK_DEFINITION, OUTCOME, \
+      BPMN_ERROR_CODE, BPMN_ERROR_NAME, RECORDED_AT) \
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""";
+
+  private static final String DELETE_EXPIRED_DELIVERIES = """
+      DELETE FROM %s \
+      WHERE RECORDED_AT < ?""";
+
+  private final JdbcConnectionAccess connectionAccess;
+
+  private final String tableName;
+
+  private final String selectDelivery;
+
+  private final String insertDelivery;
+
+  private final String deleteExpiredDeliveries;
+
+  public JdbcTaskDeliveryStore(
+      final JdbcConnectionAccess connectionAccess,
+      final String tableName) {
+
+    this.connectionAccess = connectionAccess;
+    this.tableName = tableName;
+    this.selectDelivery = SELECT_DELIVERY.formatted(tableName);
+    this.insertDelivery = INSERT_DELIVERY.formatted(tableName);
+    this.deleteExpiredDeliveries = DELETE_EXPIRED_DELIVERIES.formatted(tableName);
+
+  }
+
+  /**
+   * @return The name of the table the records are stored in
+   */
+  public String getTableName() {
+
+    return tableName;
+
+  }
+
+  /**
+   * The record of the given delivery.
+   *
+   * @param deliveryKey The delivery's identity
+   * @return The record or {@link Optional#empty()}
+   */
+  public Optional<TaskDelivery> recordedDelivery(
+      final String deliveryKey) {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      try (var statement = connection.prepareStatement(selectDelivery)) {
+        statement.setString(1, deliveryKey);
+        try (var resultSet = statement.executeQuery()) {
+          if (!resultSet.next()) {
+            return Optional.empty();
+          }
+          return Optional
+              .of(
+                  new TaskDelivery(
+                      deliveryKey, resultSet.getString(1), resultSet.getString(2), resultSet.getString(3), resultSet
+                          .getString(4), resultSet.getString(5), resultSet.getString(6), resultSet.getString(7)));
+        }
+      }
+    } catch (final SQLException e) {
+      throw new RuntimeException(
+          "Could not read the record of task delivery '%s' from table '%s'!"
+              .formatted(deliveryKey, tableName), e);
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Writes the record within the transaction currently running.
+   *
+   * @param delivery What was processed
+   * @return <code>true</code> if written, <code>false</code> if a record of the same
+   *         delivery key existed already
+   */
+  public boolean record(
+      final TaskDelivery delivery) {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      try (var statement = connection.prepareStatement(insertDelivery)) {
+        statement.setString(1, delivery.deliveryKey());
+        statement.setString(2, delivery.workflowModuleId());
+        statement.setString(3, delivery.bpmnProcessId());
+        statement.setString(4, delivery.workflowAggregateId());
+        statement.setString(5, delivery.taskDefinition());
+        statement.setString(6, delivery.outcome());
+        statement.setString(7, delivery.bpmnErrorCode());
+        statement.setString(8, delivery.bpmnErrorName());
+        statement.setTimestamp(9, Timestamp.from(Instant.now()));
+        statement.executeUpdate();
+      }
+      return true;
+    } catch (final SQLException e) {
+      if (isDuplicateKey(e)) {
+        // another node processed the same delivery concurrently - it wrote the
+        // record, and this transaction has nothing to add
+        log.debug(
+            "Task delivery '{}' of BPMN process '{}' of workflow module '{}' was recorded already",
+            delivery.deliveryKey(),
+            delivery.bpmnProcessId(),
+            delivery.workflowModuleId());
+        return false;
+      }
+      throw new RuntimeException(
+          "Could not record task delivery '%s' of BPMN process '%s' of workflow module '%s' in table '%s'!"
+              .formatted(
+                  delivery.deliveryKey(),
+                  delivery.bpmnProcessId(),
+                  delivery.workflowModuleId(),
+                  tableName), e);
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Deletes the records older than the given retention period - the deduplication
+   * window closes with them. A plain, idempotent DELETE: several application instances
+   * may run it concurrently.
+   *
+   * @param retention How long a record is kept
+   * @return The number of records deleted
+   */
+  public int deleteExpired(
+      final Duration retention) {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      try (var statement = connection.prepareStatement(deleteExpiredDeliveries)) {
+        statement.setTimestamp(1, Timestamp.from(Instant.now().minus(retention)));
+        return statement.executeUpdate();
+      }
+    } catch (final SQLException e) {
+      log.warn("Could not clean up expired task-delivery records of table '{}'", tableName, e);
+      return 0;
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Creates the table (and the index the cleanup reads) unless it exists already.
+   *
+   * @throws IllegalStateException If the DDL fails - naming the way out (manage the
+   *           schema manually)
+   */
+  public void createSchemaIfNotExists() {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      if (tableExists(connection, tableName)) {
+        return;
+      }
+      try (var statement = connection.createStatement()) {
+        statement.executeUpdate(buildCreateTable(connection, tableName));
+        statement.executeUpdate(
+            "CREATE INDEX %s_AGE ON %s (RECORDED_AT)".formatted(tableName, tableName));
+      }
+    } catch (final SQLException e) {
+      throw new IllegalStateException(
+          """
+              Could not create the task-delivery table '%s'! Set 'vanillabp.outbox.create-schema' to \
+              'false' and manage the schema manually if the DDL is not suitable for your database - \
+              the table needs a unique DELIVERY_KEY and is described in the platform integration's \
+              README."""
+              .formatted(tableName), e);
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  private void release(
+      final Connection connection) {
+
+    if (connection == null) {
+      return;
+    }
+    try {
+      connectionAccess.release(connection);
+    } catch (final SQLException e) {
+      log.warn("Could not release the connection used for the task-delivery table '{}'", tableName, e);
+    }
+
+  }
+
+  /**
+   * Whether the given exception signals a violated unique constraint (= the delivery
+   * was recorded already).
+   *
+   * @param e The exception raised by the insert
+   * @return Whether the insert failed due to a duplicate key
+   */
+  private static boolean isDuplicateKey(
+      final SQLException e) {
+
+    // PostgreSQL's JDBC driver does not map unique violations to the dedicated
+    // subclass - fall back to the standard SQL state class 23 (integrity
+    // constraint violation) for such drivers
+    return (e instanceof SQLIntegrityConstraintViolationException) || ((e.getSQLState() != null) && e
+        .getSQLState()
+        .startsWith("23"));
+
+  }
+
+  private static boolean tableExists(
+      final Connection connection,
+      final String tableName) throws SQLException {
+
+    final var metaData = connection.getMetaData();
+    // unquoted identifiers are folded to upper case by some databases (Oracle, H2)
+    // and to lower case by others (PostgreSQL) - check both spellings
+    for (final var name : List.of(
+        tableName,
+        tableName.toLowerCase())) {
+      try (var tables = metaData.getTables(null, null, name, new String[]{
+          "TABLE"
+      })) {
+        if (tables.next()) {
+          return true;
+        }
+      }
+    }
+    return false;
+
+  }
+
+  /**
+   * Builds the CREATE TABLE statement using a timestamp type suitable for the database:
+   * SQL Server's <code>TIMESTAMP</code> is a row version (not a date-time), MySQL's has
+   * auto-initialization quirks and ends in 2038.
+   *
+   * @param connection The connection used to detect the database
+   * @param tableName The table to create
+   * @return The CREATE TABLE statement
+   */
+  private static String buildCreateTable(
+      final Connection connection,
+      final String tableName) throws SQLException {
+
+    final var product = connection
+        .getMetaData()
+        .getDatabaseProductName()
+        .toLowerCase();
+    final String timestampType;
+    if (product.contains("microsoft")) {
+      timestampType = "DATETIME2";
+    } else if (product.contains("mysql") || product.contains("mariadb")) {
+      timestampType = "DATETIME(6)";
+    } else {
+      timestampType = "TIMESTAMP";
+    }
+    return """
+        CREATE TABLE %s (\
+        DELIVERY_KEY VARCHAR(512) PRIMARY KEY, \
+        WORKFLOW_MODULE_ID VARCHAR(255) NOT NULL, \
+        BPMN_PROCESS_ID VARCHAR(255) NOT NULL, \
+        AGGREGATE_ID VARCHAR(1024), \
+        TASK_DEFINITION VARCHAR(255), \
+        OUTCOME VARCHAR(32) NOT NULL, \
+        BPMN_ERROR_CODE VARCHAR(255), \
+        BPMN_ERROR_NAME VARCHAR(255), \
+        RECORDED_AT %s NOT NULL)"""
+        .formatted(tableName, timestampType);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/TaskDeliveryRetentionCleanup.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/TaskDeliveryRetentionCleanup.java
@@ -1,0 +1,101 @@
+package io.vanillabp.integration.adapter.migration.delivery;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Deletes the records of processed task deliveries once
+ * <code>vanillabp.outbox.retention</code> passed - shared by every
+ * {@link io.vanillabp.integration.spi.TaskDeliveryLog} implementation of both platforms,
+ * since a store differs in HOW it deletes, not in WHEN.
+ * <p>
+ * The cleanup runs on a private daemon thread, so neither Spring's
+ * {@code TaskScheduler} nor the <code>quarkus-scheduler</code> extension is required.
+ * It runs once at startup and then {@value #INTERVAL_HOURS}-hourly: records are kept
+ * for days, so nothing is gained by looking more often. Deleting is idempotent - the
+ * instances of a cluster may run it concurrently.
+ */
+@Slf4j
+public class TaskDeliveryRetentionCleanup {
+
+  /**
+   * The fixed delay between two cleanup runs, in hours.
+   */
+  public static final int INTERVAL_HOURS = 1;
+
+  private final String name;
+
+  private final Duration retention;
+
+  private final Runnable cleanup;
+
+  private ScheduledExecutorService executor;
+
+  /**
+   * @param name Names the store cleaned up (thread name and log messages)
+   * @param retention How long a record is kept
+   * @param cleanup Deletes the expired records of one store
+   */
+  public TaskDeliveryRetentionCleanup(
+      final String name,
+      final Duration retention,
+      final Runnable cleanup) {
+
+    this.name = name;
+    this.retention = retention;
+    this.cleanup = cleanup;
+
+  }
+
+  /**
+   * Starts the cleanup. Calling it twice is a no-op - the platforms start it from
+   * their own lifecycle hooks.
+   */
+  public synchronized void start() {
+
+    if (executor != null) {
+      return;
+    }
+    log.debug("Cleaning up task-delivery records of '{}' older than {}", name, retention);
+    executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+      final var thread = new Thread(runnable, "vanillabp-task-deliveries");
+      thread.setDaemon(true);
+      return thread;
+    });
+    executor.scheduleWithFixedDelay(
+        this::runCleanup,
+        0,
+        Duration.ofHours(INTERVAL_HOURS).toMillis(),
+        TimeUnit.MILLISECONDS);
+
+  }
+
+  /**
+   * Stops the cleanup on shutdown of the application.
+   */
+  public synchronized void stop() {
+
+    if (executor != null) {
+      executor.shutdownNow();
+      executor = null;
+    }
+
+  }
+
+  private void runCleanup() {
+
+    try {
+      cleanup.run();
+    } catch (final RuntimeException e) {
+      // a failing cleanup costs disk space, nothing else - it must not kill the
+      // scheduled task (a scheduleWithFixedDelay stops on an escaping exception)
+      log.warn("Could not clean up expired task-delivery records of '{}'", name, e);
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -4,8 +4,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
 import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.TaskDeliveryKey;
 import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskHandler;
 import io.vanillabp.integration.adapter.spi.MigratableProcessService;
 import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
@@ -13,6 +15,8 @@ import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
 import io.vanillabp.integration.spi.AggregatePersistenceAware;
 import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
 import io.vanillabp.integration.spi.WorkflowAdapterCache;
 import io.vanillabp.spi.service.TaskException;
 import lombok.Getter;
@@ -87,6 +91,33 @@ public class MigrationProcessService<A> {
   private final WorkflowLocator workflowLocator;
 
   /**
+   * The bound <code>vanillabp.*</code> tree - kept because adapter-scoped properties
+   * are resolved per DELIVERY (workflow module &gt; workflow &gt; task, see
+   * {@link MigrationAdapterProperties#resolveForAdapter}).
+   */
+  private final MigrationAdapterProperties properties;
+
+  /**
+   * Resolves the log of processed task deliveries used for this aggregate. Provided by
+   * the platform integration; may be <code>null</code> (tests) - deliveries are then
+   * not deduplicated, which is the behaviour of every VanillaBP before this existed.
+   */
+  private final TaskDeliveryLogResolver taskDeliveryLogResolver;
+
+  /**
+   * The delivery log resolved for this process service's aggregate,
+   * <code>null</code> until resolved (at startup via
+   * {@link #validateTaskDeliveryLogAtStartup()} or lazily as backstop).
+   */
+  private volatile TaskDeliveryLog taskDeliveryLog;
+
+  /**
+   * Whether the "deliveries are not deduplicated" message was logged already - it
+   * names a configuration gap, and one line per delivery would bury it.
+   */
+  private final java.util.concurrent.atomic.AtomicBoolean missingDeliveryLogReported = new java.util.concurrent.atomic.AtomicBoolean();
+
+  /**
    * Creates a process service without an adapter cache (elections probe every
    * time) - kept for tests; the platform integrations always pass the cache.
    */
@@ -104,6 +135,10 @@ public class MigrationProcessService<A> {
 
   }
 
+  /**
+   * Creates a process service without a delivery-log resolver (deliveries are not
+   * deduplicated) - kept for tests; the platform integrations always pass one.
+   */
   public MigrationProcessService(
       final String workflowModuleId,
       final String bpmnProcessId,
@@ -114,6 +149,24 @@ public class MigrationProcessService<A> {
       final PhaseTwoOutboxResolver phaseTwoOutboxResolver,
       final WorkflowAdapterCache workflowAdapterCache) {
 
+    this(
+        workflowModuleId, bpmnProcessId, workflowAggregateClass, properties, aggregatePersistenceSupport, processServices, phaseTwoOutboxResolver, workflowAdapterCache, null);
+
+  }
+
+  public MigrationProcessService(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Class<A> workflowAggregateClass,
+      final MigrationAdapterProperties properties,
+      final AggregatePersistenceAware<A> aggregatePersistenceSupport,
+      final List<MigratableProcessService<A>> processServices,
+      final PhaseTwoOutboxResolver phaseTwoOutboxResolver,
+      final WorkflowAdapterCache workflowAdapterCache,
+      final TaskDeliveryLogResolver taskDeliveryLogResolver) {
+
+    this.properties = properties;
+    this.taskDeliveryLogResolver = taskDeliveryLogResolver;
     this.workflowModuleId = workflowModuleId;
     this.bpmnProcessId = bpmnProcessId;
     this.workflowAggregateClass = workflowAggregateClass;
@@ -349,7 +402,38 @@ public class MigrationProcessService<A> {
           : WorkflowTaskOutcome.completed();
     }
 
+    // a BPMS repeating a delivery it never learned the result of must not run the
+    // business code twice - what was processed is remembered, and a redelivery is
+    // answered with the recorded outcome (leaving the task open instead would keep it
+    // open forever)
+    final var deliveryKey = deduplicateDeliveries(context.getAdapterId(), context.getTaskDefinition())
+        ? TaskDeliveryKey.of(workflowModuleId, bpmnProcessId, context)
+        : null;
+    final var deliveryLog = deliveryKey == null
+        ? null
+        : resolveTaskDeliveryLog();
+    if ((deliveryKey != null) && (deliveryLog == null)) {
+      reportMissingDeliveryLog(context.getAdapterId());
+    }
+
     final Supplier<WorkflowTaskOutcome> transactionalWork = () -> {
+      if (deliveryLog != null) {
+        final var recorded = deliveryLog
+            .recordedDelivery(deliveryKey)
+            .flatMap(delivery -> recordedOutcomeOf(delivery, context));
+        if (recorded.isPresent()) {
+          log.info(
+              "Skipping the repeated delivery of task '{}' (BPMN process '{}' of workflow module "
+                  + "'{}', aggregate '{}'): it was processed before, reporting the recorded outcome "
+                  + "{} again",
+              context.getTaskDefinition(),
+              bpmnProcessId,
+              workflowModuleId,
+              context.getWorkflowAggregateId(),
+              recorded.get().kind());
+          return recorded.get();
+        }
+      }
       final var aggregateId = convertAggregateId(context.getWorkflowAggregateId());
       final var workflowAggregate = aggregatePersistenceSupport.loadById(aggregateId);
       if (workflowAggregate == null) {
@@ -367,24 +451,185 @@ public class MigrationProcessService<A> {
       try {
         handler.invoke(workflowAggregate, context);
         aggregatePersistenceSupport.save(workflowAggregate);
-        failIfRollbackOnly(handler, context, transactionRunner, rollbackRuleRemedies);
-        return handler.isAsynchronousTask()
+        final var outcome = handler.isAsynchronousTask()
             ? WorkflowTaskOutcome.completionPending()
             : WorkflowTaskOutcome.completed();
+        recordDelivery(deliveryLog, deliveryKey, context, outcome);
+        failIfRollbackOnly(handler, context, transactionRunner, rollbackRuleRemedies);
+        return outcome;
       } catch (final TaskException taskException) {
         // the restored V1 contract: a TaskException is a BPMN error, not a
         // failure - the aggregate changes are persisted and the transaction
         // commits (V1 applications used @Transactional(noRollbackFor =
         // TaskException.class) for exactly this)
         aggregatePersistenceSupport.save(workflowAggregate);
+        final var outcome = WorkflowTaskOutcome
+            .bpmnError(taskException.getErrorCode(), taskException.getErrorName());
+        recordDelivery(deliveryLog, deliveryKey, context, outcome);
         failIfRollbackOnly(handler, context, transactionRunner, rollbackRuleRemedies);
-        return WorkflowTaskOutcome.bpmnError(taskException.getErrorCode(), taskException.getErrorName());
+        return outcome;
       }
     };
 
     return context.runInCurrentTransaction()
         ? transactionRunner.inCurrent(transactionalWork)
         : transactionRunner.requireNew(transactionalWork);
+
+  }
+
+  /**
+   * Whether deliveries of the given adapter are deduplicated for the given task
+   * (<code>vanillabp.adapters.&lt;id&gt;.deduplicate-deliveries</code>, resolvable per
+   * workflow module, workflow and task). The default is <code>true</code>; an adapter
+   * reporting no ID at all is not deduplicated, since neither the configuration nor
+   * the delivery key could be attributed to a BPMS then.
+   *
+   * @param adapterId The ID of the adapter delivering the task or <code>null</code>
+   * @param taskDefinition The task definition delivered
+   * @return Whether to remember this delivery
+   */
+  private boolean deduplicateDeliveries(
+      final String adapterId,
+      final String taskDefinition) {
+
+    if ((adapterId == null) || (properties == null)) {
+      return false;
+    }
+    final var configured = properties
+        .resolveForAdapter(
+            workflowModuleId,
+            bpmnProcessId,
+            taskDefinition,
+            adapterId,
+            AdapterProperties::getDeduplicateDeliveries);
+    return (configured == null) || configured;
+
+  }
+
+  /**
+   * Validates AT STARTUP that a delivery log is available if any prioritized adapter
+   * may repeat a delivery
+   * ({@link MigratableProcessService#deliversTasksAtLeastOnce()}) and deduplication is
+   * switched on. Unlike the outbox this does NOT fail the boot: without a log
+   * VanillaBP behaves exactly as it did before the feature existed (at-least-once, the
+   * rule to key business decisions on the aggregate's state carries the case), so a
+   * guiding WARN naming both remedies is the honest answer - and it is logged at
+   * startup instead of surfacing per delivery.
+   * <p>
+   * Nothing is resolved where no adapter can repeat a delivery: an application using
+   * an embedded BPMS only must not be pushed towards a store it does not need.
+   */
+  public void validateTaskDeliveryLogAtStartup() {
+
+    final var atLeastOnceAdapters = adapterProcessServices
+        .stream()
+        .filter(MigratableProcessService::deliversTasksAtLeastOnce)
+        .map(MigratableProcessService::getAdapterId)
+        .filter(adapterId -> deduplicateDeliveries(adapterId, null))
+        .toList();
+    if (atLeastOnceAdapters.isEmpty()) {
+      return;
+    }
+    if (resolveTaskDeliveryLog() == null) {
+      reportMissingDeliveryLog(atLeastOnceAdapters.getFirst());
+    }
+
+  }
+
+  private TaskDeliveryLog resolveTaskDeliveryLog() {
+
+    if ((taskDeliveryLog == null) && (taskDeliveryLogResolver != null)) {
+      taskDeliveryLog = taskDeliveryLogResolver.resolveFor(workflowAggregateClass);
+    }
+    return taskDeliveryLog;
+
+  }
+
+  /**
+   * States once that deliveries of this BPMN process are not deduplicated, and how to
+   * change that. Also the answer to "why did my handler run twice" - the message is
+   * the first thing to look for then.
+   *
+   * @param adapterId The ID of an adapter which may repeat a delivery
+   */
+  private void reportMissingDeliveryLog(
+      final String adapterId) {
+
+    if (!missingDeliveryLogReported.compareAndSet(false, true)) {
+      return;
+    }
+    log.warn(
+        """
+            Adapter '{}' may deliver a task of BPMN process '{}' of workflow module '{}' more than \
+            once, but no TaskDeliveryLog is available for aggregate '{}' - a repeated delivery will \
+            run the @WorkflowTask method again. To solve this either
+            {}
+            - define your own bean implementing io.vanillabp.integration.spi.TaskDeliveryLog \
+            (assign it to specific aggregates via a io.vanillabp.integration.spi.TaskDeliveryLogAware \
+            bean), or
+            - set 'vanillabp.adapters.{}.deduplicate-deliveries' to 'false' to state that the \
+            handlers of this application are idempotent themselves.""",
+        adapterId,
+        bpmnProcessId,
+        workflowModuleId,
+        workflowAggregateClass.getName(),
+        taskDeliveryLogResolver == null
+            ? "- provide a TaskDeliveryLogResolver (platform integration), or"
+            : taskDeliveryLogResolver.remediesDescription(),
+        adapterId);
+
+  }
+
+  /**
+   * Remembers a processed delivery within the transaction which also persists the
+   * aggregate - the two commit together or not at all.
+   */
+  private void recordDelivery(
+      final TaskDeliveryLog deliveryLog,
+      final String deliveryKey,
+      final TaskInvocationContext context,
+      final WorkflowTaskOutcome outcome) {
+
+    if (deliveryLog == null) {
+      return;
+    }
+    deliveryLog.record(
+        new TaskDelivery(
+            deliveryKey, workflowModuleId, bpmnProcessId, context.getWorkflowAggregateId(), context
+                .getTaskDefinition(), outcome.kind().name(), outcome.errorCode(), outcome.errorName()));
+
+  }
+
+  /**
+   * The outcome a recorded delivery is answered with. An outcome the core does not
+   * know (a record written by a newer version, or a store returning something of its
+   * own) yields an empty result: the handler runs again, which is the behaviour without
+   * any log at all, and the WARN says why.
+   */
+  private java.util.Optional<WorkflowTaskOutcome> recordedOutcomeOf(
+      final TaskDelivery delivery,
+      final TaskInvocationContext context) {
+
+    try {
+      return java.util.Optional
+          .of(
+              switch (WorkflowTaskOutcome.Kind.valueOf(delivery.outcome())) {
+                case COMPLETED -> WorkflowTaskOutcome.completed();
+                case COMPLETION_PENDING -> WorkflowTaskOutcome.completionPending();
+                case BPMN_ERROR -> WorkflowTaskOutcome
+                    .bpmnError(delivery.bpmnErrorCode(), delivery.bpmnErrorName());
+              });
+    } catch (final IllegalArgumentException e) {
+      log.warn(
+          "The recorded delivery '{}' of task '{}' (BPMN process '{}' of workflow module '{}') "
+              + "reports the unknown outcome '{}' - processing the delivery again",
+          delivery.deliveryKey(),
+          context.getTaskDefinition(),
+          bpmnProcessId,
+          workflowModuleId,
+          delivery.outcome());
+      return java.util.Optional.empty();
+    }
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/TaskDeliveryLogResolver.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/TaskDeliveryLogResolver.java
@@ -1,0 +1,45 @@
+package io.vanillabp.integration.adapter.migration.processservice;
+
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDeliveryLogAware;
+
+/**
+ * Resolves the {@link TaskDeliveryLog} used for a workflow aggregate, implemented by
+ * the platform integrations and invoked by the core AT STARTUP (see
+ * {@link MigrationProcessService#validateTaskDeliveryLogAtStartup()}). The resolution
+ * mirrors {@link PhaseTwoOutboxResolver} - a delivery record has to ride the
+ * aggregate's own transaction just like an outbox entry:
+ * <ol>
+ * <li>the most specific {@link TaskDeliveryLogAware} bean covering the aggregate class
+ * (selection via {@link AwareSelection}),</li>
+ * <li>the platform's default selection: the single available log bean, or - if several
+ * exist - the platform-default log matching the persistence technology managing the
+ * aggregate,</li>
+ * <li><code>null</code> if no log is available at all - the core then reports at
+ * startup that deliveries are not deduplicated, naming the remedies.</li>
+ * </ol>
+ */
+public interface TaskDeliveryLogResolver {
+
+  /**
+   * Resolves the delivery log for aggregates of the given class.
+   *
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @return The log or <code>null</code> if none is available
+   * @throws IllegalStateException If several logs exist and none can be attributed to
+   *           the aggregate - the guiding message names the beans found and the
+   *           remedy (provide a {@link TaskDeliveryLogAware} bean)
+   */
+  TaskDeliveryLog resolveFor(
+      Class<?> workflowAggregateClass);
+
+  /**
+   * Platform-specific remedy lines appended to the core's guiding message when no log
+   * is available but the delivering BPMS may repeat deliveries (e.g. which starter or
+   * extension enables a default implementation).
+   *
+   * @return The remedies, one per line
+   */
+  String remediesDescription();
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/TaskDeliveryKey.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/TaskDeliveryKey.java
@@ -1,0 +1,94 @@
+package io.vanillabp.integration.adapter.migration.workflowtask;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.spi.TaskDelivery;
+
+/**
+ * Builds the identity a processed task delivery is remembered by (see
+ * {@link TaskDelivery#deliveryKey()}). The delivery ID an adapter reports only has to
+ * be unique within its BPMS, so the key is qualified by everything which tells two
+ * deliveries apart in an application talking to several of them:
+ *
+ * <pre>
+ * &lt;adapterId&gt;|&lt;workflowModuleId&gt;|&lt;bpmnProcessId&gt;|&lt;taskEvent&gt;|&lt;deliveryId&gt;
+ * </pre>
+ *
+ * The EVENT is part of it because one task instance may be delivered for more than
+ * one lifecycle event (a user task created and later canceled) - those are two
+ * deliveries of the same ID and each has its own outcome.
+ * <p>
+ * A key longer than {@link #MAX_LENGTH} characters is replaced by a hash of itself:
+ * stores index the key, and unique-index key lengths are limited (MySQL: 3072 bytes,
+ * which is 768 characters with utf8mb4). Hashing keeps long identifiers working and
+ * costs only the readability of a record nobody can read anyway at that length.
+ */
+public final class TaskDeliveryKey {
+
+  /**
+   * Up to this length a key is stored as it reads; a longer one is hashed.
+   */
+  public static final int MAX_LENGTH = 512;
+
+  private static final String HASH_PREFIX = "sha256:";
+
+  private TaskDeliveryKey() {
+
+  }
+
+  /**
+   * The key of the given delivery.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param context The invocation context supplied by the adapter - it reports the
+   *          adapter ID, the event and the delivery ID
+   * @return The key or <code>null</code> if the adapter reports no delivery ID (it
+   *         cannot tell a redelivery from a new task, so nothing is remembered)
+   */
+  public static String of(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final TaskInvocationContext context) {
+
+    final var deliveryId = context.getDeliveryId();
+    if ((deliveryId == null) || deliveryId.isBlank()) {
+      return null;
+    }
+    final var key = "%s|%s|%s|%s|%s"
+        .formatted(
+            context.getAdapterId(),
+            workflowModuleId,
+            bpmnProcessId,
+            context.getTaskEvent(),
+            deliveryId);
+    return key.length() <= MAX_LENGTH
+        ? key
+        : hashed(key);
+
+  }
+
+  /**
+   * Hashes a key exceeding {@link #MAX_LENGTH}. SHA-256 is available on every JVM;
+   * the unreachable exception is wrapped rather than declared - a caller could not do
+   * anything about it either.
+   */
+  private static String hashed(
+      final String key) {
+
+    try {
+      final var digest = MessageDigest
+          .getInstance("SHA-256")
+          .digest(key.getBytes(StandardCharsets.UTF_8));
+      return HASH_PREFIX + HexFormat.of().formatHex(digest);
+    } catch (final NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 is not available to hash a task delivery key!", e);
+    }
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/InboundIdempotencyTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/InboundIdempotencyTest.java
@@ -1,0 +1,550 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.TaskAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.TaskException;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * Story 51: a BPMS repeating a delivery must not run the business code twice. What is
+ * pinned here is the CORE's part of it - which delivery is remembered, what a repeated
+ * one is answered with, and when nothing is remembered at all:
+ * <ul>
+ * <li>a repeated delivery skips the handler and reports the recorded outcome again
+ * (completed as well as BPMN error, whose code and name have to survive);</li>
+ * <li>a delivery whose handler threw leaves no record - the retry runs it, which is what
+ * makes the BPMS' retry work;</li>
+ * <li>nothing is remembered where the adapter reports no delivery identity, or where the
+ * feature is switched off for the adapter, the workflow or the single task;</li>
+ * <li>an adapter which may repeat deliveries without a log to remember them is reported
+ * at startup, naming the property to silence it.</li>
+ * </ul>
+ * The stores themselves (JDBC, MongoDB) are covered by the platform integrations' tests -
+ * per platform, as the coverage rules require.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class InboundIdempotencyTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String ADAPTER = "test-adapter";
+
+  private static final String TASK = "task";
+
+  public static class Aggregate {
+
+    String id;
+
+    int invocations;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  /**
+   * A transaction which really rolls back: everything recorded and saved while the work
+   * ran is discarded when it throws - the only way to tell "no record was written"
+   * apart from "the record was written and ignored".
+   */
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    private final Runnable rollback;
+
+    TransactionRunnerStub(
+        final Runnable rollback) {
+      this.rollback = rollback;
+    }
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      try {
+        return work.get();
+      } catch (final RuntimeException e) {
+        rollback.run();
+        throw e;
+      }
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      return requireNew(work);
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  /**
+   * A delivery log in memory, behaving like a store with a unique key.
+   */
+  static class InMemoryDeliveryLog implements TaskDeliveryLog {
+
+    final Map<String, TaskDelivery> records = new HashMap<>();
+
+    final List<String> recorded = new ArrayList<>();
+
+    @Override
+    public Optional<TaskDelivery> recordedDelivery(
+        final String deliveryKey) {
+      return Optional.ofNullable(records.get(deliveryKey));
+    }
+
+    @Override
+    public boolean record(
+        final TaskDelivery delivery) {
+      recorded.add(delivery.deliveryKey());
+      return records.putIfAbsent(delivery.deliveryKey(), delivery) == null;
+    }
+
+  }
+
+  public static class TestWorkflowService {
+
+    /**
+     * How often a handler really ran - counted outside the aggregate, since a
+     * rolled-back delivery takes the aggregate's changes with it.
+     */
+    static int handlerCalls;
+
+    @WorkflowTask(taskDefinition = TASK)
+    public void task(
+        final Aggregate aggregate) {
+
+      handlerCalls++;
+      aggregate.invocations++;
+
+    }
+
+    @WorkflowTask(taskDefinition = "failing")
+    public void failing(
+        final Aggregate aggregate) {
+
+      handlerCalls++;
+      aggregate.invocations++;
+      throw new IllegalStateException("something broke");
+
+    }
+
+    @WorkflowTask(taskDefinition = "erroneous")
+    public void erroneous(
+        final Aggregate aggregate) throws TaskException {
+
+      handlerCalls++;
+      aggregate.invocations++;
+      throw new TaskException("PaymentFailed", "PAYMENT_FAILED");
+
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  private final InMemoryDeliveryLog deliveryLog = new InMemoryDeliveryLog();
+
+  /**
+   * Properties where the given switch values are configured - <code>null</code> means
+   * "not configured at that level", so the resolution order of the story's key can be
+   * exercised.
+   */
+  private MigrationAdapterProperties properties(
+      final Boolean adapterLevel,
+      final Boolean workflowLevel,
+      final Boolean taskLevel) {
+
+    final var adapterConfig = AdapterConfigProperties.ofType("dummy");
+    adapterConfig.setDeduplicateDeliveries(adapterLevel);
+
+    final var taskAdapter = new AdapterProperties();
+    taskAdapter.setDeduplicateDeliveries(taskLevel);
+    final var task = TaskAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, taskAdapter))
+        .build();
+
+    final var workflowAdapter = new AdapterProperties();
+    workflowAdapter.setDeduplicateDeliveries(workflowLevel);
+    final var workflow = WorkflowAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, workflowAdapter))
+        .tasks(Map.of(TASK, task))
+        .build();
+
+    final var workflowModule = WorkflowModuleAdapterProperties
+        .builder()
+        .workflows(Map.of(PROCESS, workflow))
+        .build();
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, adapterConfig))
+        .prioritizedAdapters(List.of(ADAPTER))
+        .workflowModules(Map.of(MODULE, workflowModule))
+        .build();
+    properties.validateAndLink();
+    return properties;
+
+  }
+
+  private MigrationProcessService<Aggregate> processService(
+      final MigrationAdapterProperties properties,
+      final TaskDeliveryLog log) {
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn(ADAPTER);
+    lenient().when(adapter.deliversTasksAtLeastOnce()).thenReturn(true);
+
+    final TaskDeliveryLogResolver resolver = new TaskDeliveryLogResolver() {
+
+      @Override
+      public TaskDeliveryLog resolveFor(
+          final Class<?> workflowAggregateClass) {
+        return log;
+      }
+
+      @Override
+      public String remediesDescription() {
+        return "- add a store, or";
+      }
+
+    };
+
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null, null, resolver);
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final MigrationProcessService<Aggregate> processService) {
+
+    final var registry = new WorkflowTaskRegistry(
+        new TransactionRunnerStub(() -> {
+          // the rolled-back transaction takes the delivery record AND the aggregate
+          // changes with it
+          deliveryLog.records.clear();
+          persistence.aggregates.values().forEach(aggregate -> aggregate.invocations = 0);
+        }));
+    registry.registerWorkflowService(
+        MODULE,
+        PROCESS,
+        TestWorkflowService.class,
+        TestWorkflowService::new,
+        type -> null,
+        processService);
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    TestWorkflowService.handlerCalls = 0;
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A repeated delivery runs the handler once and reports the same outcome twice")
+  public void repeatedDeliveryIsAnsweredFromTheRecord() {
+
+    final var testee = registry(processService(properties(null, null, null), deliveryLog));
+    storeAggregate("4711");
+
+    final var first = testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4711", "job-1"));
+    final var second = testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4711", "job-1"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, first.kind());
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, second.kind());
+    assertEquals(1, persistence.aggregates.get("4711").invocations, "the handler ran exactly once");
+    assertEquals(1, deliveryLog.recorded.size(), "the delivery was recorded once");
+
+    // a genuinely new task instance of the same workflow is a different delivery
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4711", "job-2"));
+    assertEquals(2, persistence.aggregates.get("4711").invocations);
+
+  }
+
+  @Test
+  @DisplayName("A repeated delivery of a BPMN error reports code and name again")
+  public void repeatedDeliveryReportsTheRecordedBpmnError() {
+
+    final var testee = registry(processService(properties(null, null, null), deliveryLog));
+    storeAggregate("4712");
+
+    final var first = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("erroneous", "4712", "job-1"));
+    final var second = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("erroneous", "4712", "job-1"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.BPMN_ERROR, second.kind());
+    assertEquals(first.errorCode(), second.errorCode());
+    assertEquals("PAYMENT_FAILED", second.errorCode());
+    assertEquals("PaymentFailed", second.errorName());
+    assertEquals(1, persistence.aggregates.get("4712").invocations, "the handler ran exactly once");
+
+  }
+
+  @Test
+  @DisplayName("A delivery whose handler threw leaves no record - the retry runs it again")
+  public void aRolledBackDeliveryIsProcessedAgain() {
+
+    final var testee = registry(processService(properties(null, null, null), deliveryLog));
+    storeAggregate("4713");
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery("failing", "4713", "job-1")));
+    assertTrue(
+        deliveryLog.records.isEmpty(),
+        "a handler which threw has no outcome to remember, and the rollback would take a record with it");
+
+    // the retry of the very same delivery reaches the handler
+    assertThrows(
+        IllegalStateException.class,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery("failing", "4713", "job-1")));
+    assertEquals(2, TestWorkflowService.handlerCalls, "the handler ran for both attempts");
+
+  }
+
+  @Test
+  @DisplayName("Without a delivery identity nothing is remembered")
+  public void deliveriesWithoutAnIdentityAreNotDeduplicated() {
+
+    final var testee = registry(processService(properties(null, null, null), deliveryLog));
+    storeAggregate("4714");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4714", null));
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4714", null));
+
+    assertEquals(2, persistence.aggregates.get("4714").invocations);
+    assertTrue(deliveryLog.records.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("The switch is resolved per task: workflow on, task off")
+  public void theSwitchIsResolvedTaskBeforeWorkflowBeforeAdapter() {
+
+    // adapter level off, workflow level on, task level off again - the most specific
+    // value wins, so THIS task is not deduplicated
+    final var testee = registry(processService(properties(false, true, false), deliveryLog));
+    storeAggregate("4715");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4715", "job-1"));
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4715", "job-1"));
+    assertEquals(2, persistence.aggregates.get("4715").invocations);
+
+    // another task of the same workflow inherits the workflow's ON
+    storeAggregate("4716");
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("erroneous", "4716", "job-2"));
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("erroneous", "4716", "job-2"));
+    assertEquals(1, persistence.aggregates.get("4716").invocations);
+
+  }
+
+  @Test
+  @DisplayName("An adapter repeating deliveries without a log is reported at startup")
+  public void aMissingDeliveryLogIsReportedAtStartup() {
+
+    final var testee = processService(properties(null, null, null), null);
+
+    final var messages = loggedBy(MigrationProcessService.class, testee::validateTaskDeliveryLogAtStartup);
+
+    assertEquals(1, messages.size());
+    final var message = messages.getFirst();
+    assertTrue(message.contains(ADAPTER), "names the adapter");
+    assertTrue(message.contains(PROCESS), "names the BPMN process");
+    assertTrue(message.contains("TaskDeliveryLog"), "names the SPI to implement");
+    assertTrue(
+        message.contains("vanillabp.adapters.test-adapter.deduplicate-deliveries"),
+        "names the property to state that the handlers are idempotent themselves");
+
+    // the message names a configuration gap - it must not be repeated per delivery
+    assertTrue(
+        loggedBy(MigrationProcessService.class, testee::validateTaskDeliveryLogAtStartup).isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Nothing is reported where no adapter can repeat a delivery")
+  public void anEmbeddedBpmsNeedsNoDeliveryLog() {
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> embedded = mock(MigratableProcessService.class);
+    lenient().when(embedded.getAdapterId()).thenReturn(ADAPTER);
+    lenient().when(embedded.deliversTasksAtLeastOnce()).thenReturn(false);
+
+    final var testee = new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties(null, null, null), persistence, List
+            .of(embedded), null, null, null);
+
+    assertTrue(loggedBy(MigrationProcessService.class, testee::validateTaskDeliveryLogAtStartup).isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A record carrying an unknown outcome is processed again")
+  public void anUnknownRecordedOutcomeFallsBackToProcessing() {
+
+    final var testee = registry(processService(properties(null, null, null), deliveryLog));
+    storeAggregate("4717");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4717", "job-1"));
+    final var key = deliveryLog.recorded.getFirst();
+    final var recorded = deliveryLog.records.get(key);
+    deliveryLog.records.put(
+        key,
+        new TaskDelivery(
+            key, recorded.workflowModuleId(), recorded.bpmnProcessId(), recorded
+                .workflowAggregateId(), recorded.taskDefinition(), "WHATEVER", null, null));
+
+    final var messages = loggedBy(
+        MigrationProcessService.class,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery(TASK, "4717", "job-1")));
+
+    assertEquals(2, persistence.aggregates.get("4717").invocations, "the handler ran again");
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("WHATEVER")),
+        "the unknown outcome is named");
+
+  }
+
+  /**
+   * The messages a logger emitted while the given work ran - the guiding messages of
+   * this story are WARNings, and "normal" logging is switched off during tests.
+   */
+  private List<String> loggedBy(
+      final Class<?> loggingClass,
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggingClass);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAndStopAllAppenders();
+    }
+    return logWatcher.list
+        .stream()
+        .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+        .map(event -> event.getFormattedMessage())
+        .toList();
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/TaskDeliveryKeyTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/TaskDeliveryKeyTest.java
@@ -1,0 +1,117 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.workflowtask.TaskDeliveryKey;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.TaskEvent;
+
+/**
+ * What tells two task deliveries apart (story 51): the delivery ID an adapter reports is
+ * unique within ITS BPMS only, so the key is qualified by adapter, workflow module, BPMN
+ * process and event - and it is hashed where it would outgrow what a store can index.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class TaskDeliveryKeyTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private TaskInvocationContext context(
+      final String adapterId,
+      final TaskEvent.Event event,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return adapterId;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return "task";
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return "4711";
+      }
+
+      @Override
+      public TaskEvent.Event getTaskEvent() {
+        return event;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("The same delivery yields the same key")
+  public void theSameDeliveryYieldsTheSameKey() {
+
+    assertEquals(
+        TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, "job-1")),
+        TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, "job-1")));
+
+  }
+
+  @Test
+  @DisplayName("Adapter, workflow module, BPMN process, event and delivery ID all separate keys")
+  public void everyQualifierSeparatesKeys() {
+
+    final var key = TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, "job-1"));
+
+    // two BPMS may hand out the same ID - a migration runs both at the same time
+    assertNotEquals(key, TaskDeliveryKey.of(MODULE, PROCESS, context("c7", TaskEvent.Event.CREATED, "job-1")));
+    assertNotEquals(key, TaskDeliveryKey.of("other-module", PROCESS, context("c8", TaskEvent.Event.CREATED, "job-1")));
+    assertNotEquals(key, TaskDeliveryKey.of(MODULE, "OtherProcess", context("c8", TaskEvent.Event.CREATED, "job-1")));
+    // creation and cancellation of ONE user task share the ID and are two deliveries
+    assertNotEquals(key, TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CANCELED, "job-1")));
+    assertNotEquals(key, TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, "job-2")));
+
+  }
+
+  @Test
+  @DisplayName("An adapter reporting no delivery ID gets no key")
+  public void withoutADeliveryIdThereIsNoKey() {
+
+    assertNull(TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, null)));
+    assertNull(TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, "  ")));
+
+  }
+
+  @Test
+  @DisplayName("A key longer than the indexable length is hashed, and stays stable")
+  public void anOversizedKeyIsHashed() {
+
+    final var longId = "j".repeat(TaskDeliveryKey.MAX_LENGTH + 1);
+    final var key = TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, longId));
+
+    assertTrue(key.startsWith("sha256:"), "the key was hashed");
+    assertTrue(key.length() <= TaskDeliveryKey.MAX_LENGTH, "the hash fits into the store's column");
+    assertEquals(key, TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, longId)));
+    assertNotEquals(
+        key,
+        TaskDeliveryKey.of(MODULE, PROCESS, context("c8", TaskEvent.Event.CREATED, longId
+            + "x")));
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/MigratableProcessService.java
@@ -147,6 +147,34 @@ public interface MigratableProcessService<A> {
   boolean needsTwoPhaseCommitForStartingWorkflows();
 
   /**
+   * Whether this BPMS may deliver the same task more than once, so the core has to
+   * remember what it processed (see
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLog}). True for every REMOTE
+   * BPMS: the task is reported as done after the local transaction was committed, so
+   * a crash in between makes the BPMS repeat the delivery.
+   * <p>
+   * The default is <code>false</code> - the answer of an EMBEDDED BPMS delivering
+   * tasks inside the application's transaction
+   * ({@link io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext#runInCurrentTransaction()}):
+   * a repeated delivery there means that nothing was committed, so there is nothing
+   * to remember and deduplication would have no effect.
+   * <p>
+   * An adapter answering <code>true</code> should report a delivery identity with
+   * every invocation context
+   * ({@link io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext#getDeliveryId()}) -
+   * without one the core cannot tell a redelivery from a new task and keeps invoking
+   * the handler for every delivery. The answer is used at STARTUP, too: it decides
+   * whether a missing delivery log is worth a guiding message.
+   *
+   * @return Whether tasks may be delivered more than once
+   */
+  default boolean deliversTasksAtLeastOnce() {
+
+    return false;
+
+  }
+
+  /**
    * Start a new workflow. Phase one of the two-phase commit. This phase is executed immediately before the
    * local transaction is committed.
    * <p>

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
@@ -142,4 +142,35 @@ public interface TaskInvocationContext {
 
   }
 
+  /**
+   * What identifies THIS delivery across redeliveries of the same task: the Camunda 8
+   * job key, the ID of the task instance a remote engine reports, whatever the BPMS
+   * uses to talk about this piece of work. A BPMS repeating a delivery has to yield
+   * the SAME value, a genuinely new task instance (the next loop iteration, the next
+   * multi-instance element, a retry AFTER the task was completed) a different one.
+   * <p>
+   * The core uses it to remember which deliveries it processed
+   * ({@link io.vanillabp.integration.spi.TaskDeliveryLog}): a repeated delivery is
+   * answered with the recorded outcome instead of running the
+   * <code>&#64;WorkflowTask</code> method again.
+   * <p>
+   * The default is <code>null</code>, which means "this adapter cannot tell": the
+   * handler is invoked for every delivery, as it always was. An EMBEDDED BPMS
+   * delivering within the application's transaction ({@link #runInCurrentTransaction()})
+   * has no reason to report one - a redelivery there proves that nothing was
+   * committed, so there is nothing to remember (see
+   * {@link io.vanillabp.integration.adapter.spi.MigratableProcessService#deliversTasksAtLeastOnce()}).
+   * <p>
+   * A value does NOT have to be unique beyond this BPMS: the core prefixes it with
+   * the adapter ID, the workflow module, the BPMN process and the event, so the ID
+   * only has to be unique within the delivering BPMS.
+   *
+   * @return The delivery's identity or <code>null</code>
+   */
+  default String getDeliveryId() {
+
+    return null;
+
+  }
+
 }

--- a/quarkus-integration/README.md
+++ b/quarkus-integration/README.md
@@ -154,6 +154,32 @@ To minimize build output three actions were taken:
 In case of errors one might disable one or all of them for finding
 the root cause of the problem.
 
+## The store of processed task deliveries
+
+`io.vanillabp.integration.runtime.delivery` implements the core's `TaskDeliveryLog`
+(story 51, the inbound counterpart of the outbox) twice, registered by the build step
+`buildTaskDeliveryLog` along the capabilities present (`quarkus-agroal`,
+`quarkus-mongodb-client`) and kept by `preserveTaskDeliveryLogBeans` - the beans are
+looked up per aggregate at runtime, never injected by application code.
+`QuarkusTaskDeliveryLogResolver` picks one per workflow aggregate, and as with the
+outbox a mixed-persistence application has to attribute aggregates itself
+(`TaskDeliveryLogAware`): Quarkus has no platform-side knowledge of which persistence
+manages an aggregate.
+
+- `JdbcTaskDeliveryLog` acquires its Agroal connection within the running JTA
+  transaction, so it is enlisted there. The SQL and the portable DDL of table
+  `VANILLABP_TASK_DELIVERY` live in the core (`JdbcTaskDeliveryStore`), shared with
+  Spring Boot.
+- `MongoTaskDeliveryLog` writes into `vanillabp-task-deliveries` of
+  `quarkus.mongodb.database`. MongoDB is no JTA resource, so the record is written
+  immediately and deleted again from an interposed synchronization when the transaction
+  ends in anything but a commit - the same best-effort compensation `MongoPhaseTwoOutbox`
+  does for its entries.
+- Both observe the `StartupEvent` to create their schema (unless
+  `vanillabp.outbox.create-schema` is disabled) and to start the core's
+  `TaskDeliveryRetentionCleanup`, which calls `cleanUpExpiredRecords` per
+  `vanillabp.outbox.retention`.
+
 ## Noteworthy & Contributors
 
 [VanillaBP](https://www.github.com/vanillabp/spi-for-java) was developed by [Phactum](https://www.phactum.at) with the

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/VanillaBpBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/VanillaBpBuildStepProcessor.java
@@ -248,6 +248,62 @@ public class VanillaBpBuildStepProcessor {
   }
 
   /**
+   * Registers the default implementations of the log of processed task deliveries (see
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLog}): the JDBC/Agroal-based one if a
+   * JDBC datasource applies AND the MongoDB-based one if the
+   * <code>quarkus-mongodb-client</code> extension is present - both may coexist, each
+   * workflow aggregate is served by the log matching its persistence (attribution via
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLogAware} beans, see
+   * {@link io.vanillabp.integration.runtime.processservice.QuarkusTaskDeliveryLogResolver}).
+   * Unwanted defaults can be deactivated via
+   * <code>vanillabp.outbox.jdbc.enabled</code> /
+   * <code>vanillabp.outbox.mongo.enabled</code> - the log shares the outbox' store
+   * settings.
+   *
+   * @param capabilities Capabilities of the project's extensions
+   * @param additionalBeans Producer used to register the delivery-log beans
+   */
+  @BuildStep
+  void buildTaskDeliveryLog(
+      final Capabilities capabilities,
+      final BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+    if (capabilities.isPresent(Capability.AGROAL)) {
+      additionalBeans.produce(AdditionalBeanBuildItem
+          .builder()
+          .addBeanClasses(io.vanillabp.integration.runtime.delivery.JdbcTaskDeliveryLog.class)
+          .setUnremovable() // don't remove, since it is used under the hoods
+          .build());
+    }
+
+    if (capabilities.isPresent(Capability.MONGODB_CLIENT)) {
+      additionalBeans.produce(AdditionalBeanBuildItem
+          .builder()
+          .addBeanClasses(io.vanillabp.integration.runtime.delivery.MongoTaskDeliveryLog.class)
+          .setUnremovable() // don't remove, since it is used under the hoods
+          .build());
+    }
+
+  }
+
+  /**
+   * Beans implementing {@link io.vanillabp.integration.spi.TaskDeliveryLog} or
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLogAware} are looked up dynamically
+   * at runtime (per-aggregate log resolution), not injected by application code - ArC
+   * must not remove them as unused.
+   *
+   * @return The unremovable-bean build item covering delivery logs and their attributions
+   */
+  @BuildStep
+  io.quarkus.arc.deployment.UnremovableBeanBuildItem preserveTaskDeliveryLogBeans() {
+
+    return io.quarkus.arc.deployment.UnremovableBeanBuildItem.beanTypes(
+        io.vanillabp.integration.spi.TaskDeliveryLog.class,
+        io.vanillabp.integration.spi.TaskDeliveryLogAware.class);
+
+  }
+
+  /**
    * Beans implementing {@link io.vanillabp.integration.spi.PhaseTwoOutbox}
    * or {@link io.vanillabp.integration.spi.PhaseTwoOutboxAware} are not
    * necessarily injected by application code but looked up dynamically at runtime

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryAggregate.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryAggregate.java
@@ -1,0 +1,42 @@
+package io.vanillabp.integration.test.delivery;
+
+/**
+ * The aggregate of the inbound-idempotency test (story 51). It counts how often a
+ * handler ran on it - the business code a repeated delivery must not run again.
+ */
+public class DeliveryAggregate {
+
+  private String id;
+
+  private String status;
+
+  private int invocations;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(
+      final String status) {
+    this.status = status;
+  }
+
+  public int getInvocations() {
+    return invocations;
+  }
+
+  public void setInvocations(
+      final int invocations) {
+    this.invocations = invocations;
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryAggregatePersistence.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryAggregatePersistence.java
@@ -1,0 +1,97 @@
+package io.vanillabp.integration.test.delivery;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * In-memory persistence for the inbound-idempotency test's aggregate, copying on
+ * save/load so un-saved mutations never leak into the store.
+ */
+@ApplicationScoped
+public class DeliveryAggregatePersistence implements AggregatePersistenceAware<DeliveryAggregate> {
+
+  private final Map<String, DeliveryAggregate> aggregates = new ConcurrentHashMap<>();
+
+  @Override
+  public Class<DeliveryAggregate> getAggregateClass() {
+
+    return DeliveryAggregate.class;
+
+  }
+
+  @Override
+  public DeliveryAggregate save(
+      final DeliveryAggregate aggregate) {
+
+    aggregates.put(aggregate.getId(), copyOf(aggregate));
+    return aggregate;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final DeliveryAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public Class<?> getAggregateIdType() {
+
+    return String.class;
+
+  }
+
+  @Override
+  public DeliveryAggregate loadById(
+      final Object aggregateId) {
+
+    final var stored = aggregates.get(aggregateId);
+    return stored != null
+        ? copyOf(stored)
+        : null;
+
+  }
+
+  /**
+   * Stores an aggregate the test starts from, without going through a workflow start.
+   *
+   * @param id The aggregate's ID
+   */
+  public void store(
+      final String id) {
+
+    final var aggregate = new DeliveryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("new");
+    aggregates.put(id, aggregate);
+
+  }
+
+  /**
+   * @param id The aggregate's ID
+   * @return The stored aggregate
+   */
+  public DeliveryAggregate get(
+      final String id) {
+
+    return aggregates.get(id);
+
+  }
+
+  private static DeliveryAggregate copyOf(
+      final DeliveryAggregate aggregate) {
+
+    final var copy = new DeliveryAggregate();
+    copy.setId(aggregate.getId());
+    copy.setStatus(aggregate.getStatus());
+    copy.setInvocations(aggregate.getInvocations());
+    return copy;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryProcessWiringSource.java
@@ -1,0 +1,33 @@
+package io.vanillabp.integration.test.delivery;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of the inbound-idempotency test: the tasks of
+ * 'DeliveryProcess' matching the handlers of {@link DeliveryWorkflowService}.
+ */
+@ApplicationScoped
+public class DeliveryProcessWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "DeliveryProcess".equals(bpmnProcessId)
+        ? List.of(
+            new BpmnTaskSpec("Activity_Process", "processTask"),
+            new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
+            new BpmnTaskSpec("Activity_Fail", "failTask"),
+            new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
@@ -1,0 +1,57 @@
+package io.vanillabp.integration.test.delivery;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.TaskException;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * The workflow service of the inbound-idempotency test: one method per outcome a
+ * repeated delivery has to be answered with, each counting its invocations.
+ */
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = DeliveryAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "DeliveryProcess"))
+public class DeliveryWorkflowService {
+
+  @WorkflowTask
+  public void processTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("processed");
+
+  }
+
+  @WorkflowTask
+  public void raiseBpmnError(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("bpmn-error-raised");
+    throw new TaskException("PaymentFailed", "PAYMENT_FAILED");
+
+  }
+
+  @WorkflowTask
+  public void failTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("must-never-be-visible");
+    throw new IllegalStateException("something broke");
+
+  }
+
+  @WorkflowTask
+  public void undeduplicatedTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("processed-again");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/InboundIdempotencyTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/InboundIdempotencyTest.java
@@ -1,0 +1,208 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.delivery.DeliveryAggregate;
+import io.vanillabp.integration.test.delivery.DeliveryAggregatePersistence;
+import io.vanillabp.integration.test.delivery.DeliveryProcessWiringSource;
+import io.vanillabp.integration.test.delivery.DeliveryWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Acceptance test of the inbound idempotency (story 51) on Quarkus, with the default
+ * JDBC-based delivery log doing the remembering: the dummy adapter delivers a task TWICE
+ * under the same delivery identity - as a BPMS which never learned the result does - and
+ * the <code>&#64;WorkflowTask</code> method has to run once while both deliveries are
+ * answered with the same outcome. Also pinned: a delivery whose handler threw leaves no
+ * record (its retry runs the handler again) and the task-level switch turns the feature
+ * off.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class InboundIdempotencyTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "DeliveryProcess";
+
+  private static final String ADAPTER = "demo1";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("inbound-idempotency/application.yaml", "application.yaml")
+          .addClass(DeliveryAggregate.class)
+          .addClass(DeliveryAggregatePersistence.class)
+          .addClass(DeliveryWorkflowService.class)
+          .addClass(DeliveryProcessWiringSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/DeliveryProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  DeliveryAggregatePersistence persistence;
+
+  @Inject
+  DataSource dataSource;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> ADAPTER.equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  /**
+   * One delivery of a task, as an adapter of a remote BPMS builds it: the delivery ID is
+   * what stays the same when the BPMS repeats it.
+   */
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  private int recordCount(
+      final String aggregateId) throws SQLException {
+
+    try (var connection = dataSource.getConnection(); var statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM %s WHERE AGGREGATE_ID = ?".formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME))) {
+      statement.setString(1, aggregateId);
+      try (var resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+
+  }
+
+  @Test
+  @DisplayName("A repeated delivery runs the handler once and reports the recorded outcome")
+  public void repeatedDeliveriesRunTheHandlerOnce() throws SQLException {
+
+    final var dummyAdapter = dummyAdapter();
+
+    persistence.store("4711");
+    final var first = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+    final var second = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, first.kind());
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, second.kind());
+    assertEquals(1, persistence.get("4711").getInvocations());
+    assertEquals(1, recordCount("4711"));
+
+    // the next task instance of the same workflow is another delivery
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-2"));
+    assertEquals(2, persistence.get("4711").getInvocations());
+    assertEquals(2, recordCount("4711"));
+
+  }
+
+  @Test
+  @DisplayName("A repeated delivery of a BPMN error reports code and name again")
+  public void repeatedDeliveryReportsTheRecordedBpmnError() {
+
+    final var dummyAdapter = dummyAdapter();
+
+    persistence.store("4712");
+    final var error = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
+    final var errorAgain = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.BPMN_ERROR, errorAgain.kind());
+    assertEquals(error.errorCode(), errorAgain.errorCode());
+    assertEquals("PAYMENT_FAILED", errorAgain.errorCode());
+    assertEquals("PaymentFailed", errorAgain.errorName());
+    assertEquals(1, persistence.get("4712").getInvocations());
+
+  }
+
+  @Test
+  @DisplayName("A rolled-back delivery leaves no record, so its retry runs the handler")
+  public void aRolledBackDeliveryLeavesNoRecord() throws SQLException {
+
+    final var dummyAdapter = dummyAdapter();
+
+    persistence.store("4713");
+    assertThrows(
+        IllegalStateException.class,
+        () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
+    assertEquals(0, recordCount("4713"));
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
+    assertEquals(0, recordCount("4713"));
+
+  }
+
+  @Test
+  @DisplayName("Switched off for a task, nothing is remembered")
+  public void aTaskMayOptOut() throws SQLException {
+
+    final var dummyAdapter = dummyAdapter();
+
+    persistence.store("4714");
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
+
+    assertEquals(2, persistence.get("4714").getInvocations());
+    assertEquals(0, recordCount("4714"));
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/inbound-idempotency/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/inbound-idempotency/application.yaml
@@ -1,0 +1,22 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:inbound-idempotency;DB_CLOSE_DELAY=-1
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy
+      workflows:
+        DeliveryProcess:
+          tasks:
+            undeduplicatedTask:
+              adapters:
+                demo1:
+                  deduplicate-deliveries: false

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
@@ -114,6 +114,18 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
 
   }
 
+  /**
+   * A dummy configured as a remote BPMS (two-phase commit) also stands in for its
+   * at-least-once task delivery: the outcome is reported after the local commit, so the
+   * same task may arrive again (story 51).
+   */
+  @Override
+  public boolean deliversTasksAtLeastOnce() {
+
+    return needsTwoPhaseCommitForStartingWorkflows;
+
+  }
+
   @Override
   public void startWorkflowPhaseOne(
       final String workflowModuleId,

--- a/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
+++ b/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
@@ -1,0 +1,152 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.runtime.delivery.MongoTaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * The MongoDB store behind the inbound idempotency (story 51) on Quarkus. MongoDB is no
+ * JTA resource here, so a record is written immediately and removed again when the
+ * transaction does not commit - that best-effort compensation is what makes a rolled-back
+ * delivery reach its handler again, and it is pinned here together with reading a record
+ * back, the uniqueness of a delivery key and the retention cleanup.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MongoTaskDeliveryLogTest {
+
+  private static final String DATABASE = "delivery-log-it";
+
+  private static final String COLLECTION = "vanillabp-task-deliveries";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("quarkus.mongodb.database", DATABASE)
+      // a retention of zero makes every record expired right away, so the cleanup can be
+      // observed without waiting days for it
+      .overrideConfigKey("vanillabp.outbox.retention", "PT0S");
+
+  @Inject
+  MongoTaskDeliveryLog deliveryLog;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  MongoClient mongoClient;
+
+  @BeforeEach
+  public void clearRecords() {
+
+    mongoClient
+        .getDatabase(DATABASE)
+        .getCollection(COLLECTION)
+        .deleteMany(new org.bson.Document());
+
+  }
+
+  private TaskDelivery delivery(
+      final String deliveryKey,
+      final String outcome) {
+
+    return new TaskDelivery(
+        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed");
+
+  }
+
+  @Test
+  @DisplayName("A record is read back with its outcome")
+  public void aRecordIsWrittenAndReadBack() throws Exception {
+
+    userTransaction.begin();
+    assertTrue(deliveryLog.record(delivery("job-1", "BPMN_ERROR")));
+    userTransaction.commit();
+
+    final var recorded = deliveryLog.recordedDelivery("job-1");
+    assertTrue(recorded.isPresent());
+    assertEquals("test-module", recorded.get().workflowModuleId());
+    assertEquals("TestProcess", recorded.get().bpmnProcessId());
+    assertEquals("4711", recorded.get().workflowAggregateId());
+    assertEquals("processTask", recorded.get().taskDefinition());
+    assertEquals("BPMN_ERROR", recorded.get().outcome());
+    assertEquals("PAYMENT_FAILED", recorded.get().bpmnErrorCode());
+    assertEquals("PaymentFailed", recorded.get().bpmnErrorName());
+
+  }
+
+  @Test
+  @DisplayName("A rolled-back transaction leaves no record")
+  public void aRolledBackTransactionLeavesNoRecord() throws Exception {
+
+    userTransaction.begin();
+    deliveryLog.record(delivery("job-2", "COMPLETED"));
+    userTransaction.rollback();
+
+    assertTrue(
+        deliveryLog.recordedDelivery("job-2").isEmpty(),
+        "the record of work which was rolled back is removed again");
+
+  }
+
+  @Test
+  @DisplayName("Recording the same delivery twice is a no-op")
+  public void aDuplicateRecordIsANoOp() throws Exception {
+
+    userTransaction.begin();
+    assertTrue(deliveryLog.record(delivery("job-3", "COMPLETED")));
+    userTransaction.commit();
+
+    userTransaction.begin();
+    assertFalse(
+        deliveryLog.record(delivery("job-3", "COMPLETED")),
+        "the delivery key is unique in the store");
+    userTransaction.commit();
+
+    assertEquals(
+        1,
+        mongoClient
+            .getDatabase(DATABASE)
+            .getCollection(COLLECTION)
+            .countDocuments());
+
+  }
+
+  @Test
+  @DisplayName("Records are deleted once the retention period passed")
+  public void expiredRecordsAreDeleted() throws Exception {
+
+    userTransaction.begin();
+    deliveryLog.record(delivery("job-4", "COMPLETED"));
+    userTransaction.commit();
+
+    assertEquals(1, deliveryLog.cleanUpExpiredRecords());
+    assertTrue(deliveryLog.recordedDelivery("job-4").isEmpty());
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -130,6 +130,18 @@ public interface QuarkusMigrationAdapterProperties {
      */
     Optional<Boolean> prefixTaskDefinitionsPerProcess();
 
+    /**
+     * Whether VanillaBP remembers the task deliveries of this BPMS, so a repeated
+     * delivery reports the recorded outcome again instead of running the
+     * <code>&#64;WorkflowTask</code> method a second time (see
+     * {@link io.vanillabp.integration.spi.TaskDeliveryLog}). Defaults to
+     * <code>true</code> and takes effect only for a BPMS which may repeat a delivery
+     * at all.
+     *
+     * @return Whether deliveries are deduplicated
+     */
+    Optional<Boolean> deduplicateDeliveries();
+
   }
 
   /**
@@ -166,6 +178,18 @@ public interface QuarkusMigrationAdapterProperties {
      * @return Whether task definitions are scoped per BPMN process
      */
     Optional<Boolean> prefixTaskDefinitionsPerProcess();
+
+    /**
+     * Whether VanillaBP remembers the task deliveries of this BPMS, so a repeated
+     * delivery reports the recorded outcome again instead of running the
+     * <code>&#64;WorkflowTask</code> method a second time (see
+     * {@link io.vanillabp.integration.spi.TaskDeliveryLog}). Defaults to
+     * <code>true</code> and takes effect only for a BPMS which may repeat a delivery
+     * at all.
+     *
+     * @return Whether deliveries are deduplicated
+     */
+    Optional<Boolean> deduplicateDeliveries();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
@@ -1,0 +1,184 @@
+package io.vanillabp.integration.runtime.delivery;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.config.SmallRyeConfig;
+import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcConnectionAccess;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The default {@link TaskDeliveryLog} for Quarkus applications persisting their workflow
+ * aggregates in a relational database: the records are written through a JDBC connection
+ * of the Agroal data source. Since the connection is acquired within the still-running
+ * JTA transaction it is enlisted automatically, so a record and the aggregate changes of
+ * the same delivery commit together - the recording contract of {@link TaskDeliveryLog}.
+ * <p>
+ * The table ({@link JdbcTaskDeliveryStore#DEFAULT_TABLE_NAME}) is created at startup
+ * unless <code>vanillabp.outbox.create-schema</code> is disabled, and records are
+ * deleted once <code>vanillabp.outbox.retention</code> passed - the delivery log shares
+ * the outbox' store settings, because both keep a deduplication window open.
+ */
+@ApplicationScoped
+@Slf4j
+public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAccess {
+
+  @Inject
+  Instance<DataSource> dataSource;
+
+  @Inject
+  TransactionSynchronizationRegistry txRegistry;
+
+  private volatile PhaseTwoOutboxProperties properties;
+
+  private volatile JdbcTaskDeliveryStore store;
+
+  private volatile TaskDeliveryRetentionCleanup retentionCleanup;
+
+  /**
+   * Whether this default log is usable: the extension registers the bean at build time,
+   * but without a configured datasource it cannot store anything - an unusable default
+   * must not be selected for an aggregate (the startup validation then reports that
+   * deliveries are not deduplicated, naming the remedies).
+   *
+   * @return Whether a datasource is available
+   */
+  public boolean isAvailable() {
+
+    return dataSource.isResolvable();
+
+  }
+
+  /**
+   * The outbox configuration (<code>vanillabp.outbox.*</code>), loaded lazily - the log
+   * may be asked for a record before the startup event was observed.
+   *
+   * @return The configuration
+   */
+  PhaseTwoOutboxProperties getProperties() {
+
+    if (properties == null) {
+      properties = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(
+          ConfigProvider
+              .getConfig()
+              .unwrap(SmallRyeConfig.class)
+              .getConfigMapping(QuarkusMigrationAdapterProperties.class)
+              .outbox());
+    }
+    return properties;
+
+  }
+
+  private JdbcTaskDeliveryStore getStore() {
+
+    if (store == null) {
+      store = new JdbcTaskDeliveryStore(this, JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME);
+    }
+    return store;
+
+  }
+
+  /**
+   * Creates the table (unless disabled) and starts the retention cleanup.
+   *
+   * @param event The startup event observed
+   */
+  void onStart(
+      @Observes final StartupEvent event) {
+
+    if (!isAvailable()) {
+      log.debug("No datasource available - the JDBC-based task delivery log stays inactive");
+      return;
+    }
+    if (!getProperties().getJdbc().isEnabled()) {
+      log.debug("'vanillabp.outbox.jdbc.enabled' is false - the JDBC-based task delivery log stays inactive");
+      return;
+    }
+    if (getProperties().isCreateSchema()) {
+      getStore().createSchemaIfNotExists();
+    }
+    retentionCleanup = new TaskDeliveryRetentionCleanup(
+        getStore().getTableName(), getProperties().getRetention(), this::cleanUpExpiredRecords);
+    retentionCleanup.start();
+
+  }
+
+  /**
+   * Deletes the records whose retention period passed - run by the background cleanup and
+   * usable on demand (e.g. by tests).
+   *
+   * @return The number of records deleted
+   */
+  public int cleanUpExpiredRecords() {
+
+    return getStore().deleteExpired(getProperties().getRetention());
+
+  }
+
+  @PreDestroy
+  void shutdown() {
+
+    if (retentionCleanup != null) {
+      retentionCleanup.stop();
+      retentionCleanup = null;
+    }
+
+  }
+
+  @Override
+  public Optional<TaskDelivery> recordedDelivery(
+      final String deliveryKey) {
+
+    return getStore().recordedDelivery(deliveryKey);
+
+  }
+
+  @Override
+  public boolean record(
+      final TaskDelivery delivery) {
+
+    if (txRegistry.getTransactionKey() == null) {
+      throw new IllegalStateException(
+          """
+              No transaction active! A task delivery has to be recorded within the still-running \
+              transaction persisting the workflow aggregate - a record committed on its own would \
+              skip the @WorkflowTask method of a redelivery although nothing was persisted.""");
+    }
+    return getStore().record(delivery);
+
+  }
+
+  @Override
+  public Connection acquire() throws SQLException {
+
+    if (!dataSource.isResolvable()) {
+      throw new IllegalStateException(
+          """
+              No datasource available! The JDBC-based task delivery log requires a configured default \
+              datasource (quarkus-agroal).""");
+    }
+    // acquired within the running JTA transaction, so Agroal enlists it there
+    return dataSource.get().getConnection();
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
@@ -1,0 +1,247 @@
+package io.vanillabp.integration.runtime.delivery;
+
+import java.util.Date;
+import java.util.Optional;
+
+import org.bson.Document;
+import org.eclipse.microprofile.config.ConfigProvider;
+
+import com.mongodb.MongoWriteException;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Indexes;
+
+import io.quarkus.runtime.StartupEvent;
+import io.smallrye.config.SmallRyeConfig;
+import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
+import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
+import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import jakarta.annotation.PreDestroy;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+import jakarta.transaction.Status;
+import jakarta.transaction.Synchronization;
+import jakarta.transaction.TransactionSynchronizationRegistry;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The default {@link TaskDeliveryLog} for Quarkus applications using MongoDB (extension
+ * <code>quarkus-mongodb-client</code>) for aggregate persistence. The records live in
+ * the collection {@value #DEFAULT_COLLECTION_NAME} of the database
+ * <code>quarkus.mongodb.database</code> and are keyed by the delivery key (the
+ * document's <code>_id</code>), so uniqueness comes for free.
+ * <p>
+ * <strong>Best-effort window (no MongoDB transaction):</strong> MongoDB is no JTA
+ * resource and the Quarkus client does not enlist in the Narayana transaction, so the
+ * record is written IMMEDIATELY instead of with the commit - the same window the MongoDB
+ * outbox documents. A record whose transaction rolls back would skip a redelivery of
+ * work which never happened, therefore the record is deleted best-effort when the
+ * transaction ends in anything but a commit. Only a crash between writing the record and
+ * that rollback leaves one behind, and its delivery is then reported as done although the
+ * aggregate never changed.
+ */
+@ApplicationScoped
+@Slf4j
+public class MongoTaskDeliveryLog implements TaskDeliveryLog {
+
+  /**
+   * The collection holding the records - the same name the Spring Boot MongoDB log uses,
+   * so both platforms share the store layout.
+   */
+  public static final String DEFAULT_COLLECTION_NAME = "vanillabp-task-deliveries";
+
+  @Inject
+  Instance<MongoClient> mongoClient;
+
+  @Inject
+  TransactionSynchronizationRegistry txRegistry;
+
+  private volatile PhaseTwoOutboxProperties properties;
+
+  private volatile TaskDeliveryRetentionCleanup retentionCleanup;
+
+  /**
+   * Whether this default log is usable: the extension registers the bean at build time,
+   * but without a MongoDB client it cannot store anything.
+   *
+   * @return Whether a MongoDB client is available
+   */
+  public boolean isAvailable() {
+
+    return mongoClient.isResolvable();
+
+  }
+
+  /**
+   * The outbox configuration (<code>vanillabp.outbox.*</code>), loaded lazily.
+   *
+   * @return The configuration
+   */
+  PhaseTwoOutboxProperties getProperties() {
+
+    if (properties == null) {
+      properties = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(
+          ConfigProvider
+              .getConfig()
+              .unwrap(SmallRyeConfig.class)
+              .getConfigMapping(QuarkusMigrationAdapterProperties.class)
+              .outbox());
+    }
+    return properties;
+
+  }
+
+  /**
+   * Creates the index the cleanup reads (unless disabled) and starts the cleanup.
+   *
+   * @param event The startup event observed
+   */
+  void onStart(
+      @Observes final StartupEvent event) {
+
+    if (!isAvailable()) {
+      log.debug("No MongoDB client available - the MongoDB-based task delivery log stays inactive");
+      return;
+    }
+    if (!getProperties().getMongo().isEnabled()) {
+      log.debug("'vanillabp.outbox.mongo.enabled' is false - the MongoDB-based task delivery log stays inactive");
+      return;
+    }
+    if (getProperties().isCreateSchema()) {
+      deliveryCollection().createIndex(Indexes.ascending("recordedAt"));
+    }
+    retentionCleanup = new TaskDeliveryRetentionCleanup(
+        DEFAULT_COLLECTION_NAME, getProperties().getRetention(), this::cleanUpExpiredRecords);
+    retentionCleanup.start();
+
+  }
+
+  /**
+   * Deletes the records whose retention period passed - run by the background cleanup and
+   * usable on demand (e.g. by tests).
+   *
+   * @return The number of records deleted
+   */
+  public long cleanUpExpiredRecords() {
+
+    return deliveryCollection()
+        .deleteMany(
+            new Document(
+                "recordedAt", new Document("$lt", Date
+                    .from(java.time.Instant.now().minus(getProperties().getRetention())))))
+        .getDeletedCount();
+
+  }
+
+  @PreDestroy
+  void shutdown() {
+
+    if (retentionCleanup != null) {
+      retentionCleanup.stop();
+      retentionCleanup = null;
+    }
+
+  }
+
+  @Override
+  public Optional<TaskDelivery> recordedDelivery(
+      final String deliveryKey) {
+
+    return Optional
+        .ofNullable(
+            deliveryCollection()
+                .find(new Document("_id", deliveryKey))
+                .first())
+        .map(document -> new TaskDelivery(
+            deliveryKey, document.getString("workflowModuleId"), document.getString("bpmnProcessId"), document
+                .getString("aggregateId"), document.getString("taskDefinition"), document
+                    .getString("outcome"), document.getString("bpmnErrorCode"), document.getString("bpmnErrorName")));
+
+  }
+
+  @Override
+  public boolean record(
+      final TaskDelivery delivery) {
+
+    final var collection = deliveryCollection();
+    try {
+      collection.insertOne(
+          new Document()
+              .append("_id", delivery.deliveryKey())
+              .append("workflowModuleId", delivery.workflowModuleId())
+              .append("bpmnProcessId", delivery.bpmnProcessId())
+              .append("aggregateId", delivery.workflowAggregateId())
+              .append("taskDefinition", delivery.taskDefinition())
+              .append("outcome", delivery.outcome())
+              .append("bpmnErrorCode", delivery.bpmnErrorCode())
+              .append("bpmnErrorName", delivery.bpmnErrorName())
+              .append("recordedAt", Date.from(java.time.Instant.now())));
+    } catch (final MongoWriteException e) {
+      // 11000 = duplicate key: another node recorded the same delivery concurrently
+      if (e.getError().getCode() == 11000) {
+        log.debug(
+            "Task delivery '{}' of BPMN process '{}' of workflow module '{}' was recorded already",
+            delivery.deliveryKey(),
+            delivery.bpmnProcessId(),
+            delivery.workflowModuleId());
+        return false;
+      }
+      throw e;
+    }
+
+    // MongoDB does not take part in the JTA transaction, so the record is already
+    // written - remove it again if the transaction does not commit, otherwise a
+    // redelivery of the rolled-back work would be skipped
+    if (txRegistry.getTransactionKey() != null) {
+      txRegistry.registerInterposedSynchronization(new Synchronization() {
+        @Override
+        public void beforeCompletion() {
+          // nothing to do
+        }
+
+        @Override
+        public void afterCompletion(
+            final int status) {
+          if (status == Status.STATUS_COMMITTED) {
+            return;
+          }
+          try {
+            collection.deleteOne(new Document("_id", delivery.deliveryKey()));
+          } catch (final RuntimeException e) {
+            log.warn(
+                "Could not delete the record of task delivery '{}' after the rollback of the local "
+                    + "transaction - a redelivery of that task will be skipped although nothing was "
+                    + "persisted; delete the record manually",
+                delivery.deliveryKey(),
+                e);
+          }
+        }
+      });
+    }
+
+    return true;
+
+  }
+
+  private MongoCollection<Document> deliveryCollection() {
+
+    final var database = ConfigProvider
+        .getConfig()
+        .getOptionalValue("quarkus.mongodb.database", String.class)
+        .orElseThrow(() -> new IllegalStateException(
+            """
+                The MongoDB-based task delivery log needs the database name! Set the property \
+                'quarkus.mongodb.database' (the same database the workflow aggregates live in)."""));
+    return mongoClient
+        .get()
+        .getDatabase(database)
+        .getCollection(DEFAULT_COLLECTION_NAME);
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -81,6 +81,24 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   @Any
   Instance<PhaseTwoOutboxAware<?>> phaseTwoOutboxAwares;
 
+  /**
+   * The logs of processed task deliveries available at runtime, resolved per aggregate
+   * (mixed persistence) via {@link QuarkusTaskDeliveryLogResolver}. Unsatisfied if no
+   * implementation is available (e.g. no datasource configured) - a BPMS repeating a
+   * delivery then runs the handler again, which the startup validation reports.
+   */
+  @Inject
+  @Any
+  Instance<io.vanillabp.integration.spi.TaskDeliveryLog> taskDeliveryLogs;
+
+  /**
+   * Application-provided attributions of aggregates to delivery logs (required in
+   * mixed-persistence setups, optional otherwise).
+   */
+  @Inject
+  @Any
+  Instance<io.vanillabp.integration.spi.TaskDeliveryLogAware<?>> taskDeliveryLogAwares;
+
   @Inject
   TransactionSynchronizationRegistry txRegistry;
 
@@ -159,6 +177,12 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
             .enabled(), outboxProperties
                 .mongo()
                 .enabled());
+    final var taskDeliveryLogResolver = new QuarkusTaskDeliveryLogResolver(
+        taskDeliveryLogAwares, taskDeliveryLogs, outboxProperties
+            .jdbc()
+            .enabled(), outboxProperties
+                .mongo()
+                .enabled());
     final var electionCache = io.vanillabp.integration.adapter.migration.processservice.InstrumentedWorkflowAdapterCache
         .instrument(
             workflowAdapterCache.isResolvable()
@@ -168,7 +192,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
                 ? workflowAdapterCacheStatistics.get()
                 : null);
     this.migrationProcessService = new MigrationProcessService<>(
-        getWorkflowModuleId(), getBpmnProcessId(), getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache);
+        getWorkflowModuleId(), getBpmnProcessId(), getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache, taskDeliveryLogResolver);
 
     // register as phase-two dispatch target: outbox entries for this workflow
     // module/BPMN process are routed here after the local transaction was committed
@@ -178,7 +202,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
           .register(migrationProcessService);
     }
 
-    registerWorkflowTaskHandlers(processServices, phaseTwoOutboxResolver, electionCache);
+    registerWorkflowTaskHandlers(processServices, phaseTwoOutboxResolver, electionCache, taskDeliveryLogResolver);
 
   }
 
@@ -192,7 +216,8 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   private void registerWorkflowTaskHandlers(
       final List<io.vanillabp.integration.adapter.spi.MigratableProcessService<A>> processServices,
       final QuarkusPhaseTwoOutboxResolver phaseTwoOutboxResolver,
-      final io.vanillabp.integration.spi.WorkflowAdapterCache electionCache) {
+      final io.vanillabp.integration.spi.WorkflowAdapterCache electionCache,
+      final QuarkusTaskDeliveryLogResolver taskDeliveryLogResolver) {
 
     if (!workflowTaskRegistry.isResolvable()) {
       return;
@@ -222,7 +247,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
           "%s|%s".formatted(moduleId, bpmnProcessId),
           key -> {
             final var secondaryProcessService = new MigrationProcessService<>(
-                moduleId, bpmnProcessId, getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache);
+                moduleId, bpmnProcessId, getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache, taskDeliveryLogResolver);
             if (phaseTwoRouter.isResolvable()) {
               phaseTwoRouter
                   .get()
@@ -256,7 +281,9 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
    * process-service beans): if the first-priority adapter of this process requires
    * a two-phase commit, the phase-two outbox is resolved AT STARTUP - a missing
    * outbox fails the boot with a guiding message instead of surfacing at the first
-   * workflow start.
+   * workflow start. The log of processed task deliveries is resolved in the same pass: a
+   * BPMS repeating deliveries without a log to remember them is reported at startup, not
+   * at the first redelivery.
    *
    * @param event The startup event observed
    */
@@ -264,6 +291,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
       @Observes final StartupEvent event) {
 
     migrationProcessService.validatePhaseTwoOutboxAtStartup();
+    migrationProcessService.validateTaskDeliveryLogAtStartup();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
@@ -1,0 +1,124 @@
+package io.vanillabp.integration.runtime.processservice;
+
+import java.util.List;
+
+import io.vanillabp.integration.adapter.migration.processservice.AwareSelection;
+import io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver;
+import io.vanillabp.integration.runtime.delivery.JdbcTaskDeliveryLog;
+import io.vanillabp.integration.runtime.delivery.MongoTaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDeliveryLogAware;
+import jakarta.enterprise.inject.Instance;
+
+/**
+ * Quarkus implementation of the core's {@link TaskDeliveryLogResolver}: resolves the
+ * {@link TaskDeliveryLog} used for a workflow aggregate so a delivery record always rides
+ * the aggregate's own transaction. It mirrors {@link QuarkusPhaseTwoOutboxResolver} -
+ * including its one difference to Spring Boot: Quarkus has no platform-side knowledge of
+ * which persistence manages an aggregate (aggregate persistence is always provided by the
+ * application, see {@link io.vanillabp.integration.spi.AggregatePersistenceAware}), so a
+ * mixed-persistence application attributes aggregates to logs via
+ * {@link TaskDeliveryLogAware} beans.
+ */
+public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
+
+  private final Instance<TaskDeliveryLogAware<?>> taskDeliveryLogAwares;
+
+  private final Instance<TaskDeliveryLog> taskDeliveryLogs;
+
+  private final boolean jdbcLogEnabled;
+
+  private final boolean mongoLogEnabled;
+
+  public QuarkusTaskDeliveryLogResolver(
+      final Instance<TaskDeliveryLogAware<?>> taskDeliveryLogAwares,
+      final Instance<TaskDeliveryLog> taskDeliveryLogs,
+      final boolean jdbcLogEnabled,
+      final boolean mongoLogEnabled) {
+
+    this.taskDeliveryLogAwares = taskDeliveryLogAwares;
+    this.taskDeliveryLogs = taskDeliveryLogs;
+    this.jdbcLogEnabled = jdbcLogEnabled;
+    this.mongoLogEnabled = mongoLogEnabled;
+
+  }
+
+  @Override
+  public TaskDeliveryLog resolveFor(
+      final Class<?> workflowAggregateClass) {
+
+    // 1. the most specific TaskDeliveryLogAware bean covering the aggregate class
+    final List<TaskDeliveryLogAware<?>> awares = taskDeliveryLogAwares
+        .stream()
+        .<TaskDeliveryLogAware<?>>map(aware -> aware)
+        .toList();
+    final var mostSpecificAware = AwareSelection.mostSpecific(
+        awares,
+        TaskDeliveryLogAware::getAggregateClass,
+        workflowAggregateClass);
+    if (mostSpecificAware.isPresent()) {
+      return mostSpecificAware
+          .get()
+          .getTaskDeliveryLog();
+    }
+
+    // 2./3. the single active log bean - or a guiding error if ambiguous
+    final var logs = taskDeliveryLogs
+        .stream()
+        .filter(this::isActive)
+        .toList();
+    if (logs.isEmpty()) {
+      return null;
+    }
+    if (logs.size() > 1) {
+      throw new IllegalStateException(
+          """
+              Several TaskDeliveryLog beans exist (%s), but none can be attributed to workflow \
+              aggregate '%s'! A delivery record must be enlisted in the transaction persisting the \
+              aggregate. To solve this either
+              - provide a bean implementing io.vanillabp.integration.spi.TaskDeliveryLogAware for \
+              this aggregate (returning the log matching its persistence), or
+              - deactivate the unwanted default ('vanillabp.outbox.jdbc.enabled' / \
+              'vanillabp.outbox.mongo.enabled')."""
+              .formatted(
+                  logs
+                      .stream()
+                      .map(deliveryLog -> deliveryLog.getClass().getName())
+                      .toList(),
+                  workflowAggregateClass.getName()));
+    }
+    return logs.getFirst();
+
+  }
+
+  @Override
+  public String remediesDescription() {
+
+    return """
+        - add the 'quarkus-agroal' extension and configure a JDBC datasource (enables the JDBC default),
+        - add the 'quarkus-mongodb-client' extension and configure the MongoDB connection incl. 'quarkus.mongodb.database' (enables the MongoDB default),""";
+
+  }
+
+  /**
+   * Whether the given log is active: the platform defaults may be deactivated by
+   * configuration or be unusable (no datasource, no MongoDB client) - such a default
+   * must not be selected.
+   *
+   * @param deliveryLog The log bean
+   * @return Whether the log may be selected
+   */
+  private boolean isActive(
+      final TaskDeliveryLog deliveryLog) {
+
+    if (deliveryLog instanceof JdbcTaskDeliveryLog jdbcLog) {
+      return jdbcLogEnabled && jdbcLog.isAvailable();
+    }
+    if (deliveryLog instanceof MongoTaskDeliveryLog mongoLog) {
+      return mongoLogEnabled && mongoLog.isAvailable();
+    }
+    return true;
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -37,13 +37,15 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                       Optional<DeploymentFailurePolicy> deploymentFailure,
                                       Optional<String> resourcesLocation,
                                       Optional<io.vanillabp.integration.adapter.spi.NameClashAvoidance> nameClashAvoidance,
-                                      Optional<Boolean> prefixTaskDefinitionsPerProcess) implements QuarkusMigrationAdapterProperties.AdapterConfiguration {
+                                      Optional<Boolean> prefixTaskDefinitionsPerProcess,
+                                      Optional<Boolean> deduplicateDeliveries) implements QuarkusMigrationAdapterProperties.AdapterConfiguration {
   }
 
   private record AdapterProperties(
                                    Optional<String> resourcesLocation,
                                    Optional<io.vanillabp.integration.adapter.spi.NameClashAvoidance> nameClashAvoidance,
-                                   Optional<Boolean> prefixTaskDefinitionsPerProcess) implements QuarkusMigrationAdapterProperties.AdapterProperties {
+                                   Optional<Boolean> prefixTaskDefinitionsPerProcess,
+                                   Optional<Boolean> deduplicateDeliveries) implements QuarkusMigrationAdapterProperties.AdapterProperties {
   }
 
   private record TaskProperties(
@@ -105,33 +107,39 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
             "c8-cloud", new AdapterConfiguration(
                 Optional.of("camunda8"), Optional.of(DeploymentFailurePolicy.WARN), Optional
                     .of("adapter-level"), Optional
-                        .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.USE_PREFIX), Optional.of(false)),
+                        .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.USE_PREFIX), Optional
+                            .of(false), Optional.of(false)),
             "c7", new AdapterConfiguration(
-                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty())), Map.of(
-                    "loan-approval", new WorkflowModuleProperties(
-                        Optional.of(List.of("c7")), Map.of("c7",
-                            new AdapterProperties(Optional.of("classpath:c7-bpmn"), Optional
-                                .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.NONE), Optional
-                                    .empty())), Map
-                                        .of("LoanApproval",
-                                            new WorkflowProperties(
-                                                Optional.of(List.of("c8-cloud")), Map
-                                                    .of("c8-cloud", new AdapterProperties(Optional
-                                                        .of("workflow-level"), Optional
-                                                            .empty(), Optional.of(true))), Map
-                                                                .of("assessRisk", new TaskProperties(Map
-                                                                    .of("c8-cloud", new AdapterProperties(Optional
-                                                                        .of("task-level"), Optional.empty(), Optional
-                                                                            .empty())))))))), new OutboxProperties(
-                                                                                Duration.ofSeconds(1), Duration
-                                                                                    .ofSeconds(2), 3, false, Duration
-                                                                                        .ofDays(
-                                                                                            1), new JdbcOutboxProperties(false, Optional
-                                                                                                .of("HOT_OUTBOX")), new MongoOutboxProperties(
-                                                                                                    false, "hot-outbox")), new WorkflowAdapterCacheProperties(
-                                                                                                        50_000, Duration
-                                                                                                            .ofMinutes(
-                                                                                                                30)));
+                Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional
+                    .empty())), Map.of(
+                        "loan-approval", new WorkflowModuleProperties(
+                            Optional.of(List.of("c7")), Map.of("c7",
+                                new AdapterProperties(Optional.of("classpath:c7-bpmn"), Optional
+                                    .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.NONE), Optional
+                                        .empty(), Optional.empty())), Map
+                                            .of("LoanApproval",
+                                                new WorkflowProperties(
+                                                    Optional.of(List.of("c8-cloud")), Map
+                                                        .of("c8-cloud", new AdapterProperties(Optional
+                                                            .of("workflow-level"), Optional
+                                                                .empty(), Optional.of(true), Optional.of(true))), Map
+                                                                    .of("assessRisk", new TaskProperties(Map
+                                                                        .of("c8-cloud", new AdapterProperties(Optional
+                                                                            .of("task-level"), Optional
+                                                                                .empty(), Optional
+                                                                                    .empty(), Optional
+                                                                                        .of(false))))))))), new OutboxProperties(
+                                                                                            Duration
+                                                                                                .ofSeconds(1), Duration
+                                                                                                    .ofSeconds(
+                                                                                                        2), 3, false, Duration
+                                                                                                            .ofDays(
+                                                                                                                1), new JdbcOutboxProperties(false, Optional
+                                                                                                                    .of("HOT_OUTBOX")), new MongoOutboxProperties(
+                                                                                                                        false, "hot-outbox")), new WorkflowAdapterCacheProperties(
+                                                                                                                            50_000, Duration
+                                                                                                                                .ofMinutes(
+                                                                                                                                    30)));
 
     final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
 
@@ -155,6 +163,16 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
         "task-level",
         workflow.getTasks().get("assessRisk").getAdapters().get("c8-cloud").getResourcesLocation());
     assertEquals("adapter-level", core.getAdapters().get("c8-cloud").getResourcesLocation());
+    // the switch of story 51 travels the same four levels as every adapter-scoped key
+    assertEquals(
+        Boolean.FALSE,
+        core.getAdapters().get("c8-cloud").getDeduplicateDeliveries());
+    assertEquals(
+        Boolean.TRUE,
+        workflow.getAdapters().get("c8-cloud").getDeduplicateDeliveries());
+    assertEquals(
+        Boolean.FALSE,
+        workflow.getTasks().get("assessRisk").getAdapters().get("c8-cloud").getDeduplicateDeliveries());
 
     assertEquals(Duration.ofSeconds(1), core.getOutbox().getPollInterval());
     assertEquals(Duration.ofSeconds(2), core.getOutbox().getAttemptFrequency());

--- a/spring-boot-integration/README.md
+++ b/spring-boot-integration/README.md
@@ -48,6 +48,32 @@ coexist, and keys unknown to the core view are ignored by the JavaBean binding.
 The adapter-id set is always derived from the core properties
 (`adapterTypes()`), never from an overlay map.
 
+## The store of processed task deliveries
+
+`io.vanillabp.integration.delivery` implements the core's `TaskDeliveryLog` (story 51,
+the inbound counterpart of the outbox) twice, and `SpringTaskDeliveryLogResolver` picks
+one per workflow aggregate - the same resolution the phase-two outbox uses, since a
+record has to ride the aggregate's own transaction. The persistence technology behind an
+aggregate is detected once in `SpringPersistenceTechnology`, shared by both resolvers.
+
+- `JdbcTaskDeliveryLog` writes through `DataSourceUtils.getConnection(dataSource)`, so
+  the connection belongs to the Spring-managed transaction. The SQL and the portable DDL
+  of table `VANILLABP_TASK_DELIVERY` live in the core (`JdbcTaskDeliveryStore`), shared
+  with Quarkus. Deliberately NOT gruelbox: gruelbox stores calls to be dispatched, a
+  delivery record is a fact to be read back.
+- `MongoTaskDeliveryLog` writes `TaskDeliveryDocument`s into `vanillabp-task-deliveries`
+  through the `MongoTemplate`, keyed by the delivery key (the document ID gives
+  uniqueness). A duplicate is detected by a pre-check read: inside a MongoDB transaction
+  a duplicate-key error would abort the whole transaction, the aggregate changes
+  included.
+- Both come with an auto-configuration of their own
+  (`vanillabp.outbox.jdbc.enabled` / `.mongo.enabled`), create their schema unless
+  `vanillabp.outbox.create-schema` is disabled and delete expired records per
+  `vanillabp.outbox.retention` (`cleanUpExpiredRecords`, scheduled by the core's
+  `TaskDeliveryRetentionCleanup`). Table and index are created from a
+  `SmartInitializingSingleton`, not while the bean is built - the DDL must not
+  materialize the data source before the application's configuration is complete.
+
 ## Noteworthy & Contributors
 
 [VanillaBP](https://www.github.com/vanillabp/spi-for-java) was developed by [Phactum](https://www.phactum.at) with the

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/processservice/MigratableProcessService.java
@@ -122,6 +122,18 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
 
   }
 
+  /**
+   * A dummy configured as a remote BPMS (two-phase commit) also stands in for its
+   * at-least-once task delivery: the outcome is reported after the local commit, so the
+   * same task may arrive again (story 51).
+   */
+  @Override
+  public boolean deliversTasksAtLeastOnce() {
+
+    return needsTwoPhaseCommitForStartingWorkflows;
+
+  }
+
   @Override
   public void startWorkflowPhaseOne(
       final String workflowModuleId,

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/OutboxStartupValidationTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/OutboxStartupValidationTest.java
@@ -13,7 +13,6 @@ import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoCon
 import io.vanillabp.integration.spi.PhaseTwoOutbox;
 import io.vanillabp.integration.test.TestPersistenceConfiguration;
 import io.vanillabp.integration.test.WorkflowModuleConfiguration;
-import io.vanillabp.integration.test.sample.Aggregate;
 import io.vanillabp.integration.test.utils.SuppressOutputExtension;
 import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
 
@@ -58,8 +57,14 @@ public class OutboxStartupValidationTest {
               message.contains("requires a two-phase commit"),
               "expected the guiding message but got: "
                   + message);
-          // the message names the aggregate and ALL remedies
-          Assertions.assertTrue(message.contains(Aggregate.class.getName()));
+          // the message names an aggregate of this test application and ALL remedies.
+          // WHICH aggregate it is depends on the order the classpath scan finds the
+          // workflow services in: the application has several, and the first process
+          // service failing the validation throws
+          Assertions.assertTrue(
+              message.contains("is available for aggregate 'io.vanillabp.integration.test."),
+              "the message has to name an aggregate of the test application: "
+                  + message);
           Assertions.assertTrue(message.contains("spring-boot-starter-data-jpa"));
           Assertions.assertTrue(message.contains("spring-boot-starter-data-mongodb"));
           Assertions.assertTrue(message.contains("PhaseTwoOutbox"));

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/TaskDeliveryLogStartupValidationTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/TaskDeliveryLogStartupValidationTest.java
@@ -1,0 +1,150 @@
+package io.vanillabp.integration.test.adapter;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.sample.Aggregate;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+
+/**
+ * Startup report of the inbound idempotency (story 51): an adapter which may hand the
+ * same task out again needs a store to remember processed deliveries in. Unlike the
+ * outbox a missing store does NOT fail the boot - without it VanillaBP behaves as it did
+ * before the feature existed - so what is pinned here is the WARNING naming both ways
+ * out, and that switching the feature off silences it.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class TaskDeliveryLogStartupValidationTest {
+
+  /**
+   * An outbox of the application's own, so the boot gets past the outbox validation: the
+   * dummy adapter needs a two-phase commit here, and this context has no data source a
+   * platform default could use. Nothing is dispatched in these tests.
+   */
+  @org.springframework.context.annotation.Configuration
+  static class OwnOutboxConfiguration {
+
+    @org.springframework.context.annotation.Bean
+    io.vanillabp.integration.spi.PhaseTwoOutbox ownOutbox() {
+
+      return call -> true;
+
+    }
+
+  }
+
+  private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
+
+  /**
+   * The messages the core logged while the given work ran.
+   */
+  private List<String> loggedByCore(
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+        .getLogger(MigrationProcessService.class);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAppender(logWatcher);
+      logWatcher.stop();
+    }
+    return logWatcher.list
+        .stream()
+        .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+        .map(event -> event.getFormattedMessage())
+        .toList();
+
+  }
+
+  private void bootWith(
+      final Runnable assertions,
+      final String... properties) {
+
+    final var propertyValues = new java.util.LinkedList<String>(
+        List.of("spring.config.location=classpath:application.yaml"));
+    propertyValues.addAll(List.of(properties));
+    this.contextRunner
+        .withPropertyValues(propertyValues.toArray(String[]::new))
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withUserConfiguration(
+            WorkflowModuleConfiguration.class,
+            TestPersistenceConfiguration.class,
+            OwnOutboxConfiguration.class)
+        .withConfiguration(
+            AutoConfigurations.of(
+                DummyAdapterConfiguration.class, DummyAdapterProcessServiceConfiguration.class,
+                WorkflowModuleAutoConfiguration.class,
+                SpringBootMigrationAdapterAutoConfiguration.class))
+        .run(context -> {
+          Assertions.assertNull(
+              context.getStartupFailure(),
+              "a missing delivery log must never fail the boot");
+          assertions.run();
+        });
+
+  }
+
+  @Test
+  public void anAdapterRepeatingDeliveriesWithoutAStoreIsReported() {
+
+    // the dummy adapter stands in for a remote BPMS: it needs a two-phase commit for
+    // starting workflows AND may deliver a task more than once. There is no data source
+    // in this context, so no delivery log can be resolved
+    final var messages = loggedByCore(
+        () -> bootWith(
+            () -> {
+            },
+            "dummy-adapter.two-phase-commit=true"));
+
+    // one warning per BPMN process, each naming its own aggregate - the test application
+    // has several, so the one of this assertion is picked by the aggregate it names
+    final var message = messages
+        .stream()
+        .filter(candidate -> candidate.contains("more than once"))
+        .filter(candidate -> candidate.contains(Aggregate.class.getName()))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no warning about repeated deliveries, logged: "
+            + messages));
+    // it names the BPMS, the SPI to implement and the property to set instead
+    Assertions.assertTrue(message.contains("Adapter 'test'"));
+    Assertions.assertTrue(message.contains("TaskDeliveryLog"));
+    Assertions.assertTrue(message.contains("TaskDeliveryLogAware"));
+    Assertions.assertTrue(message.contains("vanillabp.adapters.test.deduplicate-deliveries"));
+
+  }
+
+  @Test
+  public void switchingTheFeatureOffSilencesTheReport() {
+
+    final var messages = loggedByCore(
+        () -> bootWith(
+            () -> {
+            },
+            "dummy-adapter.two-phase-commit=true",
+            "vanillabp.adapters.test.deduplicate-deliveries=false"));
+
+    Assertions.assertTrue(
+        messages.stream().noneMatch(message -> message.contains("more than once")),
+        "an application stating that its handlers are idempotent is not warned, logged: "
+            + messages);
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryAggregate.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryAggregate.java
@@ -1,0 +1,55 @@
+package io.vanillabp.integration.test.delivery;
+
+/**
+ * The workflow aggregate of the inbound-idempotency test (story 51). It lives in its own
+ * package together with its workflow service, so the scanning of the test application
+ * picks up exactly these two.
+ */
+public class DeliveryAggregate {
+
+  private String id;
+
+  private String status;
+
+  private int invocations;
+
+  public String getId() {
+
+    return id;
+
+  }
+
+  public void setId(
+      final String id) {
+
+    this.id = id;
+
+  }
+
+  public String getStatus() {
+
+    return status;
+
+  }
+
+  public void setStatus(
+      final String status) {
+
+    this.status = status;
+
+  }
+
+  public int getInvocations() {
+
+    return invocations;
+
+  }
+
+  public void setInvocations(
+      final int invocations) {
+
+    this.invocations = invocations;
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
@@ -1,0 +1,56 @@
+package io.vanillabp.integration.test.delivery;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.TaskException;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * The workflow service of the inbound-idempotency test: one method per outcome a repeated
+ * delivery has to be answered with, each counting its own invocations - the business code
+ * a redelivery must NOT run again.
+ */
+@WorkflowService(
+    workflowAggregateClass = DeliveryAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "DeliveryProcess"))
+public class DeliveryWorkflowService {
+
+  @WorkflowTask
+  public void processTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("processed");
+
+  }
+
+  @WorkflowTask
+  public void raiseBpmnError(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("bpmn-error-raised");
+    throw new TaskException("PaymentFailed", "PAYMENT_FAILED");
+
+  }
+
+  @WorkflowTask
+  public void failTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("must-never-be-visible");
+    throw new IllegalStateException("something broke");
+
+  }
+
+  @WorkflowTask
+  public void undeduplicatedTask(
+      final DeliveryAggregate aggregate) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("processed-again");
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
@@ -1,0 +1,331 @@
+package io.vanillabp.integration.test.delivery;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.delivery.JdbcTaskDeliveryLogAutoConfiguration;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+
+/**
+ * Acceptance test of the inbound idempotency (story 51) on Spring Boot, with the default
+ * JDBC-based delivery log doing the remembering: the dummy adapter delivers a task TWICE
+ * under the same delivery identity - as a BPMS which never learned the result does - and
+ * the <code>&#64;WorkflowTask</code> method has to run once while both deliveries are
+ * answered with the same outcome. Also pinned: a delivery whose handler threw leaves no
+ * record (its retry runs the handler again) and the task-level switch turns the feature
+ * off.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class InboundIdempotencyTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "DeliveryProcess";
+
+  private static final String ADAPTER = "test";
+
+  /**
+   * In-memory persistence of the test aggregate plus the transaction infrastructure the
+   * delivery log rides on (H2 - the records are really written and read back through
+   * JDBC).
+   */
+  @Configuration
+  static class DeliveryConfiguration {
+
+    static final Map<String, DeliveryAggregate> AGGREGATES = new ConcurrentHashMap<>();
+
+    @Bean
+    AggregatePersistenceAware<DeliveryAggregate> deliveryPersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<DeliveryAggregate> getAggregateClass() {
+          return DeliveryAggregate.class;
+        }
+
+        @Override
+        public DeliveryAggregate save(
+            final DeliveryAggregate aggregate) {
+          AGGREGATES.put(aggregate.getId(), copyOf(aggregate));
+          return aggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final DeliveryAggregate aggregate) {
+          return aggregate.getId();
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public DeliveryAggregate loadById(
+            final Object aggregateId) {
+          final var stored = AGGREGATES.get(aggregateId);
+          return stored != null
+              ? copyOf(stored)
+              : null;
+        }
+
+      };
+
+    }
+
+    private static DeliveryAggregate copyOf(
+        final DeliveryAggregate aggregate) {
+
+      final var copy = new DeliveryAggregate();
+      copy.setId(aggregate.getId());
+      copy.setStatus(aggregate.getStatus());
+      copy.setInvocations(aggregate.getInvocations());
+      return copy;
+
+    }
+
+    @Bean
+    DataSource deliveryDataSource() {
+
+      return new EmbeddedDatabaseBuilder()
+          .setType(EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager(
+        final DataSource deliveryDataSource) {
+
+      return new DataSourceTransactionManager(deliveryDataSource);
+
+    }
+
+    /**
+     * Stands in for the BPMN model: the tasks of 'DeliveryProcess' matching the
+     * handlers, so the wiring validation passes.
+     */
+    @Bean
+    DummyTaskWiringSource deliveryTaskWiringSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> PROCESS.equals(bpmnProcessId)
+              ? List.of(
+                  new BpmnTaskSpec("Activity_Process", "processTask"),
+                  new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
+                  new BpmnTaskSpec("Activity_Fail", "failTask"),
+                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+              : List.of();
+
+    }
+
+  }
+
+  /**
+   * The delivery-log store settings are the outbox' ones; the task
+   * 'undeduplicatedTask' switches the feature off for itself, which is the
+   * per-task resolution of the story's key.
+   */
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        adapters:
+          test:
+            type: dummy
+            test: 1
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/delivery
+            workflows:
+              DeliveryProcess:
+                tasks:
+                  undeduplicatedTask:
+                    adapters:
+                      test:
+                        deduplicate-deliveries: false
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            DeliveryWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            DeliveryConfiguration.class,
+            // after the data source it is conditional on: the auto-configuration is
+            // listed as a plain source here, so its conditions see the bean definitions
+            // registered before it
+            JdbcTaskDeliveryLogAutoConfiguration.class,
+            DeploymentTest.TestConfig.class)
+        .run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp() throws IOException {
+
+    return SpringBootTestApplication.builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  /**
+   * One delivery of a task, as an adapter of a remote BPMS builds it: the delivery ID is
+   * what stays the same when the BPMS repeats it.
+   */
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  private void storeAggregate(
+      final String id) {
+
+    final var aggregate = new DeliveryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("new");
+    DeliveryConfiguration.AGGREGATES.put(id, aggregate);
+
+  }
+
+  private int recordCount(
+      final ConfigurableApplicationContext context,
+      final String aggregateId) {
+
+    return new JdbcTemplate(context.getBean(DataSource.class))
+        .queryForObject(
+            "SELECT COUNT(*) FROM %s WHERE AGGREGATE_ID = ?".formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME),
+            Integer.class,
+            aggregateId);
+
+  }
+
+  @Test
+  public void repeatedDeliveriesRunTheHandlerOnce() throws IOException {
+
+    DeliveryConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+      // (a) the same delivery twice: handler once, both answered COMPLETED
+      storeAggregate("4711");
+      final var first = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+      final var second = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+      Assertions.assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, first.kind());
+      Assertions.assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, second.kind());
+      Assertions.assertEquals(1, DeliveryConfiguration.AGGREGATES.get("4711").getInvocations());
+      Assertions.assertEquals(1, recordCount(context, "4711"));
+
+      // the next task instance of the same workflow is another delivery
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-2"));
+      Assertions.assertEquals(2, DeliveryConfiguration.AGGREGATES.get("4711").getInvocations());
+      Assertions.assertEquals(2, recordCount(context, "4711"));
+
+      // (b) a BPMN error is reported again with code and name, from the record
+      storeAggregate("4712");
+      final var error = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
+      final var errorAgain = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
+      Assertions.assertEquals(WorkflowTaskOutcome.Kind.BPMN_ERROR, errorAgain.kind());
+      Assertions.assertEquals(error.errorCode(), errorAgain.errorCode());
+      Assertions.assertEquals("PAYMENT_FAILED", errorAgain.errorCode());
+      Assertions.assertEquals("PaymentFailed", errorAgain.errorName());
+      Assertions.assertEquals(1, DeliveryConfiguration.AGGREGATES.get("4712").getInvocations());
+
+      // (c) a handler which threw leaves no record: the transaction rolled back, so the
+      // BPMS' retry reaches the handler again
+      storeAggregate("4713");
+      Assertions.assertThrows(
+          IllegalStateException.class,
+          () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
+      Assertions.assertEquals(0, recordCount(context, "4713"));
+      Assertions.assertThrows(
+          IllegalStateException.class,
+          () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
+      Assertions.assertEquals(0, recordCount(context, "4713"));
+
+      // (d) switched off for this task: nothing is remembered, the handler runs per
+      // delivery - the behaviour of every VanillaBP before this feature
+      storeAggregate("4714");
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
+      Assertions.assertEquals(2, DeliveryConfiguration.AGGREGATES.get("4714").getInvocations());
+      Assertions.assertEquals(0, recordCount(context, "4714"));
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/delivery/DeliveryProcess.bpmn
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/resources/test-module/processes/delivery/DeliveryProcess.bpmn
@@ -1,0 +1,1 @@
+not parsed by the dummy adapter

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
@@ -1,0 +1,163 @@
+package io.vanillabp.integration.test.outbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.mongodb.autoconfigure.MongoClientSettingsBuilderCustomizer;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mongodb.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.mongodb.ConnectionString;
+
+import io.vanillabp.integration.delivery.MongoTaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The MongoDB store behind the inbound idempotency (story 51): a delivery record has to
+ * ride the transaction which persists the workflow aggregate, be unique by its delivery
+ * key and disappear once its retention period passed. The TestContainers MongoDB runs as
+ * a replica set, so record and aggregate really share one MongoDB transaction.
+ * <p>
+ * That the CORE skips a handler for a recorded delivery is pinned by the platform's
+ * acceptance test; what is tested here is the store.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+@SuppressOutputExtension.SuppressBackgroundOutput
+@SpringBootTest(
+    classes = {
+        TestApplication.class, MongoTaskDeliveryLogTest.MongoDeliveryLogTestConfiguration.class
+    },
+    // a retention of zero makes every record expired right away, so the cleanup can be
+    // observed without waiting days for it
+    properties = "vanillabp.outbox.retention=PT0S")
+@Testcontainers
+public class MongoTaskDeliveryLogTest {
+
+  private static final String COLLECTION = "vanillabp-task-deliveries";
+
+  @Container
+  static MongoDBContainer mongoDb = new MongoDBContainer(DockerImageName.parse("mongo:5.0"))
+      // MongoDB transactions require a replica set
+      .withReplicaSet()
+      .waitingFor(Wait.forLogMessage(".*Waiting for connections.*", 1))
+      .withExposedPorts(27017);
+
+  @TestConfiguration
+  static class MongoDeliveryLogTestConfiguration {
+
+    @Bean
+    MongoClientSettingsBuilderCustomizer mongoUriCustomizer() {
+      return builder -> builder.applyConnectionString(
+          new ConnectionString(mongoDb.getReplicaSetUrl()));
+    }
+
+  }
+
+  @Autowired
+  private MongoTaskDeliveryLog deliveryLog;
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  private MongoTemplate mongoTemplate;
+
+  @BeforeEach
+  public void clearRecords() {
+
+    mongoTemplate.getCollection(COLLECTION).deleteMany(new org.bson.Document());
+
+  }
+
+  private TaskDelivery delivery(
+      final String deliveryKey,
+      final String outcome) {
+
+    return new TaskDelivery(
+        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed");
+
+  }
+
+  @Test
+  @DisplayName("A record is written with the transaction and read back with its outcome")
+  public void aRecordIsWrittenAndReadBack() {
+
+    transactionTemplate.executeWithoutResult(
+        status -> assertTrue(deliveryLog.record(delivery("job-1", "BPMN_ERROR"))));
+
+    final var recorded = deliveryLog.recordedDelivery("job-1");
+    assertTrue(recorded.isPresent());
+    assertEquals("test-module", recorded.get().workflowModuleId());
+    assertEquals("TestProcess", recorded.get().bpmnProcessId());
+    assertEquals("4711", recorded.get().workflowAggregateId());
+    assertEquals("processTask", recorded.get().taskDefinition());
+    assertEquals("BPMN_ERROR", recorded.get().outcome());
+    assertEquals("PAYMENT_FAILED", recorded.get().bpmnErrorCode());
+    assertEquals("PaymentFailed", recorded.get().bpmnErrorName());
+
+  }
+
+  @Test
+  @DisplayName("A rolled-back transaction leaves no record")
+  public void aRolledBackTransactionLeavesNoRecord() {
+
+    assertThrowsExactly(
+        IllegalStateException.class,
+        () -> transactionTemplate.executeWithoutResult(status -> {
+          deliveryLog.record(delivery("job-2", "COMPLETED"));
+          throw new IllegalStateException("the handler failed after the record was written");
+        }));
+
+    assertTrue(
+        deliveryLog.recordedDelivery("job-2").isEmpty(),
+        "work and record commit together - or neither of them does");
+
+  }
+
+  @Test
+  @DisplayName("Recording the same delivery twice is a no-op")
+  public void aDuplicateRecordIsANoOp() {
+
+    transactionTemplate.executeWithoutResult(
+        status -> assertTrue(deliveryLog.record(delivery("job-3", "COMPLETED"))));
+    transactionTemplate.executeWithoutResult(
+        status -> assertFalse(
+            deliveryLog.record(delivery("job-3", "COMPLETED")),
+            "the delivery key is unique in the store"));
+
+    assertEquals(1, mongoTemplate.getCollection(COLLECTION).countDocuments());
+
+  }
+
+  @Test
+  @DisplayName("Records are deleted once the retention period passed")
+  public void expiredRecordsAreDeleted() {
+
+    transactionTemplate.executeWithoutResult(
+        status -> deliveryLog.record(delivery("job-4", "COMPLETED")));
+
+    // this context runs with a retention of zero, so the record is expired right away
+    final var deleted = deliveryLog.cleanUpExpiredRecords();
+
+    assertEquals(1, deleted);
+    assertTrue(deliveryLog.recordedDelivery("job-4").isEmpty());
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
@@ -1,0 +1,130 @@
+package io.vanillabp.integration.delivery;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Optional;
+
+import javax.sql.DataSource;
+
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import io.vanillabp.integration.adapter.migration.delivery.JdbcConnectionAccess;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+
+/**
+ * The default {@link TaskDeliveryLog} for Spring Boot applications persisting their
+ * workflow aggregates via JPA/JDBC: the records are written through a connection
+ * {@link DataSourceUtils} binds to the Spring-managed transaction, so a record and the
+ * aggregate changes of the same delivery commit together - the recording contract of
+ * {@link TaskDeliveryLog}.
+ * <p>
+ * Unlike the phase-two outbox this does NOT use gruelbox: gruelbox stores calls to be
+ * dispatched, while a delivery record is a fact to be read back. The table
+ * ({@link JdbcTaskDeliveryStore#DEFAULT_TABLE_NAME}) is VanillaBP's own and is created
+ * at startup unless <code>vanillabp.outbox.create-schema</code> is disabled.
+ */
+public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAccess {
+
+  private final DataSource dataSource;
+
+  private final JdbcTaskDeliveryStore store;
+
+  private final java.time.Duration retention;
+
+  private final TaskDeliveryRetentionCleanup retentionCleanup;
+
+  public JdbcTaskDeliveryLog(
+      final DataSource dataSource,
+      final String tableName,
+      final Duration retention) {
+
+    this.dataSource = dataSource;
+    this.store = new JdbcTaskDeliveryStore(this, tableName);
+    this.retention = retention;
+    this.retentionCleanup = new TaskDeliveryRetentionCleanup(
+        tableName, retention, this::cleanUpExpiredRecords);
+
+  }
+
+  /**
+   * Creates the table and starts the retention cleanup.
+   *
+   * @param createSchema Whether VanillaBP creates the table itself
+   */
+  public void start(
+      final boolean createSchema) {
+
+    if (createSchema) {
+      store.createSchemaIfNotExists();
+    }
+    retentionCleanup.start();
+
+  }
+
+  /**
+   * Deletes the records whose retention period passed - run by the background cleanup and
+   * usable on demand (e.g. by tests).
+   *
+   * @return The number of records deleted
+   */
+  public int cleanUpExpiredRecords() {
+
+    return store.deleteExpired(retention);
+
+  }
+
+  /**
+   * Stops the retention cleanup - called on shutdown of the application context.
+   */
+  public void stop() {
+
+    retentionCleanup.stop();
+
+  }
+
+  @Override
+  public Optional<TaskDelivery> recordedDelivery(
+      final String deliveryKey) {
+
+    return store.recordedDelivery(deliveryKey);
+
+  }
+
+  @Override
+  public boolean record(
+      final TaskDelivery delivery) {
+
+    if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+      throw new IllegalStateException(
+          """
+              No transaction active! A task delivery has to be recorded within the still-running \
+              transaction persisting the workflow aggregate - a record committed on its own would \
+              skip the @WorkflowTask method of a redelivery although nothing was persisted.""");
+    }
+    return store.record(delivery);
+
+  }
+
+  @Override
+  public Connection acquire() throws SQLException {
+
+    // bound to the Spring-managed transaction if one is running (which the recording
+    // contract requires) - a plain connection of the pool otherwise, used by reads
+    return DataSourceUtils.getConnection(dataSource);
+
+  }
+
+  @Override
+  public void release(
+      final Connection connection) {
+
+    DataSourceUtils.releaseConnection(connection, dataSource);
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLogAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLogAutoConfiguration.java
@@ -1,0 +1,89 @@
+package io.vanillabp.integration.delivery;
+
+import javax.sql.DataSource;
+
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.config.VanillaBpConfigurationProperties;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+
+/**
+ * Auto-configuration of the default {@link TaskDeliveryLog} for JPA/JDBC-based aggregate
+ * persistence. Active whenever a {@link DataSource} and a transaction manager exist - it
+ * COEXISTS with the MongoDB default ({@link MongoTaskDeliveryLogAutoConfiguration}):
+ * each workflow aggregate is served by the log matching its persistence (selection per
+ * aggregate, see {@link io.vanillabp.integration.spi.TaskDeliveryLogAware}), so a
+ * delivery record always rides the aggregate's own transaction even in mixed-persistence
+ * applications.
+ * <p>
+ * The store settings are the outbox' ones, since both keep a deduplication window open:
+ * <code>vanillabp.outbox.create-schema</code> decides whether VanillaBP creates the
+ * table {@value io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore#DEFAULT_TABLE_NAME},
+ * <code>vanillabp.outbox.retention</code> how long a record is kept, and
+ * <code>vanillabp.outbox.jdbc.enabled</code> switches the default off for an application
+ * bringing its own {@link TaskDeliveryLog} bean.
+ */
+@AutoConfiguration(
+    afterName = {
+        "org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration", "org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration", "org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration"
+    })
+@ConditionalOnBean({
+    DataSource.class, PlatformTransactionManager.class
+})
+@ConditionalOnBooleanProperty(name = "vanillabp.outbox.jdbc.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(VanillaBpConfigurationProperties.class)
+public class JdbcTaskDeliveryLogAutoConfiguration {
+
+  /**
+   * The name of the default JDBC delivery-log bean - used by the resolver to attribute
+   * JPA-persisted aggregates to THE default when several log beans exist.
+   */
+  public static final String DEFAULT_DELIVERY_LOG_BEAN_NAME = "vanillaBpJdbcTaskDeliveryLog";
+
+  /**
+   * @param dataSource The data source holding the records
+   * @param vanillaBpProperties The bound <code>vanillabp.*</code> tree carrying the
+   *          <code>vanillabp.outbox</code> section
+   * @return The {@link TaskDeliveryLog} used for JPA/JDBC-persisted aggregates
+   */
+  @Bean(name = DEFAULT_DELIVERY_LOG_BEAN_NAME, destroyMethod = "stop")
+  public JdbcTaskDeliveryLog vanillaBpJdbcTaskDeliveryLog(
+      final DataSource dataSource,
+      final VanillaBpConfigurationProperties vanillaBpProperties) {
+
+    return new JdbcTaskDeliveryLog(
+        dataSource, JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME, vanillaBpProperties
+            .getOutbox()
+            .getRetention());
+
+  }
+
+  /**
+   * Creates the table and starts the retention cleanup once all singletons exist - the
+   * DDL must not run mid-bean-construction (it would materialize the data source before
+   * the application's own configuration is complete).
+   *
+   * @param deliveryLog The delivery log to start
+   * @param vanillaBpProperties The bound <code>vanillabp.*</code> tree
+   * @return The startup hook
+   */
+  @Bean
+  public SmartInitializingSingleton vanillaBpJdbcTaskDeliveryLogStartup(
+      final JdbcTaskDeliveryLog deliveryLog,
+      final VanillaBpConfigurationProperties vanillaBpProperties) {
+
+    return () -> deliveryLog.start(
+        vanillaBpProperties
+            .getOutbox()
+            .isCreateSchema());
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
@@ -1,0 +1,153 @@
+package io.vanillabp.integration.delivery;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+
+import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The default {@link TaskDeliveryLog} for Spring Boot applications persisting their
+ * workflow aggregates in MongoDB. The records are written through the
+ * {@link MongoTemplate} which takes part in the Spring-managed MongoDB transaction, so
+ * a record and the aggregate changes of the same delivery commit together.
+ * <p>
+ * <strong>Note:</strong> MongoDB transactions require a replica set. Without one (no
+ * <code>MongoTransactionManager</code> or a standalone server) the record is written
+ * immediately, exactly like an outbox entry is (see
+ * {@link io.vanillabp.integration.outbox.mongo.MongoPhaseTwoOutbox}): a crash between
+ * writing the record and committing the aggregate would then skip a redelivery of work
+ * which was rolled back.
+ */
+@Slf4j
+public class MongoTaskDeliveryLog implements TaskDeliveryLog {
+
+  /**
+   * The collection holding the records.
+   */
+  public static final String DEFAULT_COLLECTION_NAME = "vanillabp-task-deliveries";
+
+  private final MongoTemplate mongoTemplate;
+
+  private final String collection;
+
+  private final Duration retention;
+
+  private final TaskDeliveryRetentionCleanup retentionCleanup;
+
+  public MongoTaskDeliveryLog(
+      final MongoTemplate mongoTemplate,
+      final String collection,
+      final Duration retention) {
+
+    this.mongoTemplate = mongoTemplate;
+    this.collection = collection;
+    this.retention = retention;
+    this.retentionCleanup = new TaskDeliveryRetentionCleanup(
+        collection, retention, this::cleanUpExpiredRecords);
+
+  }
+
+  /**
+   * Starts the retention cleanup - called once the application context is ready.
+   */
+  public void start() {
+
+    retentionCleanup.start();
+
+  }
+
+  /**
+   * Stops the retention cleanup - called on shutdown of the application context.
+   */
+  public void stop() {
+
+    retentionCleanup.stop();
+
+  }
+
+  @Override
+  public Optional<TaskDelivery> recordedDelivery(
+      final String deliveryKey) {
+
+    return Optional
+        .ofNullable(
+            mongoTemplate
+                .findById(deliveryKey, TaskDeliveryDocument.class, collection))
+        .map(document -> new TaskDelivery(
+            document.getId(), document.getWorkflowModuleId(), document.getBpmnProcessId(), document
+                .getAggregateId(), document.getTaskDefinition(), document
+                    .getOutcome(), document.getBpmnErrorCode(), document.getBpmnErrorName()));
+
+  }
+
+  @Override
+  public boolean record(
+      final TaskDelivery delivery) {
+
+    // pre-check for an existing record: within a MongoDB transaction a duplicate-key
+    // error would abort the whole transaction (the aggregate changes included), so the
+    // common duplicate case is detected by a read - the unique document ID stays the
+    // backstop for two nodes recording the same delivery at the same time, where the
+    // loser's transaction aborts and its work is rolled back
+    if (mongoTemplate.exists(
+        Query.query(Criteria.where("_id").is(delivery.deliveryKey())),
+        TaskDeliveryDocument.class,
+        collection)) {
+      logRecordedAlready(delivery);
+      return false;
+    }
+
+    try {
+      mongoTemplate.insert(
+          new TaskDeliveryDocument(
+              delivery.deliveryKey(), delivery.workflowModuleId(), delivery.bpmnProcessId(), delivery
+                  .workflowAggregateId(), delivery.taskDefinition(), delivery
+                      .outcome(), delivery.bpmnErrorCode(), delivery.bpmnErrorName(), Instant.now()),
+          collection);
+      return true;
+    } catch (final DuplicateKeyException e) {
+      // another node recorded the same delivery between the pre-check and the insert
+      logRecordedAlready(delivery);
+      return false;
+    }
+
+  }
+
+  private void logRecordedAlready(
+      final TaskDelivery delivery) {
+
+    log.debug(
+        "Task delivery '{}' of BPMN process '{}' of workflow module '{}' was recorded already",
+        delivery.deliveryKey(),
+        delivery.bpmnProcessId(),
+        delivery.workflowModuleId());
+
+  }
+
+  /**
+   * Deletes the records whose retention period passed - run by the background cleanup and
+   * usable on demand (e.g. by tests).
+   *
+   * @return The number of records deleted
+   */
+  public long cleanUpExpiredRecords() {
+
+    return mongoTemplate
+        .remove(
+            Query.query(Criteria.where("recordedAt").lt(Instant.now().minus(retention))),
+            TaskDeliveryDocument.class,
+            collection)
+        .getDeletedCount();
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
@@ -1,0 +1,94 @@
+package io.vanillabp.integration.delivery;
+
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.index.Index;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import io.vanillabp.integration.config.VanillaBpConfigurationProperties;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+
+/**
+ * Auto-configuration of the default {@link TaskDeliveryLog} for MongoDB-based aggregate
+ * persistence, coexisting with the JDBC default
+ * ({@link JdbcTaskDeliveryLogAutoConfiguration}) - each workflow aggregate is served by
+ * the log matching its persistence.
+ * <p>
+ * The records live in the collection
+ * {@value MongoTaskDeliveryLog#DEFAULT_COLLECTION_NAME} and are keyed by the delivery
+ * key, so uniqueness comes from the document ID and no unique index is needed. Unless
+ * <code>vanillabp.outbox.create-schema</code> is disabled, an index on the record's
+ * timestamp is created for the retention cleanup
+ * (<code>vanillabp.outbox.retention</code>).
+ */
+@AutoConfiguration(
+    after = JdbcTaskDeliveryLogAutoConfiguration.class,
+    afterName = "org.springframework.boot.data.mongodb.autoconfigure.DataMongoAutoConfiguration")
+@ConditionalOnClass(MongoRepository.class)
+@ConditionalOnBean({
+    MongoDatabaseFactory.class, MongoTemplate.class
+})
+@ConditionalOnBooleanProperty(name = "vanillabp.outbox.mongo.enabled", matchIfMissing = true)
+@EnableConfigurationProperties(VanillaBpConfigurationProperties.class)
+public class MongoTaskDeliveryLogAutoConfiguration {
+
+  /**
+   * The name of the default MongoDB delivery-log bean - used by the resolver to
+   * attribute MongoDB-persisted aggregates to THE default when several log beans exist.
+   */
+  public static final String DEFAULT_DELIVERY_LOG_BEAN_NAME = "vanillaBpMongoTaskDeliveryLog";
+
+  /**
+   * @param mongoTemplate The template writing the records within the current transaction
+   * @param vanillaBpProperties The bound <code>vanillabp.*</code> tree carrying the
+   *          <code>vanillabp.outbox</code> section
+   * @return The {@link TaskDeliveryLog} used for MongoDB-persisted aggregates
+   */
+  @Bean(name = DEFAULT_DELIVERY_LOG_BEAN_NAME, destroyMethod = "stop")
+  public MongoTaskDeliveryLog vanillaBpMongoTaskDeliveryLog(
+      final MongoTemplate mongoTemplate,
+      final VanillaBpConfigurationProperties vanillaBpProperties) {
+
+    return new MongoTaskDeliveryLog(
+        mongoTemplate, MongoTaskDeliveryLog.DEFAULT_COLLECTION_NAME, vanillaBpProperties
+            .getOutbox()
+            .getRetention());
+
+  }
+
+  /**
+   * Creates the index the cleanup reads and starts the cleanup once all singletons
+   * exist.
+   *
+   * @param mongoTemplate The template creating the index
+   * @param deliveryLog The delivery log to start
+   * @param vanillaBpProperties The bound <code>vanillabp.*</code> tree
+   * @return The startup hook
+   */
+  @Bean
+  public SmartInitializingSingleton vanillaBpMongoTaskDeliveryLogStartup(
+      final MongoTemplate mongoTemplate,
+      final MongoTaskDeliveryLog deliveryLog,
+      final VanillaBpConfigurationProperties vanillaBpProperties) {
+
+    return () -> {
+      if (vanillaBpProperties.getOutbox().isCreateSchema()) {
+        mongoTemplate
+            .indexOps(MongoTaskDeliveryLog.DEFAULT_COLLECTION_NAME)
+            .createIndex(new Index()
+                .on("recordedAt", Sort.Direction.ASC));
+      }
+      deliveryLog.start();
+    };
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/TaskDeliveryDocument.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/TaskDeliveryDocument.java
@@ -1,0 +1,53 @@
+package io.vanillabp.integration.delivery;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * The record of one processed task delivery in the MongoDB-based
+ * {@link io.vanillabp.integration.spi.TaskDeliveryLog}. The delivery key IS the
+ * document's ID, so MongoDB enforces the uniqueness the deduplication needs without an
+ * index of its own.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TaskDeliveryDocument {
+
+  /**
+   * The delivery's identity (see
+   * {@link io.vanillabp.integration.spi.TaskDelivery#deliveryKey()}).
+   */
+  @Id
+  private String id;
+
+  private String workflowModuleId;
+
+  private String bpmnProcessId;
+
+  private String aggregateId;
+
+  private String taskDefinition;
+
+  /**
+   * The outcome reported to the BPMS, which a repeated delivery is answered with.
+   */
+  private String outcome;
+
+  private String bpmnErrorCode;
+
+  private String bpmnErrorName;
+
+  /**
+   * When the delivery was processed - the retention cleanup deletes by this field.
+   */
+  private Instant recordedAt;
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
@@ -238,6 +238,12 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
               final var phaseTwoOutboxResolver = supplierContext
                   .bean(SpringPhaseTwoOutboxResolver.class);
 
+              // the same, for the log of processed task deliveries: a record has to
+              // ride the aggregate's own transaction, so the store is picked per
+              // aggregate as well
+              final var taskDeliveryLogResolver = supplierContext
+                  .bean(SpringTaskDeliveryLogResolver.class);
+
               // the bean registers itself with the router as phase-two dispatch
               // target of this workflow module/BPMN process
               final var phaseTwoRouter = supplierContext
@@ -257,7 +263,7 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
                           io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics.class));
 
               final var processServiceBean = new ProcessServiceSpringBean<A>(
-                  workflowModuleId, bpmnProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, phaseTwoRouter, workflowAdapterCache);
+                  workflowModuleId, bpmnProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, phaseTwoRouter, workflowAdapterCache, taskDeliveryLogResolver);
 
               // register ALL classes declaring this aggregate under ALL their
               // declared BPMN process IDs: @WorkflowTask handlers per (module,
@@ -282,7 +288,7 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
                       "%s|%s".formatted(declaringModuleId, declaredProcessId),
                       key -> {
                         final var secondaryProcessService = new MigrationProcessService<A>(
-                            declaringModuleId, declaredProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, workflowAdapterCache);
+                            declaringModuleId, declaredProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, workflowAdapterCache, taskDeliveryLogResolver);
                         if (phaseTwoRouter != null) {
                           phaseTwoRouter.register(secondaryProcessService);
                         }

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceSpringBean.java
@@ -30,10 +30,11 @@ public class ProcessServiceSpringBean<A> extends ProcessServiceBase<A> {
       final List<MigratableProcessService<A>> migratableProcessServices,
       final PhaseTwoOutboxResolver phaseTwoOutboxResolver,
       final PhaseTwoRouter phaseTwoRouter,
-      final WorkflowAdapterCache workflowAdapterCache) {
+      final WorkflowAdapterCache workflowAdapterCache,
+      final io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver taskDeliveryLogResolver) {
 
     migrationProcessService = new MigrationProcessService<A>(
-        workflowModuleId, bpmnProcessId, workflowAggregateClass, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, workflowAdapterCache);
+        workflowModuleId, bpmnProcessId, workflowAggregateClass, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, workflowAdapterCache, taskDeliveryLogResolver);
 
     // register as phase-two dispatch target: outbox entries for this workflow
     // module/BPMN process are routed here after the local transaction was committed

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -388,12 +388,30 @@ public class SpringBootMigrationAdapterAutoConfiguration {
   }
 
   /**
+   * Resolves the log of processed task deliveries per workflow aggregate (mixed
+   * persistence, own stores) - injected into the process-service beans and invoked at
+   * startup by {@link #vanillaBpProcessServiceStartupValidation}.
+   *
+   * @param applicationContext Used to look up log/aware beans and repositories
+   * @return The resolver
+   */
+  @Bean
+  public SpringTaskDeliveryLogResolver vanillaBpTaskDeliveryLogResolver(
+      final org.springframework.context.ApplicationContext applicationContext) {
+
+    return new SpringTaskDeliveryLogResolver(applicationContext);
+
+  }
+
+  /**
    * Startup validation of the process services, run once all singletons exist (so
    * no persistence infrastructure is materialized mid-bean-construction): for every
    * process service whose first-priority adapter requires a two-phase commit the
    * phase-two outbox is resolved (per aggregate - mixed persistence, dedicated
    * outboxes) - a missing outbox fails the startup with a guiding message instead
-   * of surfacing at the first workflow start.
+   * of surfacing at the first workflow start. The log of processed task deliveries is
+   * resolved in the same pass: a BPMS repeating deliveries without a log to remember
+   * them is reported at startup, not at the first redelivery.
    *
    * @param beanFactory Used to iterate all process-service beans
    * @return The startup validation hook
@@ -407,9 +425,14 @@ public class SpringBootMigrationAdapterAutoConfiguration {
         .stream()
         .filter(ProcessServiceSpringBean.class::isInstance)
         .map(ProcessServiceSpringBean.class::cast)
-        .forEach(processService -> processService
-            .getMigrationProcessService()
-            .validatePhaseTwoOutboxAtStartup());
+        .forEach(processService -> {
+          processService
+              .getMigrationProcessService()
+              .validatePhaseTwoOutboxAtStartup();
+          processService
+              .getMigrationProcessService()
+              .validateTaskDeliveryLogAtStartup();
+        });
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringPersistenceTechnology.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringPersistenceTechnology.java
@@ -1,0 +1,102 @@
+package io.vanillabp.integration.processservice;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.context.ApplicationContext;
+import org.springframework.data.repository.support.Repositories;
+
+/**
+ * Detects which persistence technology manages a workflow aggregate, asked by everything
+ * which has to write something in the aggregate's OWN transaction: the phase-two outbox
+ * ({@link SpringPhaseTwoOutboxResolver}) and the log of processed task deliveries
+ * ({@link SpringTaskDeliveryLogResolver}).
+ * <p>
+ * The technology is read from the aggregate's Spring Data repository. The repository
+ * interfaces are matched BY NAME, so the check works in applications having only one of
+ * the Spring Data modules on the classpath.
+ */
+public class SpringPersistenceTechnology {
+
+  public enum Technology {
+    JPA,
+    MONGO,
+    UNKNOWN
+  }
+
+  private static final String JPA_REPOSITORY = "org.springframework.data.jpa.repository.JpaRepository";
+
+  private static final String MONGO_REPOSITORY = "org.springframework.data.mongodb.repository.MongoRepository";
+
+  private final ApplicationContext applicationContext;
+
+  private volatile Repositories repositories;
+
+  public SpringPersistenceTechnology(
+      final ApplicationContext applicationContext) {
+
+    this.applicationContext = applicationContext;
+
+  }
+
+  /**
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @return The technology, {@link Technology#UNKNOWN} if the aggregate has no Spring
+   *         Data repository (custom persistence)
+   */
+  public Technology of(
+      final Class<?> workflowAggregateClass) {
+
+    if (repositories == null) {
+      repositories = new Repositories(applicationContext);
+    }
+    Class<?> current = workflowAggregateClass;
+    Optional<Object> repository = Optional.empty();
+    while (repository.isEmpty() && (current != null) && (current != Object.class)) {
+      repository = repositories.getRepositoryFor(current);
+      current = current.getSuperclass();
+    }
+    return repository
+        .map(repo -> {
+          if (implementsInterfaceNamed(repo.getClass(), JPA_REPOSITORY)) {
+            return Technology.JPA;
+          }
+          if (implementsInterfaceNamed(repo.getClass(), MONGO_REPOSITORY)) {
+            return Technology.MONGO;
+          }
+          return Technology.UNKNOWN;
+        })
+        .orElse(Technology.UNKNOWN);
+
+  }
+
+  private static boolean implementsInterfaceNamed(
+      final Class<?> type,
+      final String interfaceName) {
+
+    return implementsInterfaceNamed(type, interfaceName, new HashSet<>());
+
+  }
+
+  private static boolean implementsInterfaceNamed(
+      final Class<?> type,
+      final String interfaceName,
+      final Set<Class<?>> visited) {
+
+    if ((type == null) || !visited.add(type)) {
+      return false;
+    }
+    if (type.getName().equals(interfaceName)) {
+      return true;
+    }
+    for (final var iface : type.getInterfaces()) {
+      if (implementsInterfaceNamed(iface, interfaceName, visited)) {
+        return true;
+      }
+    }
+    return implementsInterfaceNamed(type.getSuperclass(), interfaceName, visited);
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringPhaseTwoOutboxResolver.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringPhaseTwoOutboxResolver.java
@@ -1,12 +1,10 @@
 package io.vanillabp.integration.processservice;
 
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.context.ApplicationContext;
-import org.springframework.data.repository.support.Repositories;
 
 import io.vanillabp.integration.adapter.migration.processservice.AwareSelection;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoOutboxResolver;
@@ -37,24 +35,15 @@ import io.vanillabp.integration.spi.PhaseTwoOutboxAware;
  */
 public class SpringPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
 
-  private enum PersistenceTechnology {
-    JPA,
-    MONGO,
-    UNKNOWN
-  }
-
-  private static final String JPA_REPOSITORY = "org.springframework.data.jpa.repository.JpaRepository";
-
-  private static final String MONGO_REPOSITORY = "org.springframework.data.mongodb.repository.MongoRepository";
-
   private final ApplicationContext applicationContext;
 
-  private volatile Repositories repositories;
+  private final SpringPersistenceTechnology persistenceTechnology;
 
   public SpringPhaseTwoOutboxResolver(
       final ApplicationContext applicationContext) {
 
     this.applicationContext = applicationContext;
+    this.persistenceTechnology = new SpringPersistenceTechnology(applicationContext);
 
   }
 
@@ -84,7 +73,7 @@ public class SpringPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
       return null;
     }
 
-    final var technology = detectPersistenceTechnology(workflowAggregateClass);
+    final var technology = persistenceTechnology.of(workflowAggregateClass);
 
     // 2. exactly one outbox bean: use it - unless it is a platform default clearly
     // not matching the aggregate's persistence (broken atomicity, fail guiding)
@@ -93,10 +82,10 @@ public class SpringPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
           .entrySet()
           .iterator()
           .next();
-      final var mismatch = ((technology == PersistenceTechnology.MONGO) && entry
+      final var mismatch = ((technology == SpringPersistenceTechnology.Technology.MONGO) && entry
           .getKey()
           .equals(
-              GruelboxPhaseTwoOutboxAutoConfiguration.DEFAULT_OUTBOX_BEAN_NAME)) || ((technology == PersistenceTechnology.JPA) && entry
+              GruelboxPhaseTwoOutboxAutoConfiguration.DEFAULT_OUTBOX_BEAN_NAME)) || ((technology == SpringPersistenceTechnology.Technology.JPA) && entry
                   .getKey()
                   .equals(MongoPhaseTwoOutboxAutoConfiguration.DEFAULT_OUTBOX_BEAN_NAME));
       if (mismatch) {
@@ -132,7 +121,7 @@ public class SpringPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
 
   private String buildAttributionErrorMessage(
       final Class<?> workflowAggregateClass,
-      final PersistenceTechnology technology,
+      final SpringPersistenceTechnology.Technology technology,
       final Set<String> outboxBeanNames) {
 
     return """
@@ -147,70 +136,6 @@ public class SpringPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
             outboxBeanNames,
             workflowAggregateClass.getName(),
             technology);
-
-  }
-
-  /**
-   * Detects the persistence technology managing the aggregate from its Spring Data
-   * repository's type. The repository interfaces are matched BY NAME so this check
-   * works in applications having only one of the Spring Data modules on the
-   * classpath.
-   *
-   * @param workflowAggregateClass The workflow aggregate's class
-   * @return The technology, {@link PersistenceTechnology#UNKNOWN} if the aggregate
-   *         has no Spring Data repository (custom persistence)
-   */
-  private PersistenceTechnology detectPersistenceTechnology(
-      final Class<?> workflowAggregateClass) {
-
-    if (repositories == null) {
-      repositories = new Repositories(applicationContext);
-    }
-    Class<?> current = workflowAggregateClass;
-    Optional<Object> repository = Optional.empty();
-    while (repository.isEmpty() && (current != null) && (current != Object.class)) {
-      repository = repositories.getRepositoryFor(current);
-      current = current.getSuperclass();
-    }
-    return repository
-        .map(repo -> {
-          if (implementsInterfaceNamed(repo.getClass(), JPA_REPOSITORY)) {
-            return PersistenceTechnology.JPA;
-          }
-          if (implementsInterfaceNamed(repo.getClass(), MONGO_REPOSITORY)) {
-            return PersistenceTechnology.MONGO;
-          }
-          return PersistenceTechnology.UNKNOWN;
-        })
-        .orElse(PersistenceTechnology.UNKNOWN);
-
-  }
-
-  private static boolean implementsInterfaceNamed(
-      final Class<?> type,
-      final String interfaceName) {
-
-    return implementsInterfaceNamed(type, interfaceName, new HashSet<>());
-
-  }
-
-  private static boolean implementsInterfaceNamed(
-      final Class<?> type,
-      final String interfaceName,
-      final Set<Class<?>> visited) {
-
-    if ((type == null) || !visited.add(type)) {
-      return false;
-    }
-    if (type.getName().equals(interfaceName)) {
-      return true;
-    }
-    for (final var iface : type.getInterfaces()) {
-      if (implementsInterfaceNamed(iface, interfaceName, visited)) {
-        return true;
-      }
-    }
-    return implementsInterfaceNamed(type.getSuperclass(), interfaceName, visited);
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringTaskDeliveryLogResolver.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringTaskDeliveryLogResolver.java
@@ -1,0 +1,139 @@
+package io.vanillabp.integration.processservice;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.context.ApplicationContext;
+
+import io.vanillabp.integration.adapter.migration.processservice.AwareSelection;
+import io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver;
+import io.vanillabp.integration.delivery.JdbcTaskDeliveryLogAutoConfiguration;
+import io.vanillabp.integration.delivery.MongoTaskDeliveryLogAutoConfiguration;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDeliveryLogAware;
+
+/**
+ * Spring Boot implementation of the core's {@link TaskDeliveryLogResolver}: resolves the
+ * {@link TaskDeliveryLog} used for a workflow aggregate so delivery records always ride
+ * the aggregate's own transaction (also in mixed-persistence applications). Resolution
+ * order - the same as {@link SpringPhaseTwoOutboxResolver} applies to outbox entries:
+ * <ol>
+ * <li>the most specific {@link TaskDeliveryLogAware} bean covering the aggregate
+ * class,</li>
+ * <li>the single {@link TaskDeliveryLog} bean if exactly one exists - unless it is a
+ * platform default NOT matching the aggregate's detectable persistence technology (that
+ * mismatch would break the atomicity of record and aggregate change and fails with a
+ * guiding message instead),</li>
+ * <li>with several log beans: the platform-default bean matching the persistence
+ * technology managing the aggregate (JPA-managed → the JDBC default, Mongo-managed → the
+ * MongoDB default).</li>
+ * </ol>
+ */
+public class SpringTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
+
+  private final ApplicationContext applicationContext;
+
+  private final SpringPersistenceTechnology persistenceTechnology;
+
+  public SpringTaskDeliveryLogResolver(
+      final ApplicationContext applicationContext) {
+
+    this.applicationContext = applicationContext;
+    this.persistenceTechnology = new SpringPersistenceTechnology(applicationContext);
+
+  }
+
+  @Override
+  public TaskDeliveryLog resolveFor(
+      final Class<?> workflowAggregateClass) {
+
+    // 1. the most specific TaskDeliveryLogAware bean covering the aggregate class
+    final var awares = applicationContext
+        .getBeanProvider(TaskDeliveryLogAware.class)
+        .stream()
+        .<TaskDeliveryLogAware<?>>map(aware -> (TaskDeliveryLogAware<?>) aware)
+        .toList();
+    final var mostSpecificAware = AwareSelection.mostSpecific(
+        awares,
+        TaskDeliveryLogAware::getAggregateClass,
+        workflowAggregateClass);
+    if (mostSpecificAware.isPresent()) {
+      return mostSpecificAware
+          .get()
+          .getTaskDeliveryLog();
+    }
+
+    final Map<String, TaskDeliveryLog> logs = applicationContext.getBeansOfType(TaskDeliveryLog.class);
+    if (logs.isEmpty()) {
+      return null;
+    }
+
+    final var technology = persistenceTechnology.of(workflowAggregateClass);
+
+    // 2. exactly one log bean: use it - unless it is a platform default clearly not
+    // matching the aggregate's persistence (a record which does not commit with the
+    // aggregate is worse than no deduplication, so this fails guiding)
+    if (logs.size() == 1) {
+      final var entry = logs
+          .entrySet()
+          .iterator()
+          .next();
+      final var mismatch = ((technology == SpringPersistenceTechnology.Technology.MONGO) && entry
+          .getKey()
+          .equals(
+              JdbcTaskDeliveryLogAutoConfiguration.DEFAULT_DELIVERY_LOG_BEAN_NAME)) || ((technology == SpringPersistenceTechnology.Technology.JPA) && entry
+                  .getKey()
+                  .equals(MongoTaskDeliveryLogAutoConfiguration.DEFAULT_DELIVERY_LOG_BEAN_NAME));
+      if (mismatch) {
+        throw new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, logs.keySet()));
+      }
+      return entry.getValue();
+    }
+
+    // 3. several log beans: attribute by the persistence technology managing the
+    // aggregate - to THE platform-default bean of that technology
+    final var defaultBeanName = switch (technology) {
+      case JPA -> JdbcTaskDeliveryLogAutoConfiguration.DEFAULT_DELIVERY_LOG_BEAN_NAME;
+      case MONGO -> MongoTaskDeliveryLogAutoConfiguration.DEFAULT_DELIVERY_LOG_BEAN_NAME;
+      case UNKNOWN -> null;
+    };
+    return Optional
+        .ofNullable(defaultBeanName)
+        .map(logs::get)
+        .orElseThrow(() -> new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, logs.keySet())));
+
+  }
+
+  @Override
+  public String remediesDescription() {
+
+    return """
+        - add spring-boot-starter-data-jpa and configure a data source (enables the JDBC-based default),
+        - add spring-boot-starter-data-mongodb and configure the MongoDB connection (enables the MongoDB default),""";
+
+  }
+
+  private String buildAttributionErrorMessage(
+      final Class<?> workflowAggregateClass,
+      final SpringPersistenceTechnology.Technology technology,
+      final Set<String> deliveryLogBeanNames) {
+
+    return """
+        The TaskDeliveryLog beans %s cannot be attributed to workflow aggregate '%s' (persistence \
+        technology detected: %s)! A delivery record must be enlisted in the transaction persisting \
+        the aggregate. To solve this either
+        - provide a bean implementing io.vanillabp.integration.spi.TaskDeliveryLogAware for this \
+        aggregate (returning the log matching its persistence), or
+        - enable the platform default matching the aggregate's persistence (add the corresponding \
+        Spring Data starter; check 'vanillabp.outbox.jdbc.enabled' / 'vanillabp.outbox.mongo.enabled')."""
+        .formatted(
+            deliveryLogBeanNames,
+            workflowAggregateClass.getName(),
+            technology);
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/spring-boot-integration/runtime/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -3,5 +3,7 @@ io.vanillabp.integration.utils.config.JpaSpringDataUtilConfiguration
 io.vanillabp.integration.utils.config.MongoDbSpringDataUtilAutoConfiguration
 io.vanillabp.integration.outbox.gruelbox.GruelboxPhaseTwoOutboxAutoConfiguration
 io.vanillabp.integration.outbox.mongo.MongoPhaseTwoOutboxAutoConfiguration
+io.vanillabp.integration.delivery.JdbcTaskDeliveryLogAutoConfiguration
+io.vanillabp.integration.delivery.MongoTaskDeliveryLogAutoConfiguration
 io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration
 io.vanillabp.integration.deployment.DeploymentAutoConfiguration

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/PhaseTwoAggregateIdConverterTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/PhaseTwoAggregateIdConverterTest.java
@@ -66,7 +66,7 @@ public class PhaseTwoAggregateIdConverterTest {
 
     new ProcessServiceSpringBean<>(
         "test-module", "TestProcess", Object.class, buildProperties(), aggregatePersistenceAware, List
-            .of(migratableProcessService), null, router, null);
+            .of(migratableProcessService), null, router, null, null);
 
   }
 

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/ProcessServiceSpringBeanTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/processservice/ProcessServiceSpringBeanTest.java
@@ -50,7 +50,7 @@ public class ProcessServiceSpringBeanTest {
 
     testee = new ProcessServiceSpringBean<>(
         "test-module", "TestProcess", Object.class, properties, aggregatePersistenceAware, List
-            .of(migratableProcessService), null, null, null);
+            .of(migratableProcessService), null, null, null, null);
 
   }
 


### PR DESCRIPTION
A remote BPMS delivers a task at least once: it hands the task out again whenever it did not learn the result, for instance after a crash between the commit of the local transaction and the report to the BPMS. That ran the `@WorkflowTask` method a second time, and the only statement about it was the wiki's rule to write handlers idempotently.

The core now records every processed delivery **in the transaction of the handler** and answers a repeated delivery with the recorded outcome instead of invoking the method again. Skipping the answer as well would leave the task open forever, so the record carries the outcome including the BPMN error code.

## What is new

- business SPI `TaskDeliveryLog`, `TaskDelivery`, `TaskDeliveryLogAware` - the inbound counterpart of the outbox, resolved per aggregate so a record rides the aggregate's own transaction;
- adapter SPI `TaskInvocationContext.getDeliveryId()` and `MigratableProcessService.deliversTasksAtLeastOnce()`, both `default` methods, so an adapter compiled before this keeps working;
- `TaskDeliveryKey` qualifies the adapter's ID with module, process and event, and hashes keys above 512 characters, which is what a store can index;
- the switch is the adapter-scoped `deduplicate-deliveries` (default `true`), resolvable per workflow module, workflow and task;
- stores without new configuration: table `VANILLABP_TASK_DELIVERY` respectively collection `vanillabp-task-deliveries` in the database of the aggregates, sharing the outbox' `create-schema` and `retention` settings. SQL and portable DDL live once in the core; per platform only the connection differs. Gruelbox is deliberately not the store: it dispatches calls, a delivery record is read back;
- a missing store is a guiding WARN at startup, not a failed boot - without a record VanillaBP behaves as it did before.

## The boundary, documented as prominently as the feature

A handler which threw leaves no record and runs again, two deliveries running at the same time both run, and everything a handler does outside its transaction stays the application's business. This is also the answer story 59 (aggregate write conflicts) needs.

## Adapters

Camunda 8 reports the job key (the user-task listener reports the listener job, not the user-task key: creation and cancellation share the latter), the Process-Engine-API adapter the task id. Camunda 7 reports nothing on purpose: it delivers inside the engine's transaction, so a redelivery proves that nothing was committed. All three adapter repositories are merged and green.

## Tests

`InboundIdempotencyTest` and `TaskDeliveryKeyTest` in the core, acceptance tests over the dummy adapter against the real JDBC store on both platforms, the MongoDB store per platform, the startup report, and `Camunda8InboundIdempotencyIT` against a real cluster: with an `async-task-timeout` of two seconds the dormant job of a `@TaskId` task is really handed out again, and the handler still ran exactly once.