### PR TITLE
Serve a version-less delivery by '*' only, never by whichever method …

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -135,10 +135,16 @@ The version meant is the version of the deployed process DEFINITION as the BPMS 
 application invents. A boundary may also name a version TAG of the model
 (`camunda:versionTag`, `zeebe:versionTag`).
 
-Three things flip for an application which already carries the attribute:
+Four things flip for an application which already carries the attribute:
 
 - Disjoint ranges really are disjoint now. A version served by NO method fails the
   delivery with a message naming that version, where before the first method ran.
+- A BPMS which reports no version at all (the Process-Engine-API, and any adapter whose
+  BPMS cannot tell) reaches methods without the attribute only. A method naming versions
+  is not called there, and a task whose every method names versions fails the delivery
+  saying so, where before the first method ran. Whether a version nobody reported lies
+  within `1-3` cannot be answered, and answering it by the order the methods happen to be
+  reflected in was not stable between two starts of the same application.
 - Two methods wired to one BPMN element with OVERLAPPING ranges fail the boot, naming both
   methods. The duplicate check compared `matchesVersion(null)`, which is `true` for every
   specification, so it never fired; and the workflow-task registry compared newly scanned

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -205,9 +205,12 @@ public class WorkflowEndedHandlers {
       return;
     }
 
-    final var handler = registered
+    final var wired = registered
         .stream()
         .filter(candidate -> candidate.matchesEndEvent(context.getEndEventId()))
