### PR TITLE
Let an adapter ask whether a task has to stay open

### DIFF
--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -646,6 +646,27 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
   }
 
   @Override
+  public boolean workflowTaskCompletesAsynchronously(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinitionOrActivityId) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (entry == null) {
+      return false;
+    }
+    // ONE method wanting to keep the task open is enough - see the SPI: methods
+    // serving different process versions share the BPMN element, and the element
+    // either can stay open or it cannot
+    return entry.handlers
+        .stream()
+        .filter(candidate -> sameWiring(candidate.getTaskDefinition(),
+            taskDefinitionOrActivityId) || sameWiring(candidate.getActivityId(), taskDefinitionOrActivityId))
+        .anyMatch(WorkflowTaskHandler::isAsynchronousTask);
+
+  }
+
+  @Override
   public String resolveWorkflowAggregateIdName(
       final String workflowModuleId,
       final String bpmnProcessId) {

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -286,6 +286,32 @@ public class WorkflowTaskRegistryTest {
 
   }
 
+  /**
+   * Two methods serving ONE BPMN element, one of them keeping the task open (story
+   * 50): what an adapter has to treat as "this element cannot complete on return".
+   */
+  static class MixedAsyncService {
+
+    @WorkflowTask(taskDefinition = "mixedVersioned", version = "1")
+    public void firstVersion(
+        final Aggregate aggregate) {
+
+      aggregate.processedBy = "firstVersion";
+
+    }
+
+    @WorkflowTask(taskDefinition = "mixedVersioned", version = ">1")
+    public void laterVersions(
+        final Aggregate aggregate,
+        @TaskId final String taskId) {
+
+      aggregate.processedBy = "laterVersions";
+      aggregate.taskId = taskId;
+
+    }
+
+  }
+
   private static final String MODULE = "test-module";
 
   private static final String PROCESS = "TestProcess";
@@ -914,6 +940,55 @@ public class WorkflowTaskRegistryTest {
           () -> registry.invokeWorkflowTask(MODULE, "VersionedProcess", versionedContext(null)));
       assertTrue(exception.getMessage().contains("reports no process version"), exception.getMessage());
       assertNull(persistence.aggregates.get("4711").processedBy, "no handler ran");
+
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Asynchronous completion (story 50)")
+  class AsynchronousCompletion {
+
+    @Test
+    @DisplayName("A method declaring @TaskId says its task stays open")
+    public void aTaskIdMethodCompletesAsynchronously() {
+
+      assertTrue(registry.workflowTaskCompletesAsynchronously(MODULE, PROCESS, "asyncTask"));
+
+    }
+
+    @Test
+    @DisplayName("A method without @TaskId completes its task on return")
+    public void aMethodWithoutTaskIdCompletesOnReturn() {
+
+      assertFalse(registry.workflowTaskCompletesAsynchronously(MODULE, PROCESS, "doSomething"));
+      assertFalse(registry.workflowTaskCompletesAsynchronously(MODULE, PROCESS, "explicitDefinition"));
+      assertFalse(registry.workflowTaskCompletesAsynchronously(MODULE, PROCESS, "Activity_4711"));
+
+    }
+
+    @Test
+    @DisplayName("An element no method serves is not asynchronous either")
+    public void anUnknownElementIsNotAsynchronous() {
+
+      assertFalse(registry.workflowTaskCompletesAsynchronously(MODULE, PROCESS, "unknownTask"));
+      assertFalse(registry.workflowTaskCompletesAsynchronously(MODULE, "UnknownProcess", "asyncTask"));
+
+    }
+
+    @Test
+    @DisplayName("One of several methods keeping the task open is enough")
+    public void oneAsynchronousMethodDecidesForTheElement() {
+
+      registry.registerWorkflowService(
+          MODULE,
+          "MixedAsyncProcess",
+          MixedAsyncService.class,
+          MixedAsyncService::new,
+          beans::get,
+          createProcessService());
+
+      assertTrue(registry.workflowTaskCompletesAsynchronously(MODULE, "MixedAsyncProcess", "mixedVersioned"));
 
     }
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -141,6 +141,40 @@ public interface WorkflowTaskInvoker {
       String taskDefinitionOrActivityId);
 
   /**
+   * Whether the <code>&#64;WorkflowTask</code> method serving the given task
+   * definition (or BPMN activity ID) completes its task ASYNCHRONOUSLY, which a
+   * method says by declaring a <code>&#64;TaskId</code> parameter: the task stays
+   * open until the application completes it.
+   * <p>
+   * Adapters ask this while wiring, because a BPMN element which cannot stay open
+   * is a modelling defect the developer should learn about while the application
+   * starts rather than as an incident on a live workflow. Camunda 7's
+   * <code>camunda:expression</code> is such an element - it completes the task as
+   * soon as the expression returns.
+   * <p>
+   * ONE such method is enough for the answer to be <code>true</code>: several
+   * methods may serve one element (different process versions, story 48), and an
+   * element which cannot stay open is wired wrongly as soon as any of them wants to
+   * keep it open.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param taskDefinitionOrActivityId The task definition or BPMN activity ID
+   * @return Whether a matching method completes its task asynchronously;
+   *         <code>false</code> if no method is registered at all
+   */
+  default boolean workflowTaskCompletesAsynchronously(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinitionOrActivityId) {
+
+    // the core answers this; the default keeps test doubles of this SPI compiling
+    // and switches such a check off rather than inventing an answer
+    return false;
+
+  }
+
+  /**
    * The values of a workflow aggregate SHARED WITH THE BPMS
    * ({@code @SyncWithBPMS}/{@code @NoSyncWithBPMS}, see
    * {@link io.vanillabp.integration.adapter.spi.WorkflowAggregateSync}) - for


### PR DESCRIPTION
Story 50 (`prompts/50-camunda7-async-task-wiring-check.md`), core half.

`WorkflowTaskInvoker` gains `workflowTaskCompletesAsynchronously`, answered by the `WorkflowTaskRegistry` from the method's `@TaskId` parameter. Adapters ask it while wiring, so a BPMN element which cannot stay open is reported while the application starts instead of as an incident on a live workflow.

One matching method is enough for a `true`: several methods may serve one element since story 48, and the element either can stay open or it cannot. The SPI method is a `default` returning `false`, so test doubles keep compiling and the check stays off where nobody answers it.

The Camunda 7 half is vanillabp/camunda7-adapter#feature/async-task-wiring-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUj1bzCMbmhZYtg6u7fWD8