+        .toList();
+    final var handler = wired
+        .stream()
         .filter(candidate -> candidate.matchesVersion(
             context.getProcessVersion(),
             processVersions.resolverFor(
@@ -216,15 +219,34 @@ public class WorkflowEndedHandlers {
         .findFirst()
         .orElse(null);
     if (handler == null) {
-      log
-          .debug(
-              "No @WorkflowEnded method of BPMN process '{}' (workflow module '{}') serves end event "
-                  + "'{}' of process version '{}' - the end of workflow '{}' is not reported",
-              processService.getBpmnProcessId(),
-              processService.getWorkflowModuleId(),
-              context.getEndEventId(),
-              context.getProcessVersion(),
-              context.getWorkflowAggregateId());
+      // a method wired to the event but excluded by its version is worth a warning: the
+      // application asked to be notified and is not, which no log level should hide
+      final var message = "No @WorkflowEnded method of BPMN process '{}' (workflow module '{}') "
+          + "serves end event '{}' of process version '{}' - the end of workflow '{}' is not "
+          + "reported.{}";
+      final var hint = io.vanillabp.integration.adapter.migration.workflowtask.VersionRange
+          .noVersionReportedHint(context.getProcessVersion());
+      if (wired.isEmpty()) {
+        log
+            .debug(
+                message,
+                processService.getBpmnProcessId(),
+                processService.getWorkflowModuleId(),
+                context.getEndEventId(),
+                context.getProcessVersion(),
+                context.getWorkflowAggregateId(),
+                hint);
+      } else {
+        log
+            .warn(
+                message,
+                processService.getBpmnProcessId(),
+                processService.getWorkflowModuleId(),
+                context.getEndEventId(),
+                context.getProcessVersion(),
+                context.getWorkflowAggregateId(),
+                hint);
+      }
       return;
     }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
@@ -8,6 +8,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
 import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
@@ -22,6 +25,8 @@ import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec
  * which the workflow-task registry implements by delegating here.
  */
 public class BpmsInitiatedStarts {
+
+  private static final Logger log = LoggerFactory.getLogger(BpmsInitiatedStarts.class);
 
   private record RegistryKey(
                              String workflowModuleId,
@@ -257,18 +262,37 @@ public class BpmsInitiatedStarts {
     final var entry = entries
         .get(
             new RegistryKey(processService.getWorkflowModuleId(), processService.getBpmnProcessId()));
-    final var handler = entry == null
-        ? null
+    final var wired = entry == null
+        ? List.<BpmsInitiatedStartHandler>of()
         : entry.handlers
             .stream()
             .filter(candidate -> candidate.matchesStartEvent(context.getStartEventId()))
-            .filter(candidate -> candidate.matchesVersion(
-                context.getProcessVersion(),
-                processVersions.resolverFor(
-                    processService.getWorkflowModuleId(),
-                    processService.getBpmnProcessId())))
-            .findFirst()
-            .orElse(null);
+            .toList();
+    final var handler = wired
+        .stream()
+        .filter(candidate -> candidate.matchesVersion(
+            context.getProcessVersion(),
+            processVersions.resolverFor(
+                processService.getWorkflowModuleId(),
+                processService.getBpmnProcessId())))
+        .findFirst()
+        .orElse(null);
+    if ((handler == null) && !wired.isEmpty()) {
+      // the aggregate is built either way, but the method meant to initialize it does
+      // not run - said out loud, because an empty aggregate looks like a defect later
+      log
+          .warn(
+              "No @WorkflowStartedByBpms method of BPMN process '{}' (workflow module '{}') serves "
+                  + "start event '{}' of process version '{}' - the aggregate is built without "
+                  + "initialization. Methods wired to that start event: {}.{}",
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              context.getStartEventId(),
+              context.getProcessVersion(),
+              describeHandlers(wired),
+              io.vanillabp.integration.adapter.migration.workflowtask.VersionRange
+                  .noVersionReportedHint(context.getProcessVersion()));
+    }
 
     final var result = BpmsInitiatedStartExecution.run(processService, handler, context, transactionRunner);
     // the BPMS just built this workflow through us - it holds it

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/VersionRange.java
@@ -194,9 +194,9 @@ public class VersionRange {
 
   /**
    * @param processVersion The version the BPMS reported
-   * @return Whether this specification covers that version - always
-   *         <code>true</code> for <code>null</code> (a BPMS which cannot report a
-   *         version matches every method)
+   * @return Whether this specification covers that version - only <code>*</code>
+   *         covers <code>null</code> (see
+   *         {@link #matches(String, ProcessVersionResolver)})
    */
   public boolean matches(
       final String processVersion) {
@@ -206,6 +206,12 @@ public class VersionRange {
   }
 
   /**
+   * A BPMS which reports NO version (<code>null</code>) is served by <code>*</code>
+   * only: whether a version lies within <code>1-3</code> cannot be answered without
+   * knowing the version, and answering it with "yes" would run a method for a version
+   * its author excluded. Which is why the choice is not left to the order the methods
+   * happen to be reflected in either.
+   *
    * @param processVersion The version the BPMS reported
    * @param resolver Resolves version tags of the BPMN process the version belongs to
    * @return Whether this specification covers that version
@@ -214,8 +220,11 @@ public class VersionRange {
       final String processVersion,
       final ProcessVersionResolver resolver) {
 
-    if ((kind == Kind.ALL) || (processVersion == null)) {
+    if (kind == Kind.ALL) {
       return true;
+    }
+    if (processVersion == null) {
+      return false;
     }
     if (kind == Kind.EXACT) {
       if (lower.equals(processVersion)) {
@@ -242,6 +251,25 @@ public class VersionRange {
     // the boundaries are closed - '>' and '<' moved theirs by one when they were built
     return ((boundaries[0] == null) || (version.value() >= boundaries[0]
         .value())) && ((boundaries[1] == null) || (version.value() <= boundaries[1].value()));
+
+  }
+
+  /**
+   * The reason a delivery of a BPMS which reports no version found no method, ready to
+   * be appended to a message - empty for a reported version, where the version itself
+   * is the reason.
+   *
+   * @param processVersion The version the BPMS reported
+   * @return The sentence to append, or an empty string
+   */
+  public static String noVersionReportedHint(
+      final String processVersion) {
+
+    return processVersion == null
+        ? " This BPMS reports no process version, so only a method whose version is '*' (the "
+            + "default) can serve the delivery - whether a version lies within a range nobody "
+            + "reported is not something VanillaBP guesses."
+        : "";
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -458,12 +458,13 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
         .orElseThrow(() -> new IllegalStateException(
             """
                 No @WorkflowTask method of BPMN process '%s' of workflow module '%s' matches task \
-                definition '%s' (process version '%s')! Registered methods: %s."""
+                definition '%s' (process version '%s')!%s Registered methods: %s."""
                 .formatted(
                     bpmnProcessId,
                     workflowModuleId,
                     context.getTaskDefinition(),
                     context.getProcessVersion(),
+                    VersionRange.noVersionReportedHint(context.getProcessVersion()),
                     entry.handlers
                         .stream()
                         .map(candidate -> "'%s' (%s)".formatted(candidate.describe(), candidate.describeWiring()))

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/ProcessVersionMatchingTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/ProcessVersionMatchingTest.java
@@ -364,6 +364,18 @@ public class ProcessVersionMatchingTest {
 
   }
 
+  static class UnversionedService {
+
+    @WorkflowTask(taskDefinition = "task")
+    public void everyVersion(
+        final Aggregate aggregate) {
+
+      aggregate.servedBy = "everyVersion";
+
+    }
+
+  }
+
   static class TaggedVersionsService {
 
     @WorkflowTask(taskDefinition = "task", version = "release-2024")
@@ -446,10 +458,31 @@ public class ProcessVersionMatchingTest {
     testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "3"));
     assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy);
 
-    // a BPMS which cannot report a version is served by the first method - the
-    // compatible behavior every application not using the attribute relies on
+    // a BPMS reporting NO version is served by '*' only: whether a version nobody
+    // reported lies within '1-2' cannot be answered, and the answer must not depend on
+    // the order the methods happen to be reflected in
+    final var unreported = assertThrows(
+        IllegalStateException.class,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", null)));
+    assertTrue(unreported.getMessage().contains("reports no process version"), unreported.getMessage());
+    assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy, "no method ran");
+
+  }
+
+  @Test
+  @DisplayName("A BPMS reporting no version is served by the method without a version")
+  public void withoutAReportedVersionTheUnrestrictedMethodServes() {
+
+    final var testee = registry(UnversionedService.class, UnversionedService::new);
+    storeAggregate("4711");
+
     testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", null));
-    assertEquals("upToTwo", persistence.aggregates.get("4711").servedBy);
+    assertEquals("everyVersion", persistence.aggregates.get("4711").servedBy);
+
+    // the same method serves a reported version, which is what makes the attribute
+    // free of cost for an application not using it
+    testee.invokeWorkflowTask(MODULE, PROCESS, taskContext("4711", "7"));
+    assertEquals("everyVersion", persistence.aggregates.get("4711").servedBy);
 
   }
 
@@ -678,6 +711,16 @@ public class ProcessVersionMatchingTest {
     testee.startWorkflowByBpms(MODULE, PROCESS, startContext("4712", "3"));
     assertEquals("afterTwo", persistence.aggregates.get("4712").servedBy);
 
+    // without a reported version no ranged method runs: the aggregate is built anyway,
+    // since the BPMS created that workflow either way - and it is said out loud
+    final var messages = loggedBy(
+        io.vanillabp.integration.adapter.migration.workflowstart.BpmsInitiatedStarts.class,
+        () -> testee.startWorkflowByBpms(MODULE, PROCESS, startContext("4713", null)));
+    assertNull(persistence.aggregates.get("4713").servedBy, "no method initialized the aggregate");
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("reports no process version")),
+        messages.toString());
+
   }
 
   @Test
@@ -697,6 +740,16 @@ public class ProcessVersionMatchingTest {
 
     testee.workflowEnded(MODULE, PROCESS, endedContext("3"));
     assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy);
+
+    // a notification without a version reaches no ranged method - a warning, because
+    // the application asked to hear about the end and does not
+    final var messages = loggedBy(
+        io.vanillabp.integration.adapter.migration.workflowend.WorkflowEndedHandlers.class,
+        () -> testee.workflowEnded(MODULE, PROCESS, endedContext(null)));
+    assertEquals("afterTwo", persistence.aggregates.get("4711").servedBy, "no method ran");
+    assertTrue(
+        messages.stream().anyMatch(message -> message.contains("reports no process version")),
+        messages.toString());
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -906,11 +906,14 @@ public class WorkflowTaskRegistryTest {
     }
 
     @Test
-    @DisplayName("A null process version matches any handler")
-    public void nullVersionMatchesAll() {
+    @DisplayName("A BPMS reporting no version reaches no handler naming versions")
+    public void withoutAReportedVersionRangedHandlersAreNotCalled() {
 
-      registry.invokeWorkflowTask(MODULE, "VersionedProcess", versionedContext(null));
-      assertEquals("oldVersions", persistence.aggregates.get("4711").processedBy);
+      final var exception = assertThrows(
+          IllegalStateException.class,
+          () -> registry.invokeWorkflowTask(MODULE, "VersionedProcess", versionedContext(null)));
+      assertTrue(exception.getMessage().contains("reports no process version"), exception.getMessage());
+      assertNull(persistence.aggregates.get("4711").processedBy, "no handler ran");
 
     }
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/TaskInvocationContext.java
@@ -98,8 +98,14 @@ public interface TaskInvocationContext {
    * <code>&#64;WorkflowTask(version = ...)</code>, and a specification naming a
    * version TAG is resolved using the
    * {@link io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog} the
-   * adapter registered. <code>null</code> matches every handler regardless of its
-   * version ranges - the compatible answer of an adapter whose BPMS cannot tell.
+   * adapter registered.
+   * <p>
+   * <code>null</code> is the answer of an adapter whose BPMS cannot tell. Such a
+   * delivery is served by a method whose version is <code>*</code> (the default), and
+   * an application not using the attribute is therefore unaffected. A method naming
+   * versions is NOT called: whether the version lies within its range cannot be
+   * answered, and VanillaBP does not decide it by the order the methods happen to be
+   * reflected in.
    *
    * @return The process version or <code>null</code>
    */

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ProcessVersionsTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ProcessVersionsTest.java
@@ -118,10 +118,13 @@ public class ProcessVersionsTest {
     assertEquals("tagged", persistence.stored("4711").getServedBy());
     assertEquals(1, versionSource.getQueries());
 
-    // a BPMS which cannot report a version is served by the first method - what
-    // every application not using the attribute relies on
-    dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", null));
-    assertEquals("upToTwo", persistence.stored("4711").getServedBy());
+    // a BPMS reporting NO version reaches none of these methods: every one of them
+    // names versions, and which of them applies is not something to guess
+    final var unreported = assertThrows(
+        IllegalStateException.class,
+        () -> dummyAdapter.invokeTask("test-module", "VersionedProcess", context("4711", null)));
+    assertTrue(unreported.getMessage().contains("reports no process version"), unreported.getMessage());
+    assertEquals("tagged", persistence.stored("4711").getServedBy(), "no method ran");
 
     // ANOTHER cluster node deploys version 5 and moves the tag to it: this node has
     // never seen that version, so it asks the BPMS while the task is dispatched

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateChangedTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateChangedTest.java
@@ -79,7 +79,7 @@ public class AggregateChangedTest {
     try {
       final var aggregate = workflowService.startWorkflow(content);
       userTransaction.commit();
-      listener.awaitInvocations(1, 10000);
+      listener.awaitInvocations(1, 30_000);
       awareness.answerWith(WorkflowAwareness.ACTIVE);
       return aggregate;
     } catch (final Exception e) {
@@ -110,7 +110,7 @@ public class AggregateChangedTest {
       throw e;
     }
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getAggregateChanges().size() < 3) {
       assertTrue(
           System.currentTimeMillis() < deadline,

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/MigrationElectionTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/MigrationElectionTest.java
@@ -91,7 +91,7 @@ public class MigrationElectionTest {
     final var aggregate = aggregateHolder[0];
 
     // the NEW start went to the CURRENT first-priority adapter 'new-bpms'
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getStartedByAdapter().isEmpty() && (System.currentTimeMillis() < deadline)) {
       Thread.sleep(50);
     }
@@ -137,7 +137,7 @@ public class MigrationElectionTest {
   private void awaitCompletedTasksByAdapter(
       final int count) throws Exception {
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getCompletedTasksByAdapter().size() < count) {
       assertTrue(
           System.currentTimeMillis() < deadline,

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxCustomTableTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxCustomTableTest.java
@@ -101,7 +101,7 @@ public class OutboxCustomTableTest {
     assertNotNull(attachedAggregate.getId());
 
     // dispatched from the configured table
-    final var invocations = listener.awaitInvocations(1, 10000);
+    final var invocations = listener.awaitInvocations(1, 30_000);
     assertEquals(attachedAggregate.getId(), invocations.getFirst());
 
     // the default table was never created

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxDispatchTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxDispatchTest.java
@@ -116,12 +116,12 @@ public class OutboxDispatchTest {
 
     // after the commit, phase two has to be dispatched with the aggregate's ID
     // converted back from its string representation to the original type
-    final var invocations = listener.awaitInvocations(1, 10000);
+    final var invocations = listener.awaitInvocations(1, 30_000);
     assertEquals(attachedAggregate.getId(), invocations.getFirst());
 
     // DONE instead of delete: the entry has to be marked DONE after the successful
     // dispatch and stays visible until the asynchronous retention cleanup
-    final var deadline = System.currentTimeMillis() + 10000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (count(COUNT_DONE_ENTRIES_OF_AGGREGATE.formatted(attachedAggregate.getId())) == 0) {
       assertTrue(System.currentTimeMillis() < deadline, "outbox entry was not marked DONE");
       Thread.sleep(50);
@@ -137,7 +137,7 @@ public class OutboxDispatchTest {
     final var attachedAggregate = workflowService.startWorkflow("dedup-test");
     userTransaction.commit();
 
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
 
     // starting the workflow again for the same aggregate schedules the same
     // idempotency key: the unique constraint makes it a no-op - no second entry,
@@ -185,7 +185,7 @@ public class OutboxDispatchTest {
     userTransaction.commit();
 
     // the first dispatch fails, the retry succeeds
-    final var invocations = listener.awaitInvocations(2, 10000);
+    final var invocations = listener.awaitInvocations(2, 30_000);
     assertEquals(attachedAggregate.getId(), invocations.get(0));
     assertEquals(attachedAggregate.getId(), invocations.get(1));
 

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxRedispatchMitigationTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxRedispatchMitigationTest.java
@@ -82,12 +82,12 @@ public class OutboxRedispatchMitigationTest {
 
     // the first (failing) dispatch happened - previouslyAttempted was false, so
     // NO mitigation probe ran up to now
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     assertEquals(0, awareness.countProbesOf("test"), "the first dispatch must not probe");
 
     // the RETRY recognizes attempts > 0, probes the adapter (ACTIVE) and consumes
     // the entry without a second start
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while ((awareness.countProbesOf("test") == 0) && (System.currentTimeMillis() < deadline)) {
       Thread.sleep(50);
     }

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxRetentionTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxRetentionTest.java
@@ -73,10 +73,10 @@ public class OutboxRetentionTest {
     final var attachedAggregate = workflowService.startWorkflow("retention-test");
     userTransaction.commit();
 
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
 
     // retention PT1S + poll interval PT0.5S: the DONE entry has to be gone soon
-    final var deadline = System.currentTimeMillis() + 10000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (countEntriesOfAggregate(attachedAggregate) > 0) {
       assertTrue(
           System.currentTimeMillis() < deadline,

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/SendSignalTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/SendSignalTest.java
@@ -69,7 +69,7 @@ public class SendSignalTest {
   private List<String> awaitBroadcast(
       final int count) throws InterruptedException {
 
-    final var deadline = System.currentTimeMillis() + 10_000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getBroadcastSignals().size() < count) {
       if (System.currentTimeMillis() > deadline) {
         throw new AssertionError(

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/TaskOperationsDispatchTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/TaskOperationsDispatchTest.java
@@ -86,7 +86,7 @@ public class TaskOperationsDispatchTest {
   public void taskOperationsDispatchAfterCommit() throws Exception {
 
     final var aggregate = startedAggregate("task-ops");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     awareness.answerWith(WorkflowAwareness.ACTIVE);
 
     userTransaction.begin();
@@ -99,7 +99,7 @@ public class TaskOperationsDispatchTest {
       throw e;
     }
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getCompletedTasks().isEmpty() || listener.getCanceledTasks().isEmpty()) {
       assertTrue(
           System.currentTimeMillis() < deadline,
@@ -125,7 +125,7 @@ public class TaskOperationsDispatchTest {
   public void userTaskOperationsDispatchAfterCommit() throws Exception {
 
     final var aggregate = startedAggregate("user-task-ops");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     awareness.answerWith(WorkflowAwareness.ACTIVE);
 
     userTransaction.begin();
@@ -138,7 +138,7 @@ public class TaskOperationsDispatchTest {
       throw e;
     }
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getCompletedUserTasks().isEmpty() || listener.getCanceledUserTasks().isEmpty()) {
       assertTrue(
           System.currentTimeMillis() < deadline,
@@ -161,7 +161,7 @@ public class TaskOperationsDispatchTest {
   public void correlateMessageDispatchesAfterCommit() throws Exception {
 
     final var aggregate = startedAggregate("correlate");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     awareness.answerWith(WorkflowAwareness.ACTIVE);
 
     userTransaction.begin();
@@ -178,7 +178,7 @@ public class TaskOperationsDispatchTest {
       throw e;
     }
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getCorrelatedMessages().size() < 3) {
       assertTrue(
           System.currentTimeMillis() < deadline,
@@ -215,7 +215,7 @@ public class TaskOperationsDispatchTest {
   public void unknownWorkflowRaisesGuidingException() throws Exception {
 
     final var aggregate = startedAggregate("correlate-unknown");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     // awareness stays UNKNOWN_TO_BPMS
 
     userTransaction.begin();
@@ -239,7 +239,7 @@ public class TaskOperationsDispatchTest {
   public void completedWorkflowCorrelationIsNoOp() throws Exception {
 
     final var aggregate = startedAggregate("correlate-completed");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     awareness.answerWith(WorkflowAwareness.COMPLETED);
 
     userTransaction.begin();
@@ -270,7 +270,7 @@ public class TaskOperationsDispatchTest {
       throw e;
     }
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getStartedByMessage().isEmpty()) {
       assertTrue(
           System.currentTimeMillis() < deadline,
@@ -289,7 +289,7 @@ public class TaskOperationsDispatchTest {
   public void rollbackAndUnknownTask() throws Exception {
 
     final var aggregate = startedAggregate("task-rollback");
-    listener.awaitInvocations(1, 10000);
+    listener.awaitInvocations(1, 30_000);
     awareness.answerWith(WorkflowAwareness.ACTIVE);
 
     userTransaction.begin();

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/WorkflowVisibilityDelayTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/WorkflowVisibilityDelayTest.java
@@ -113,7 +113,7 @@ public class WorkflowVisibilityDelayTest {
     assertEquals(
         0, awareness.remainingInvisibleProbes(), "the core has to keep asking until the workflow shows up");
 
-    final var deadline = System.currentTimeMillis() + 15000;
+    final var deadline = System.currentTimeMillis() + 30_000;
     while (listener.getCorrelatedMessages().isEmpty()) {
       assertTrue(
           System.currentTimeMillis() < deadline,

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/ProcessVersionsTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowversion/ProcessVersionsTest.java
@@ -261,10 +261,17 @@ public class ProcessVersionsTest {
       Assertions.assertEquals("tagged", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
       Assertions.assertEquals(1, VersionsConfiguration.QUERIES.get());
 
-      // a BPMS which cannot report a version is served by the first method - what
-      // every application not using the attribute relies on
-      dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", null));
-      Assertions.assertEquals("upToTwo", VersionsConfiguration.AGGREGATES.get("4711").getServedBy());
+      // a BPMS reporting NO version reaches none of these methods: every one of them
+      // names versions, and which of them applies is not something to guess
+      final var unreported = Assertions.assertThrows(
+          IllegalStateException.class,
+          () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("4711", null)));
+      Assertions.assertTrue(unreported.getMessage().contains("reports no process version"),
+          unreported.getMessage());
+      Assertions.assertEquals(
+          "tagged",
+          VersionsConfiguration.AGGREGATES.get("4711").getServedBy(),
+          "no method ran");
 
       // ANOTHER cluster node deploys version 5 and moves the tag to it: this node
       // has never seen that version, so it asks the BPMS while the task is dispatched


### PR DESCRIPTION
…came first

A BPMS which reports no process version used to match every @WorkflowTask, @WorkflowStartedByBpms and @WorkflowEnded method, and the first registered one served the delivery. Which one that is comes from Class.getDeclaredMethods(), whose order the JLS leaves open, so two tests failed in full builds and passed alone (ProcessVersionsTest.theProcessVersionDecidesWhichMethodServesTheTask, ProcessVersionMatchingTest.disjointRangesServeTheirVersions). Pinning Surefire to runOrder=alphabetical hid the symptom; the same class order does not mean the same method order.

Decided with Stephan: a delivery without a reported version is served by '*', the default, and by nothing else. Whether a version nobody reported lies within '1-3' cannot be answered, and a method whose author excluded that version must not run for it. If every method of a task names versions, the delivery fails with a message saying exactly that.

The rule sits in one place - VersionRange.matches treats null as covered by Kind.ALL only - so it holds for all three annotations at once. Two paths which used to decide silently now speak up: @WorkflowEnded logs WARN instead of DEBUG when a method is wired to the event and only its version excludes it, and a BPMS-initiated start warns when it builds the aggregate without running the method meant to initialize it.

Applications not using the attribute are unaffected. Adapters reporting null are the Process-Engine-API (where the engine supplies no version tag) and the dummy adapters of the platform tests.

Also: the polling deadlines of the Quarkus outbox tests were 10 s and 15 s, against this project's own rule for such tests, and two of them timed out under load. They wait for a condition, not for the deadline, so 30 s costs nothing when they pass.


Claude-Session: https://claude.ai/code/session_0182ZE1WCkm5p3ogRFxusoKT