### PR TITLE
Ask the BPMS what it still holds, and let an application fade a version out

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1255,3 +1255,28 @@ require `spring-boot-data-mongodb-test` — not needed so far.)
 - Spring Boot 4.1.0 manages JUnit Jupiter **6.0.x** and Mockito 5.23; tests kept
   running without changes (root `mockito.version` is upgraded separately).
 
+## Story 57: the older versions a BPMS still holds (2026-08-15)
+
+**Adapters** gain two optional questions and one report, all of them additive:
+
+- `ProcessVersionCatalog#tasksOfVersion(workflowModuleId, bpmnProcessId, version)` reads the
+  model of a version the BPMS still holds and returns its tasks; `null` means "this BPMS
+  cannot say", which switches the check off for that adapter.
+- `ProcessVersionCatalog#activeInstanceCountOf(...)` counts the workflows still running on a
+  version; `null` again means "cannot say".
+- `WorkflowTaskInvoker#registerDeployedVersion(adapterId, workflowModuleId, bpmnProcessId,
+  version)` reports the version the BPMS assigned to the model deployed by this boot. Report
+  it even when the BPMS deployed nothing because the resources were unchanged, otherwise the
+  startup check runs only on boots which changed a model.
+
+An adapter implementing none of them keeps working exactly as before.
+
+**Applications** gain `vanillabp.adapters.<id>.outfaded-versions` (a list, in the grammar of
+the `version` attribute) and `vanillabp.adapters.<id>.outfaded-versions-in-use` (`LOG` by
+default, `FAIL` to make workflows on a faded-out version stop the boot). Both are
+adapter-scoped and resolvable per workflow module and workflow.
+
+**Behaviour which changed without a property:** a `@WorkflowTask` or `@WorkflowStartedByBpms`
+method whose version range excludes the version this boot deployed no longer has to match a
+task respectively a start event of the deployed model. It is reported as a warning if it
+matches no version the BPMS holds at all.

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -827,6 +827,44 @@ the message names the required version and every artifact to raise (starting wit
 BOM), following the [configuration/error-message principle](#features) of guiding the
 developer instead of just reporting.
 
+## The older versions a BPMS still holds (story 57)
+
+A BPMS keeps every version of a process it was ever given while the application brings only
+its newest model, so "does this application still serve version 1" is a question only the
+BPMS and the registry together can answer. The check runs once per BPMN process after the
+module was deployed, next to the version-tag resolution in
+`WorkflowTaskRegistry#resolveProcessVersions`.
+
+The split follows the rule of this project: reading a model is BPMS-specific, deciding what
+it means is not.
+
+- The adapter answers two optional questions of `ProcessVersionCatalog`:
+  `tasksOfVersion` reads the model the BPMS still holds and builds the same `BpmnTaskSpec`
+  list `wireBpmn` builds (both adapters extract it once and use it for both directions, so
+  the two cannot drift), and `activeInstanceCountOf` counts the workflows of that version.
+  A BPMS which cannot answer returns `null`, which switches the respective half off instead
+  of inventing an answer.
+- The adapter also reports what it deployed, through
+  `WorkflowTaskInvoker#registerDeployedVersion`. That is the border between "the model this
+  boot brought" and the older ones, and it is what makes fading out the deployed version a
+  boot failure. Watch out for the case where the BPMS deploys NOTHING because the resources
+  did not change - the version has to be reported anyway, otherwise the check would only
+  ever run on a boot which changed a model (Camunda 7 queries the latest version for that).
+- `DeployedProcessVersionsCheck` owns the decisions and every message: which versions are
+  older, which are faded out (`OutfadedProcessVersions`, the `outfaded-versions` property in
+  the grammar of `VersionRange`), which task definitions of a version nobody serves
+  (`WorkflowTaskRegistry#tasksNotServedInVersion`, version-aware and marking nothing as
+  wired), and which methods serve no version worth serving at all
+  (`handlersNotServingAnyVersion`, for all three annotations carrying a `version`).
+
+Two rules of the reverse direction come from this story. A method whose version range
+excludes the deployed version needs no task in the deployed model - without that exemption
+an application could only serve an old version by keeping a dead task in its current BPMN -
+and the same exemption applies to a `@WorkflowStartedByBpms` method naming a start event the
+new model dropped. What used to be caught by those checks is caught by the dead-method
+warning instead, which reports rather than fails: a version which does not exist YET is
+normal during a rolling deployment.
+
 ## Modules
 
 1. **business-spi:** (artifact `io.vanillabp:vanillabp-integration-spi`)<br>

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/AdapterProperties.java
@@ -53,4 +53,28 @@ public class AdapterProperties {
    */
   private Boolean deduplicateDeliveries;
 
+  /**
+   * The versions of a BPMN process this application does not serve any more (story
+   * 57), each written in the grammar of the <code>version</code> attribute of
+   * <code>&#64;WorkflowTask</code> and its siblings (<code>&lt;4</code>,
+   * <code>1-3</code>, <code>v1.0..v2.0</code>, a version tag). A version covered by
+   * ANY of them is ignored by the startup check, so its task definitions need no
+   * methods.
+   * <p>
+   * Adapter-scoped and therefore resolvable per workflow module and workflow - every
+   * BPMS counts its own versions, which is why a specification without an adapter
+   * would be meaningless and why the two adapters of a BPMS migration fade out their
+   * own versions independently. <code>null</code> or empty means "not configured at
+   * this level".
+   */
+  private java.util.List<String> outfadedVersions;
+
+  /**
+   * What happens when workflows still run on an outfaded version - see
+   * {@link OutfadedVersionsInUsePolicy}. Defaults to
+   * {@link OutfadedVersionsInUsePolicy#LOG}; <code>null</code> means "not configured
+   * at this level".
+   */
+  private OutfadedVersionsInUsePolicy outfadedVersionsInUse;
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/OutfadedVersionsInUsePolicy.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/OutfadedVersionsInUsePolicy.java
@@ -1,0 +1,25 @@
+package io.vanillabp.integration.adapter.migration.config;
+
+/**
+ * What happens when workflows still run on a process version the configuration faded
+ * out (<code>vanillabp.adapters.&lt;id&gt;.outfaded-versions</code>, story 57).
+ * <p>
+ * Those workflows will run into an incident at their next task of an unserved
+ * definition, so the finding is FATAL either way. What the operator decides is whether
+ * that also stops the application: living with old instances or with an application
+ * which does not start is a trade nobody but the operator can make.
+ */
+public enum OutfadedVersionsInUsePolicy {
+
+  /**
+   * The default: the finding is logged as FATAL, naming the process, the version and
+   * how many workflows are affected, and the application starts.
+   */
+  LOG,
+
+  /**
+   * The boot aborts with the same message.
+   */
+  FAIL
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandler.java
@@ -94,6 +94,22 @@ public class WorkflowEndedHandler {
 
   }
 
+  /**
+   * The version specification(s) this method names, for messages about a method
+   * serving no version the BPMS holds (story 57).
+   *
+   * @return The specifications, comma separated
+   */
+  String describeVersions() {
+
+    return versions
+        .stream()
+        .map(VersionRange::toString)
+        .map("'%s'"::formatted)
+        .collect(java.util.stream.Collectors.joining(", "));
+
+  }
+
   boolean matchesVersion(
       final String processVersion) {
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -45,6 +45,39 @@ public class WorkflowEndedHandlers {
   }
 
   /**
+   * The &#64;WorkflowEnded methods of that BPMN process whose version specification
+   * matches NONE of the given versions (story 57): the versions the BPMS holds, minus
+   * the ones the configuration faded out. Such a method never runs, and the start says
+   * so.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param servableVersions The versions worth serving
+   * @param resolver Resolves version tags of that process
+   * @return One description per dead method
+   */
+  public List<String> handlersNotServing(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final java.util.Collection<String> servableVersions,
+      final io.vanillabp.integration.adapter.migration.workflowtask.VersionRange.ProcessVersionResolver resolver) {
+
+    final var registered = handlers.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (registered == null) {
+      return List.of();
+    }
+    return registered
+        .stream()
+        .filter(handler -> servableVersions
+            .stream()
+            .noneMatch(version -> handler.matchesVersion(version, resolver)))
+        .map(handler -> "@WorkflowEnded method '%s' (version %s)"
+            .formatted(handler.describe(), handler.describeVersions()))
+        .toList();
+
+  }
+
+  /**
    * Scans a workflow service class and registers what it found. Called by the
    * platform integration at startup, once per (workflow service class, declared
    * BPMN process ID).

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartHandler.java
@@ -108,6 +108,22 @@ public class BpmsInitiatedStartHandler {
 
   }
 
+  /**
+   * The version specification(s) this method names, for messages about a method
+   * serving no version the BPMS holds (story 57).
+   *
+   * @return The specifications, comma separated
+   */
+  String describeVersions() {
+
+    return versions
+        .stream()
+        .map(VersionRange::toString)
+        .map("'%s'"::formatted)
+        .collect(java.util.stream.Collectors.joining(", "));
+
+  }
+
   boolean matchesVersion(
       final String processVersion) {
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStarts.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
 import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartContext;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartResult;
 import io.vanillabp.integration.adapter.spi.workflowstart.BpmsInitiatedStartSpec;
@@ -188,6 +189,38 @@ public class BpmsInitiatedStarts {
    * @throws IllegalStateException If a method serves a process without such a start
    *           event, or names a start event the process does not have
    */
+  /**
+   * The @WorkflowStartedByBpms methods of that BPMN process whose version specification matches
+   * NONE of the given versions (story 57): the versions the BPMS holds, minus the ones
+   * the configuration faded out. Such a method never runs, and the start says so.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param servableVersions The versions worth serving
+   * @param resolver Resolves version tags of that process
+   * @return One description per dead method
+   */
+  public java.util.List<String> handlersNotServing(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final java.util.Collection<String> servableVersions,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (entry == null) {
+      return java.util.List.of();
+    }
+    return entry.handlers
+        .stream()
+        .filter(handler -> servableVersions
+            .stream()
+            .noneMatch(version -> handler.matchesVersion(version, resolver)))
+        .map(handler -> "@WorkflowStartedByBpms method '%s' (version %s)"
+            .formatted(handler.describe(), handler.describeVersions()))
+        .toList();
+
+  }
+
   public void validate(
       final String workflowModuleId,
       final String bpmnProcessId,
@@ -224,6 +257,11 @@ public class BpmsInitiatedStarts {
       entry.handlers
           .stream()
           .filter(handler -> handler.getStartEventId() != null)
+          // story 57: a method kept for an OLDER version names a start event the
+          // deployed model may not have any more - that is what it is for. Whether
+          // such a version still exists is answered by the startup check, which
+          // reports a method serving no held version as dead.
+          .filter(handler -> !servesOnlyOlderVersions(workflowModuleId, bpmnProcessId, handler))
           .filter(handler -> entry.startEvents
               .stream()
               .noneMatch(spec -> spec.elementId().equals(handler.getStartEventId())))
@@ -242,6 +280,32 @@ public class BpmsInitiatedStarts {
                         describeStartEvents(entry.startEvents)));
           });
     }
+
+  }
+
+  /**
+   * Whether the method exists for versions OLDER than the one this boot deployed
+   * (story 57) - it then names an element of a model which is not the deployed one.
+   */
+  private boolean servesOnlyOlderVersions(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final BpmsInitiatedStartHandler handler) {
+
+    final var deployedVersions = processVersions
+        .registeredCatalogs(workflowModuleId, bpmnProcessId)
+        .stream()
+        .map(registered -> processVersions.deployedVersion(registered.adapterId(), workflowModuleId, bpmnProcessId))
+        .filter(java.util.Objects::nonNull)
+        .distinct()
+        .toList();
+    if (deployedVersions.isEmpty()) {
+      return false;
+    }
+    final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+    return deployedVersions
+        .stream()
+        .noneMatch(version -> handler.matchesVersion(version, resolver));
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/DeployedProcessVersionsCheck.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/DeployedProcessVersionsCheck.java
@@ -1,0 +1,487 @@
+package io.vanillabp.integration.adapter.migration.workflowtask;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vanillabp.integration.adapter.migration.config.OutfadedVersionsInUsePolicy;
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+
+/**
+ * The startup check of story 57: a BPMS keeps every version of a process it was ever
+ * given, and workflows keep running on them, while the application only brings the
+ * newest model with it. Whether the application still SERVES the older versions is
+ * therefore a question nobody asked in version 2 until now, and the first news of a
+ * version nobody serves used to be an incident on a live workflow.
+ * <p>
+ * The check runs once per BPMN process after its workflow module was deployed. Reading
+ * an old model belongs to the adapter ({@link ProcessVersionCatalogAccess}), deciding
+ * whether a method serves it belongs to the core, and the two ends meet here.
+ * <p>
+ * How loud a finding is depends on whether workflows still run on that version: a
+ * version nobody runs is a warning, a version with running workflows is FATAL and,
+ * where the operator asked for it, the end of the boot.
+ */
+public class DeployedProcessVersionsCheck {
+
+  private static final Logger log = LoggerFactory.getLogger(DeployedProcessVersionsCheck.class);
+
+  /**
+   * Which of the given tasks no <code>&#64;WorkflowTask</code> method serves in that
+   * version - answered by the {@link WorkflowTaskRegistry}, which is the only place
+   * knowing the version ranges of the methods.
+   */
+  @FunctionalInterface
+  public interface UnservedTasks {
+
+    Collection<BpmnTaskSpec> of(
+        String workflowModuleId,
+        String bpmnProcessId,
+        String version,
+        Collection<BpmnTaskSpec> tasks);
+
+  }
+
+  /**
+   * Which methods serve none of the versions worth serving - answered by the
+   * {@link WorkflowTaskRegistry} for all three annotations carrying a
+   * <code>version</code> attribute.
+   */
+  @FunctionalInterface
+  public interface DeadHandlers {
+
+    List<String> of(
+        String workflowModuleId,
+        String bpmnProcessId,
+        Collection<String> servableVersions,
+        VersionRange.ProcessVersionResolver resolver);
+
+  }
+
+  /**
+   * What the check reads from an adapter's catalog - narrowed to the two questions of
+   * this story so a test double does not have to be a whole catalog.
+   */
+  public interface ProcessVersionCatalogAccess {
+
+    List<DeployedProcessVersion> deployedVersionsOf(
+        String workflowModuleId,
+        String bpmnProcessId);
+
+    Collection<BpmnTaskSpec> tasksOfVersion(
+        String workflowModuleId,
+        String bpmnProcessId,
+        String version);
+
+    Long activeInstanceCountOf(
+        String workflowModuleId,
+        String bpmnProcessId,
+        String version);
+
+  }
+
+  private final ProcessVersions processVersions;
+
+  private final OutfadedProcessVersions outfadedVersions;
+
+  private final UnservedTasks unservedTasks;
+
+  private final DeadHandlers deadHandlers;
+
+  /**
+   * The adapters already reported as unable to answer, so a BPMS which cannot read old
+   * models says so once per process instead of once per version.
+   */
+  private final Set<String> reportedAsUnableToTell = ConcurrentHashMap.newKeySet();
+
+  public DeployedProcessVersionsCheck(
+      final ProcessVersions processVersions,
+      final OutfadedProcessVersions outfadedVersions,
+      final UnservedTasks unservedTasks,
+      final DeadHandlers deadHandlers) {
+
+    this.processVersions = processVersions;
+    this.outfadedVersions = outfadedVersions;
+    this.unservedTasks = unservedTasks;
+    this.deadHandlers = deadHandlers;
+
+  }
+
+  /**
+   * Runs the check for one BPMN process, for every BPMS serving it.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @throws IllegalStateException If the configuration fades out the version this boot
+   *           deployed, or if workflows run on an outfaded version and the policy is
+   *           {@link OutfadedVersionsInUsePolicy#FAIL}
+   */
+  public void check(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+    processVersions
+        .registeredCatalogs(workflowModuleId, bpmnProcessId)
+        .forEach(registered -> check(
+            workflowModuleId,
+            bpmnProcessId,
+            registered.adapterId(),
+            access(registered.catalog()),
+            resolver));
+
+  }
+
+  /**
+   * The check for ONE adapter - the entry point of the tests, which hand in their own
+   * {@link ProcessVersionCatalogAccess}.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param adapterId The adapter ID
+   * @param catalog What that BPMS can tell about the process
+   * @param resolver Resolves version tags of that process
+   */
+  public void check(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final ProcessVersionCatalogAccess catalog,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    final var deployed = processVersions.deployedVersion(adapterId, workflowModuleId, bpmnProcessId);
+    if (deployed == null) {
+      // a BPMS counting no versions: there is no "older version" to speak of
+      return;
+    }
+    failIfDeployedVersionIsOutfaded(workflowModuleId, bpmnProcessId, adapterId, deployed, resolver);
+
+    final var known = catalog.deployedVersionsOf(workflowModuleId, bpmnProcessId);
+    if ((known == null) || known.isEmpty()) {
+      return;
+    }
+    reportDeadHandlers(workflowModuleId, bpmnProcessId, adapterId, known, deployed, resolver);
+    for (final var version : olderThan(known, deployed)) {
+      if (outfadedVersions.isOutfaded(workflowModuleId, bpmnProcessId, adapterId, version, resolver)) {
+        reportOutfadedVersionInUse(workflowModuleId, bpmnProcessId, adapterId, version, catalog);
+        continue;
+      }
+      final var tasks = catalog.tasksOfVersion(workflowModuleId, bpmnProcessId, version);
+      if (tasks == null) {
+        reportUnableToReadModels(workflowModuleId, bpmnProcessId, adapterId);
+        return;
+      }
+      final var unserved = unservedTasks.of(workflowModuleId, bpmnProcessId, version, tasks);
+      if ((unserved == null) || unserved.isEmpty()) {
+        continue;
+      }
+      reportUnservedTasks(workflowModuleId, bpmnProcessId, adapterId, version, unserved, catalog);
+    }
+
+  }
+
+  /**
+   * Reports the methods which serve no version worth serving (story 57). "Worth
+   * serving" is what the BPMS holds minus what the configuration faded out, so fading
+   * out a version also tells the developer which methods just became pointless - the
+   * code-side counterpart of <code>outfaded-versions-in-use</code>, which speaks about
+   * running workflows only.
+   */
+  private void reportDeadHandlers(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final List<DeployedProcessVersion> known,
+      final String deployed,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    if (deadHandlers == null) {
+      return;
+    }
+    final var heldVersions = known == null
+        ? List.<String>of()
+        : known
+            .stream()
+            .map(DeployedProcessVersion::version)
+            .filter(java.util.Objects::nonNull)
+            .toList();
+    // the version this boot deployed is held even where the BPMS did not list it
+    final var allHeld = heldVersions.contains(deployed)
+        ? heldVersions
+        : java.util.stream.Stream.concat(heldVersions.stream(), java.util.stream.Stream.of(deployed)).toList();
+    final var servable = allHeld
+        .stream()
+        .filter(version -> !outfadedVersions.isOutfaded(workflowModuleId, bpmnProcessId, adapterId, version, resolver))
+        .toList();
+    final var outfaded = allHeld
+        .stream()
+        .filter(version -> !servable.contains(version))
+        .toList();
+    deadHandlers
+        .of(workflowModuleId, bpmnProcessId, servable, resolver)
+        .stream()
+        .filter(handler -> reportedAsUnableToTell.add(adapterId
+            + "|dead|"
+            + handler))
+        .forEach(handler -> log.warn(
+            """
+                The {} of BPMN process '{}' (workflow module '{}') matches no version adapter '{}' \
+                holds{} - the method never runs. Widen its version range, remove the method, or deploy \
+                a version it serves.""",
+            handler,
+            bpmnProcessId,
+            workflowModuleId,
+            adapterId,
+            outfaded.isEmpty()
+                ? " (held: %s)".formatted(String.join(", ", allHeld))
+                : " (held: %s, of which %s %s faded out by '%s')".formatted(
+                    String.join(", ", allHeld),
+                    String.join(", ", outfaded),
+                    outfaded.size() == 1
+                        ? "is"
+                        : "are",
+                    OutfadedProcessVersions.propertyName(adapterId))));
+
+  }
+
+  /**
+   * The versions the BPMS holds which are OLDER than the one this boot deployed. The
+   * catalog reports them in deployment order, so "older" is "before it in that list";
+   * a deployed version the catalog does not know at all (a query which failed, a BPMS
+   * which does not list what it just accepted) leaves every other version to be
+   * checked, which errs towards checking too much rather than too little.
+   */
+  private static List<String> olderThan(
+      final List<DeployedProcessVersion> known,
+      final String deployed) {
+
+    final var identifiers = known
+        .stream()
+        .map(DeployedProcessVersion::version)
+        .filter(java.util.Objects::nonNull)
+        .toList();
+    final var index = identifiers.indexOf(deployed);
+    return index < 0
+        ? identifiers.stream().filter(version -> !version.equals(deployed)).toList()
+        : identifiers.subList(0, index);
+
+  }
+
+  private void failIfDeployedVersionIsOutfaded(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final String deployed,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    final var covering = outfadedVersions
+        .specificationsFor(workflowModuleId, bpmnProcessId, adapterId)
+        .stream()
+        .filter(specification -> specification.matches(deployed, resolver))
+        .map(VersionRange::toString)
+        .toList();
+    if (covering.isEmpty()) {
+      return;
+    }
+    throw new IllegalStateException(
+        """
+            Version '%s' of BPMN process '%s' (workflow module '%s') is the version adapter '%s' \
+            deployed during this boot, but the specification(s) %s of '%s' cover it! Fading out the \
+            version an application just deployed would leave the process without a served version. \
+            Narrow the specification (e.g. '<%s') or remove it."""
+            .formatted(
+                deployed,
+                bpmnProcessId,
+                workflowModuleId,
+                adapterId,
+                covering.stream().map("'%s'"::formatted).collect(Collectors.joining(", ")),
+                OutfadedProcessVersions.propertyName(adapterId),
+                deployed));
+
+  }
+
+  private void reportUnservedTasks(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final String version,
+      final Collection<BpmnTaskSpec> unserved,
+      final ProcessVersionCatalogAccess catalog) {
+
+    final var definitions = unserved
+        .stream()
+        .map(task -> "'%s'".formatted(task.taskDefinition() == null
+            ? task.activityId()
+            : task.taskDefinition()))
+        .distinct()
+        .collect(Collectors.joining(", "));
+    final var running = catalog.activeInstanceCountOf(workflowModuleId, bpmnProcessId, version);
+    final var remedy = """
+        Add a @WorkflowTask method whose version range covers version '%s', or declare that version \
+        obsolete by adding e.g. '%s' to '%s'."""
+        .formatted(version, version, OutfadedProcessVersions.propertyName(adapterId));
+
+    if ((running != null) && (running > 0)) {
+      log.error(
+          """
+              {} workflow(s) still run on version '{}' of BPMN process '{}' (workflow module '{}', \
+              adapter '{}'), whose task definition(s) {} are served by NO @WorkflowTask method of this \
+              application - each of them will fail with an incident at its next such task! {}""",
+          running,
+          version,
+          bpmnProcessId,
+          workflowModuleId,
+          adapterId,
+          definitions,
+          remedy);
+      return;
+    }
+    log.warn(
+        """
+            Version '{}' of BPMN process '{}' (workflow module '{}') is still deployed at adapter '{}' \
+            and its task definition(s) {} are served by NO @WorkflowTask method of this application{}. \
+            {}""",
+        version,
+        bpmnProcessId,
+        workflowModuleId,
+        adapterId,
+        definitions,
+        running == null
+            ? ", and this BPMS cannot say whether workflows still run on it"
+            : ", no workflow runs on it right now",
+        remedy);
+
+  }
+
+  private void reportOutfadedVersionInUse(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final String version,
+      final ProcessVersionCatalogAccess catalog) {
+
+    final var running = catalog.activeInstanceCountOf(workflowModuleId, bpmnProcessId, version);
+    if (running == null) {
+      reportUnableToTellAboutInstances(workflowModuleId, bpmnProcessId, adapterId);
+      return;
+    }
+    if (running == 0) {
+      return;
+    }
+    final var message = """
+        %d workflow(s) still run on version '%s' of BPMN process '%s' (workflow module '%s', adapter \
+        '%s'), which '%s' fades out - this application does not serve that version any more, so each \
+        of them will fail with an incident at its next task whose definition nobody serves! Complete \
+        or migrate those workflows, or stop fading out that version. Set \
+        'vanillabp.adapters.%s.outfaded-versions-in-use' to 'FAIL' to make this stop the application \
+        instead of only reporting it."""
+        .formatted(
+            running,
+            version,
+            bpmnProcessId,
+            workflowModuleId,
+            adapterId,
+            OutfadedProcessVersions.propertyName(adapterId),
+            adapterId);
+    if (outfadedVersions.policyFor(workflowModuleId, bpmnProcessId, adapterId) == OutfadedVersionsInUsePolicy.FAIL) {
+      throw new IllegalStateException(message);
+    }
+    log.error(message);
+
+  }
+
+  private void reportUnableToReadModels(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId) {
+
+    if (!reportedAsUnableToTell.add(adapterId
+        + "|models|"
+        + workflowModuleId
+        + "|"
+        + bpmnProcessId)) {
+      return;
+    }
+    log.warn(
+        """
+            Adapter '{}' cannot read the models of the older versions of BPMN process '{}' (workflow \
+            module '{}') its BPMS still holds, so VanillaBP cannot tell whether this application still \
+            serves them - the adapter's own log says why. Workflows running on such a version fail with \
+            an incident at a task no @WorkflowTask method serves, which is what this check exists to \
+            report before it happens.""",
+        adapterId,
+        bpmnProcessId,
+        workflowModuleId);
+
+  }
+
+  private void reportUnableToTellAboutInstances(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId) {
+
+    if (!reportedAsUnableToTell.add(adapterId
+        + "|instances|"
+        + workflowModuleId
+        + "|"
+        + bpmnProcessId)) {
+      return;
+    }
+    log.warn(
+        """
+            Adapter '{}' cannot say how many workflows of BPMN process '{}' (workflow module '{}') still \
+            run on the versions '{}' fades out - the adapter's own log says why. The versions stay faded \
+            out; workflows still running on one of them fail with an incident at a task no @WorkflowTask \
+            method serves.""",
+        adapterId,
+        bpmnProcessId,
+        workflowModuleId,
+        OutfadedProcessVersions.propertyName(adapterId));
+
+  }
+
+  private static ProcessVersionCatalogAccess access(
+      final io.vanillabp.integration.adapter.spi.version.ProcessVersionCatalog catalog) {
+
+    return new ProcessVersionCatalogAccess() {
+
+      @Override
+      public List<DeployedProcessVersion> deployedVersionsOf(
+          final String workflowModuleId,
+          final String bpmnProcessId) {
+
+        return catalog.deployedVersionsOf(workflowModuleId, bpmnProcessId);
+
+      }
+
+      @Override
+      public Collection<BpmnTaskSpec> tasksOfVersion(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final String version) {
+
+        return catalog.tasksOfVersion(workflowModuleId, bpmnProcessId, version);
+
+      }
+
+      @Override
+      public Long activeInstanceCountOf(
+          final String workflowModuleId,
+          final String bpmnProcessId,
+          final String version) {
+
+        return catalog.activeInstanceCountOf(workflowModuleId, bpmnProcessId, version);
+
+      }
+
+    };
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/OutfadedProcessVersions.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/OutfadedProcessVersions.java
@@ -1,0 +1,179 @@
+package io.vanillabp.integration.adapter.migration.workflowtask;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.OutfadedVersionsInUsePolicy;
+
+/**
+ * The versions of a BPMN process an application declares obsolete (story 57):
+ * <code>vanillabp.adapters.&lt;id&gt;.outfaded-versions</code>, resolvable per workflow
+ * module and workflow like every adapter-scoped property.
+ * <p>
+ * A specification is written in the grammar of the <code>version</code> attribute (see
+ * {@link VersionRange}), so nobody has to learn a second one, and a version is outfaded
+ * as soon as ANY specification of the most specific configured level covers it.
+ * Specifications naming a version TAG need the BPMS, which is why the resolver of the
+ * process is handed in - the same one the annotations use.
+ */
+public class OutfadedProcessVersions {
+
+  /**
+   * The bound <code>vanillabp.*</code> tree, or <code>null</code> where nobody bound
+   * one (test doubles registering workflow services directly) - then nothing is
+   * outfaded.
+   */
+  private final MigrationAdapterProperties properties;
+
+  private record SpecKey(
+                         String workflowModuleId,
+                         String bpmnProcessId,
+                         String adapterId) {
+  }
+
+  /**
+   * The parsed specifications per scope - parsing reports a broken specification with
+   * the grammar, and doing that once per boot is enough.
+   */
+  private final Map<SpecKey, List<VersionRange>> parsed = new ConcurrentHashMap<>();
+
+  public OutfadedProcessVersions(
+      final MigrationAdapterProperties properties) {
+
+    this.properties = properties;
+
+  }
+
+  /**
+   * The specifications configured for that process and adapter, most specific level
+   * wins.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param adapterId The adapter ID
+   * @return The parsed specifications, empty if nothing is outfaded
+   * @throws IllegalStateException If a specification cannot be parsed (the message
+   *           carries the whole grammar)
+   */
+  public List<VersionRange> specificationsFor(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId) {
+
+    if (properties == null) {
+      return List.of();
+    }
+    return parsed
+        .computeIfAbsent(
+            new SpecKey(workflowModuleId, bpmnProcessId, adapterId),
+            key -> parse(key, configuredFor(key)));
+
+  }
+
+  /**
+   * Whether that version is faded out - a tag is placed through the BPMS, and a tag no
+   * BPMS knows covers nothing (same rule as the annotations).
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param adapterId The adapter ID
+   * @param version The version identifier the BPMS reported
+   * @param resolver Resolves version tags of that process
+   * @return Whether the version is outfaded
+   */
+  public boolean isOutfaded(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final String version,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    return specificationsFor(workflowModuleId, bpmnProcessId, adapterId)
+        .stream()
+        .anyMatch(specification -> specification.matches(version, resolver));
+
+  }
+
+  /**
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param adapterId The adapter ID
+   * @return What happens when workflows still run on an outfaded version
+   */
+  public OutfadedVersionsInUsePolicy policyFor(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId) {
+
+    if (properties == null) {
+      return OutfadedVersionsInUsePolicy.LOG;
+    }
+    final var configured = properties
+        .resolveForAdapter(
+            workflowModuleId,
+            bpmnProcessId,
+            null,
+            adapterId,
+            adapter -> adapter.getOutfadedVersionsInUse());
+    return configured == null
+        ? OutfadedVersionsInUsePolicy.LOG
+        : configured;
+
+  }
+
+  /**
+   * The property name of that scope, for messages which have to name what to change.
+   *
+   * @param adapterId The adapter ID
+   * @return The least specific spelling of the property
+   */
+  public static String propertyName(
+      final String adapterId) {
+
+    return "vanillabp.adapters.%s.outfaded-versions".formatted(adapterId);
+
+  }
+
+  private List<String> configuredFor(
+      final SpecKey key) {
+
+    final var configured = properties
+        .resolveForAdapter(
+            key.workflowModuleId(),
+            key.bpmnProcessId(),
+            null,
+            key.adapterId(),
+            adapter -> {
+              final var versions = adapter.getOutfadedVersions();
+              // a level which materialized the section but left the list empty is a
+              // level which configured nothing - the next one decides
+              return (versions == null) || versions.isEmpty()
+                  ? null
+                  : versions;
+            });
+    return configured == null
+        ? List.of()
+        : configured;
+
+  }
+
+  private static List<VersionRange> parse(
+      final SpecKey key,
+      final List<String> configured) {
+
+    return configured
+        .stream()
+        .map(specification -> VersionRange
+            .parse(
+                specification,
+                "'%s' of BPMN process '%s' (workflow module '%s')".formatted(
+                    propertyName(key.adapterId()),
+                    key.bpmnProcessId(),
+                    key.workflowModuleId())))
+        .toList();
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/ProcessVersions.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/ProcessVersions.java
@@ -35,12 +35,30 @@ public class ProcessVersions {
                              String bpmnProcessId) {
   }
 
-  private record RegisteredCatalog(
-                                   String adapterId,
-                                   ProcessVersionCatalog catalog) {
+  /**
+   * One BPMS answering for one BPMN process.
+   *
+   * @param adapterId The adapter ID
+   * @param catalog What that BPMS knows about the process' versions
+   */
+  public record RegisteredCatalog(
+                                  String adapterId,
+                                  ProcessVersionCatalog catalog) {
+  }
+
+  private record DeploymentKey(
+                               String adapterId,
+                               String workflowModuleId,
+                               String bpmnProcessId) {
   }
 
   private final Map<RegistryKey, List<RegisteredCatalog>> catalogs = new ConcurrentHashMap<>();
+
+  /**
+   * The version each adapter deployed during THIS boot (story 57) - the border between
+   * "the model this application brings" and the older versions the BPMS still holds.
+   */
+  private final Map<DeploymentKey, String> deployedVersions = new ConcurrentHashMap<>();
 
   /**
    * The version identifiers and tags already reported as unknown - a task delivery
@@ -76,6 +94,59 @@ public class ProcessVersions {
         .noneMatch(existing -> existing.adapterId().equals(adapterId) && (existing.catalog() == catalog))) {
       registered.add(new RegisteredCatalog(adapterId, catalog));
     }
+
+  }
+
+  /**
+   * Remembers the version an adapter deployed during this boot - see
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#registerDeployedVersion}.
+   *
+   * @param adapterId The adapter ID
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param version The version identifier the BPMS assigned, or <code>null</code>
+   */
+  public void recordDeployedVersion(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version) {
+
+    if (version == null) {
+      return;
+    }
+    deployedVersions.put(new DeploymentKey(adapterId, workflowModuleId, bpmnProcessId), version);
+
+  }
+
+  /**
+   * @param adapterId The adapter ID
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @return The version that adapter deployed during this boot, or <code>null</code>
+   */
+  public String deployedVersion(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return deployedVersions.get(new DeploymentKey(adapterId, workflowModuleId, bpmnProcessId));
+
+  }
+
+  /**
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @return The BPMS answering for that process, in registration order
+   */
+  public List<RegisteredCatalog> registeredCatalogs(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    final var registered = catalogs.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    return registered == null
+        ? List.of()
+        : List.copyOf(registered);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
@@ -162,6 +162,22 @@ public class WorkflowTaskHandler {
 
   }
 
+  /**
+   * The version specification(s) this method names, for messages about a method
+   * serving no version the BPMS holds (story 57).
+   *
+   * @return The specifications, comma separated
+   */
+  String describeVersions() {
+
+    return versions
+        .stream()
+        .map(VersionRange::toString)
+        .map("'%s'"::formatted)
+        .collect(java.util.stream.Collectors.joining(", "));
+
+  }
+
   boolean matchesVersion(
       final String processVersion) {
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -119,6 +119,16 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
    */
   private final List<String> rollbackRuleRemedies;
 
+  /**
+   * The process versions this application declares obsolete (story 57).
+   */
+  private final OutfadedProcessVersions outfadedVersions;
+
+  /**
+   * Whether the application still serves the OLDER versions the BPMS holds (story 57).
+   */
+  private final DeployedProcessVersionsCheck deployedVersionsCheck;
+
   public WorkflowTaskRegistry(
       final TransactionRunner transactionRunner) {
 
@@ -139,9 +149,22 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
       final io.vanillabp.integration.adapter.spi.WorkflowAggregateSync aggregateSync,
       final List<TransactionAnnotationSpec> transactionAnnotations) {
 
+    this(transactionRunner, aggregateSync, transactionAnnotations, null);
+
+  }
+
+  public WorkflowTaskRegistry(
+      final TransactionRunner transactionRunner,
+      final io.vanillabp.integration.adapter.spi.WorkflowAggregateSync aggregateSync,
+      final List<TransactionAnnotationSpec> transactionAnnotations,
+      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
+
     this.transactionRunner = transactionRunner;
     this.aggregateSync = aggregateSync;
     this.transactionAnnotations = transactionAnnotations;
+    this.outfadedVersions = new OutfadedProcessVersions(properties);
+    this.deployedVersionsCheck = new DeployedProcessVersionsCheck(
+        processVersions, outfadedVersions, this::tasksNotServedInVersion, this::handlersNotServingAnyVersion);
     this.rollbackRuleRemedies = transactionAnnotations
         .stream()
         .filter(TransactionAnnotationSpec::honored)
@@ -388,7 +411,7 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
               if (entry.getValue().wiringValidated) {
                 validatedMethods.add(method);
               }
-              if (handler.isWired()) {
+              if (handler.isWired() || servesOnlyOlderVersions(entry.getKey(), handler)) {
                 wiredMethods.add(method);
               } else {
                 unwiredByMethod.putIfAbsent(method, handler);
@@ -414,6 +437,42 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
                 annotation or add the task to one of the class' BPMN processes."""
                 .formatted(handler.describe(), handler.describeWiring())));
     throw new IllegalStateException(message.toString());
+
+  }
+
+  /**
+   * Whether the method exists for OLDER versions of its process only (story 57) - it
+   * then matches no task of the model this boot deployed, and that is the point of it
+   * rather than a defect.
+   * <p>
+   * Without this, keeping a method for a version the BPMS still holds would be
+   * impossible: the reverse direction would demand that the deployed model still
+   * carries the task the newer model dropped, so an application could only serve an
+   * old version by keeping a dead task in its current BPMN.
+   */
+  private boolean servesOnlyOlderVersions(
+      final RegistryKey key,
+      final WorkflowTaskHandler handler) {
+
+    final var deployedVersions = processVersions
+        .registeredCatalogs(key.workflowModuleId(), key.bpmnProcessId())
+        .stream()
+        .map(registered -> processVersions
+            .deployedVersion(registered.adapterId(), key.workflowModuleId(), key.bpmnProcessId()))
+        .filter(java.util.Objects::nonNull)
+        .distinct()
+        .toList();
+    if (deployedVersions.isEmpty()) {
+      // no BPMS counting versions: nothing to exempt, and the reverse direction
+      // stays as strict as it was
+      return false;
+    }
+    final var resolver = processVersions.resolverFor(key.workflowModuleId(), key.bpmnProcessId());
+    // a method serving the version deployed by ANY of the BPMS is expected to match
+    // a task of that model - only a method excluded everywhere is an old-version one
+    return deployedVersions
+        .stream()
+        .noneMatch(version -> handler.matchesVersion(version, resolver));
 
   }
 
@@ -458,13 +517,17 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
         .orElseThrow(() -> new IllegalStateException(
             """
                 No @WorkflowTask method of BPMN process '%s' of workflow module '%s' matches task \
-                definition '%s' (process version '%s')!%s Registered methods: %s."""
+                definition '%s' (process version '%s')!%s%s Registered methods: %s."""
                 .formatted(
                     bpmnProcessId,
                     workflowModuleId,
                     context.getTaskDefinition(),
                     context.getProcessVersion(),
                     VersionRange.noVersionReportedHint(context.getProcessVersion()),
+                    // story 57: a delivery from a version the configuration faded out
+                    // looks exactly like a wiring defect otherwise
+                    outfadedVersionHint(
+                        workflowModuleId, bpmnProcessId, context.getAdapterId(), context.getProcessVersion()),
                     entry.handlers
                         .stream()
                         .map(candidate -> "'%s' (%s)".formatted(candidate.describe(), candidate.describeWiring()))
@@ -503,6 +566,9 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
               .stream()
               .anyMatch(handler -> !handler.versionTags().isEmpty());
           if (!tagsUsed) {
+            // story 57: the older versions are checked even where no annotation
+            // names a tag, so this is no longer the end of the story
+            deployedVersionsCheck.check(workflowModuleId, bpmnProcessId);
             return;
           }
           // the BPMS is asked ONCE per process, right after the deployment: the
@@ -528,6 +594,7 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
                     handler,
                     resolver));
           }
+          deployedVersionsCheck.check(workflowModuleId, bpmnProcessId);
         });
 
     bpmsInitiatedStarts.resolveProcessVersions(workflowModuleId);
@@ -642,6 +709,130 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
         .stream()
         .anyMatch(candidate -> sameWiring(candidate.getTaskDefinition(),
             taskDefinitionOrActivityId) || sameWiring(candidate.getActivityId(), taskDefinitionOrActivityId));
+
+  }
+
+  /**
+   * The sentence a delivery from an OUTFADED version deserves - without it the
+   * developer reads "no method matches" and looks for a wiring defect, while the
+   * configuration says on purpose that this version is not served any more.
+   */
+  private String outfadedVersionHint(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String adapterId,
+      final String processVersion) {
+
+    if ((adapterId == null) || (processVersion == null)) {
+      return "";
+    }
+    if (!outfadedVersions
+        .isOutfaded(
+            workflowModuleId,
+            bpmnProcessId,
+            adapterId,
+            processVersion,
+            processVersions.resolverFor(workflowModuleId, bpmnProcessId))) {
+      return "";
+    }
+    return " Version '%s' is faded out by '%s', so this application deliberately does not serve it - the workflow has to be completed or migrated, or the version has to be served again."
+        .formatted(processVersion, OutfadedProcessVersions.propertyName(adapterId));
+
+  }
+
+  @Override
+  public void registerDeployedVersion(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version) {
+
+    processVersions.recordDeployedVersion(adapterId, workflowModuleId, bpmnProcessId, version);
+
+  }
+
+  /**
+   * Which of the given tasks of ONE deployed version no <code>&#64;WorkflowTask</code>
+   * method serves - the version-aware sibling of {@link #validateTaskWiring}, used by
+   * the startup check of story 57.
+   * <p>
+   * Two differences to the wiring validation, and both matter. It asks per VERSION, so
+   * a method carrying <code>version = "3"</code> counts for version 3 and for nothing
+   * else. And it marks NOTHING as wired: serving an old version says nothing about the
+   * reverse direction {@link #validateNoUnwiredWorkflowTaskMethods} decides, and a
+   * method kept only for an old version must still match a task of the deployed model.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param version The version identifier the BPMS reported
+   * @param tasks The tasks of that version's model
+   * @return The tasks no method serves in that version
+   */
+  /**
+   * The methods of that BPMN process which serve NO version worth serving - the
+   * versions the BPMS holds, minus the ones the configuration faded out (story 57).
+   * All three annotations carry a <code>version</code> attribute, so all three are
+   * asked.
+   * <p>
+   * Such a method never runs. It is a warning rather than a boot failure, because a
+   * version which does not exist YET is a normal state: an application may be rolled
+   * out before the model that needs it, and during a rolling deployment another node
+   * may still be deploying it.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The plain BPMN process ID
+   * @param servableVersions The versions worth serving
+   * @param resolver Resolves version tags of that process
+   * @return One description per dead method
+   */
+  public List<String> handlersNotServingAnyVersion(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Collection<String> servableVersions,
+      final VersionRange.ProcessVersionResolver resolver) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    final var tasks = entry == null
+        ? List.<String>of()
+        : List
+            .copyOf(entry.handlers)
+            .stream()
+            .filter(handler -> servableVersions
+                .stream()
+                .noneMatch(version -> handler.matchesVersion(version, resolver)))
+            .map(handler -> "@WorkflowTask method '%s' (version %s)"
+                .formatted(handler.describe(), handler.describeVersions()))
+            .toList();
+    return java.util.stream.Stream
+        .of(
+            tasks,
+            bpmsInitiatedStarts.handlersNotServing(workflowModuleId, bpmnProcessId, servableVersions, resolver),
+            workflowEndedHandlers.handlersNotServing(workflowModuleId, bpmnProcessId, servableVersions, resolver))
+        .flatMap(List::stream)
+        .toList();
+
+  }
+
+  public Collection<BpmnTaskSpec> tasksNotServedInVersion(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version,
+      final Collection<BpmnTaskSpec> tasks) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    final var handlers = entry == null
+        ? List.<WorkflowTaskHandler>of()
+        : List.copyOf(entry.handlers);
+    final var resolver = processVersions.resolverFor(workflowModuleId, bpmnProcessId);
+    return tasks
+        .stream()
+        // a user task without a handler is processed through forms or task lists, in
+        // an old version exactly as in the deployed one
+        .filter(task -> !task.optional())
+        .filter(task -> handlers
+            .stream()
+            .noneMatch(handler -> matches(handler, task) && handler.matchesVersion(version, resolver)))
+        .toList();
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/OldProcessVersionsTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/OldProcessVersionsTest.java
@@ -1,0 +1,509 @@
+package io.vanillabp.migration.test.workflowtask;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import ch.qos.logback.classic.Level;
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.OutfadedVersionsInUsePolicy;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.DeployedProcessVersionsCheck;
+import io.vanillabp.integration.adapter.migration.workflowtask.OutfadedProcessVersions;
+import io.vanillabp.integration.adapter.migration.workflowtask.ProcessVersions;
+import io.vanillabp.integration.adapter.migration.workflowtask.VersionRange;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.version.DeployedProcessVersion;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * The startup check of story 57: does this application still serve the OLDER versions
+ * of its processes the BPMS holds, and what does outfading a version do.
+ * <p>
+ * The BPMS is a stub here, because the question the core answers is version arithmetic,
+ * not model reading: the adapters prove the reading half against real engines.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OldProcessVersionsTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String ADAPTER = "c7";
+
+  public static class Aggregate {
+
+    String id;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  /**
+   * Serves the deployed version 3 and, with a second method, the older version 2. The
+   * task 'goneTask' existed in older models only and is served by nobody.
+   */
+  public static class Service {
+
+    @WorkflowTask(taskDefinition = "stillThere")
+    public void stillThere(
+        final Aggregate aggregate) {
+    }
+
+    @WorkflowTask(taskDefinition = "oldOnly", version = "2")
+    public void oldOnly(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  /**
+   * A method for a version this BPMS does not hold - a typo, a version deleted from
+   * the engine, or code shipped before the model it needs.
+   */
+  public static class DeadVersionService {
+
+    @WorkflowTask(taskDefinition = "stillThere", version = "99")
+    public void neverRuns(
+        final Aggregate aggregate) {
+    }
+
+  }
+
+  /**
+   * What the BPMS is asked, with every answer handed in by the test.
+   */
+  private static class CatalogStub implements DeployedProcessVersionsCheck.ProcessVersionCatalogAccess {
+
+    private List<DeployedProcessVersion> versions = List.of();
+
+    private Map<String, Collection<BpmnTaskSpec>> tasksPerVersion = Map.of();
+
+    private Map<String, Long> instancesPerVersion = Map.of();
+
+    private boolean canReadModels = true;
+
+    private boolean canCountInstances = true;
+
+    @Override
+    public List<DeployedProcessVersion> deployedVersionsOf(
+        final String workflowModuleId,
+        final String bpmnProcessId) {
+
+      return versions;
+
+    }
+
+    @Override
+    public Collection<BpmnTaskSpec> tasksOfVersion(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String version) {
+
+      return canReadModels
+          ? tasksPerVersion.getOrDefault(version, List.of())
+          : null;
+
+    }
+
+    @Override
+    public Long activeInstanceCountOf(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String version) {
+
+      return canCountInstances
+          ? instancesPerVersion.getOrDefault(version, 0L)
+          : null;
+
+    }
+
+  }
+
+  private MigrationAdapterProperties properties;
+
+  private WorkflowTaskRegistry registry;
+
+  private CatalogStub catalog;
+
+  /**
+   * The check reads the version this boot deployed from here - the registry records it
+   * through the SPI (see below), and the test drives the check directly.
+   */
+  private ProcessVersions processVersions;
+
+  /**
+   * ONE instance per test, as in an application: what it reported once it does not
+   * report again.
+   */
+  private DeployedProcessVersionsCheck deployedVersionsCheck;
+
+  @BeforeEach
+  public void setUp() {
+
+    properties = new MigrationAdapterProperties();
+    properties.setAdapters(Map.of(ADAPTER, AdapterConfigProperties.ofType("camunda7")));
+    registry = new WorkflowTaskRegistry(new TransactionRunnerStub(), null, List.of(), properties);
+    registry
+        .registerWorkflowService(
+            MODULE,
+            PROCESS,
+            Service.class,
+            Service::new,
+            type -> null,
+            processService());
+    registry.registerDeployedVersion(ADAPTER, MODULE, PROCESS, "3");
+    processVersions = new ProcessVersions();
+    processVersions.recordDeployedVersion(ADAPTER, MODULE, PROCESS, "3");
+    deployedVersionsCheck = new DeployedProcessVersionsCheck(
+        processVersions, new OutfadedProcessVersions(properties), registry::tasksNotServedInVersion, registry::handlersNotServingAnyVersion);
+
+    catalog = new CatalogStub();
+    catalog.versions = List
+        .of(DeployedProcessVersion.of("1"), DeployedProcessVersion.of("2"), DeployedProcessVersion.of("3"));
+    catalog.tasksPerVersion = Map.of(
+        "1", List.of(new BpmnTaskSpec("Activity_gone", "goneTask")),
+        "2", List.of(new BpmnTaskSpec("Activity_old", "oldOnly")),
+        "3", List.of(new BpmnTaskSpec("Activity_still", "stillThere")));
+
+  }
+
+  @Test
+  @DisplayName("A version whose tasks are all served is not reported")
+  public void aServedVersionIsQuiet() {
+
+    catalog.tasksPerVersion = Map.of("1", List.of(new BpmnTaskSpec("Activity_still", "stillThere")), "2", List
+        .of(new BpmnTaskSpec("Activity_old", "oldOnly")));
+
+    assertEquals(List.of(), check());
+
+  }
+
+  @Test
+  @DisplayName("A version nobody runs whose task is unserved is a warning naming both ways out")
+  public void anUnservedVersionWithoutInstancesWarns() {
+
+    final var messages = check();
+
+    assertEquals(1, messages.size(), messages.toString());
+    final var message = messages.get(0);
+    assertTrue(message.contains("'1'"), message);
+    assertTrue(message.contains("'goneTask'"), message);
+    assertTrue(message.contains("no workflow runs on it right now"), message);
+    assertTrue(message.contains("version range covers version '1'"), message);
+    assertTrue(message.contains("vanillabp.adapters.c7.outfaded-versions"), message);
+
+  }
+
+  @Test
+  @DisplayName("Workflows running on an unserved version turn the warning into an error")
+  public void anUnservedVersionWithInstancesIsAnError() {
+
+    catalog.instancesPerVersion = Map.of("1", 7L);
+
+    final var errors = check(Level.ERROR);
+
+    assertEquals(1, errors.size(), errors.toString());
+    assertTrue(errors.get(0).contains("7 workflow(s) still run on version '1'"), errors.get(0));
+    assertTrue(errors.get(0).contains("incident"), errors.get(0));
+
+  }
+
+  @Test
+  @DisplayName("A version the method serves by its version range is served, one it excludes is not")
+  public void versionRangesDecidePerVersion() {
+
+    // 'oldOnly' names version 2, so the same task in version 1 is unserved
+    catalog.tasksPerVersion = Map.of("1", List.of(new BpmnTaskSpec("Activity_old", "oldOnly")), "2", List
+        .of(new BpmnTaskSpec("Activity_old", "oldOnly")));
+
+    final var messages = check();
+
+    assertEquals(1, messages.size(), messages.toString());
+    assertTrue(messages.get(0).contains("'1'"), messages.get(0));
+    assertTrue(messages.get(0).contains("'oldOnly'"), messages.get(0));
+
+  }
+
+  @Test
+  @DisplayName("Serving an old version does not mark a method as wired")
+  public void servingAnOldVersionSaysNothingAboutTheDeployedModel() {
+
+    check();
+
+    // the method serving version 2 matched no task of the DEPLOYED model, which is
+    // the direction validateNoUnwiredWorkflowTaskMethods decides
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> {
+          registry.validateTaskWiring(MODULE, PROCESS, List.of(new BpmnTaskSpec("Activity_still", "stillThere")));
+          registry.validateNoUnwiredWorkflowTaskMethods(MODULE);
+        });
+    assertTrue(failure.getMessage().contains("oldOnly"), failure.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("A method serving no held version is reported as dead, naming what it names")
+  public void aMethodServingNoHeldVersionIsReported() {
+
+    registry
+        .registerWorkflowService(
+            MODULE,
+            "DeadProcess",
+            DeadVersionService.class,
+            DeadVersionService::new,
+            type -> null,
+            processService());
+    processVersions.recordDeployedVersion(ADAPTER, MODULE, "DeadProcess", "3");
+
+    final var message = deadMethodMessage(check(Level.WARN, "DeadProcess"));
+
+    assertTrue(message.contains("@WorkflowTask method"), message);
+    assertTrue(message.contains("neverRuns"), message);
+    assertTrue(message.contains("'99'"), message);
+    assertTrue(message.contains("held: 1, 2, 3"), message);
+
+  }
+
+  @Test
+  @DisplayName("Fading a version out makes the method serving it dead, and the message says so")
+  public void outfadingMakesAMethodDead() {
+
+    // 'oldOnly' serves version 2 only, which is now faded out
+    outfade("2");
+
+    final var message = deadMethodMessage(check());
+
+    assertTrue(message.contains("oldOnly"), message);
+    assertTrue(message.contains("faded out by 'vanillabp.adapters.c7.outfaded-versions'"), message);
+
+  }
+
+  @Test
+  @DisplayName("An outfaded version is not checked at all")
+  public void anOutfadedVersionIsSkipped() {
+
+    outfade("1");
+
+    assertEquals(List.of(), check());
+
+  }
+
+  @Test
+  @DisplayName("Workflows on an outfaded version are FATAL, and the policy decides whether the boot survives")
+  public void workflowsOnAnOutfadedVersionAreReported() {
+
+    outfade("<3");
+    catalog.instancesPerVersion = Map.of("1", 2L, "2", 3L);
+
+    final var errors = check(Level.ERROR);
+
+    assertEquals(2, errors.size(), errors.toString());
+    assertTrue(errors.get(0).contains("2 workflow(s) still run on version '1'"), errors.get(0));
+    assertTrue(errors.get(0).contains("outfaded-versions-in-use"), errors.get(0));
+
+    properties
+        .getAdapters()
+        .get(ADAPTER)
+        .setOutfadedVersionsInUse(OutfadedVersionsInUsePolicy.FAIL);
+    final var failure = assertThrows(IllegalStateException.class, this::runCheck);
+    assertTrue(failure.getMessage().contains("still run on version"), failure.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("Fading out the version this boot deployed fails the start")
+  public void outfadingTheDeployedVersionFailsTheBoot() {
+
+    outfade("<=3");
+
+    final var failure = assertThrows(IllegalStateException.class, this::runCheck);
+
+    assertTrue(failure.getMessage().contains("deployed during this boot"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("'<=3'"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("'<3'"), failure.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("A BPMS which cannot read old models says so once")
+  public void aBpmsWhichCannotReadModelsIsReportedOnce() {
+
+    catalog.canReadModels = false;
+
+    final var first = check();
+    final var second = check();
+
+    assertEquals(1, first.size(), first.toString());
+    assertTrue(first.get(0).contains("cannot read the models"), first.get(0));
+    assertEquals(List.of(), second, "the same adapter does not repeat itself");
+
+  }
+
+  @Test
+  @DisplayName("A BPMS which cannot count workflows keeps outfading and says why")
+  public void aBpmsWhichCannotCountInstancesKeepsOutfading() {
+
+    outfade("1");
+    catalog.canCountInstances = false;
+
+    final var messages = check();
+
+    assertEquals(1, messages.size(), messages.toString());
+    assertTrue(messages.get(0).contains("cannot say how many workflows"), messages.get(0));
+    assertTrue(messages.get(0).contains("stay faded out"), messages.get(0));
+
+  }
+
+  @Test
+  @DisplayName("A broken specification names the grammar")
+  public void aBrokenSpecificationIsReportedWithTheGrammar() {
+
+    outfade(">");
+
+    final var failure = assertThrows(IllegalStateException.class, this::runCheck);
+
+    assertTrue(failure.getMessage().contains("Unsupported version specification"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("outfaded-versions"), failure.getMessage());
+
+  }
+
+  /**
+   * The registry needs a process service to register a workflow service; nothing of
+   * this story invokes it.
+   */
+  @SuppressWarnings("unchecked")
+  private static io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService<Aggregate> processService() {
+
+    final var processService = org.mockito.Mockito
+        .mock(io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService.class);
+    org.mockito.Mockito
+        .when(processService.getWorkflowAggregateClass())
+        .thenReturn((Class) Aggregate.class);
+    return processService;
+
+  }
+
+  /**
+   * The one message about a method which never runs - the same check also reports the
+   * unserved tasks of the versions that method left behind.
+   */
+  private static String deadMethodMessage(
+      final List<String> messages) {
+
+    return messages
+        .stream()
+        .filter(message -> message.contains("the method never runs"))
+        .reduce((
+            first,
+            second) -> {
+          throw new AssertionError("more than one dead method reported: "
+              + messages);
+        })
+        .orElseThrow(() -> new AssertionError("no dead method reported: "
+            + messages));
+
+  }
+
+  private void outfade(
+      final String... specifications) {
+
+    properties
+        .getAdapters()
+        .get(ADAPTER)
+        .setOutfadedVersions(List.of(specifications));
+
+  }
+
+  private String checkedProcess = PROCESS;
+
+  private void runCheck() {
+
+    deployedVersionsCheck.check(MODULE, checkedProcess, ADAPTER, catalog, VersionRange.NO_RESOLVER);
+
+  }
+
+  private List<String> check() {
+
+    return check(Level.WARN);
+
+  }
+
+  private List<String> check(
+      final Level level) {
+
+    return check(level, PROCESS);
+
+  }
+
+  private List<String> check(
+      final Level level,
+      final String bpmnProcessId) {
+
+    checkedProcess = bpmnProcessId;
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+        .getLogger(DeployedProcessVersionsCheck.class);
+    logger.addAppender(logWatcher);
+    try {
+      runCheck();
+    } finally {
+      logger.detachAndStopAllAppenders();
+    }
+    return logWatcher.list
+        .stream()
+        .filter(event -> event.getLevel().isGreaterOrEqual(level))
+        .map(event -> event.getFormattedMessage())
+        .toList();
+
+  }
+
+  /**
+   * The transaction runner is irrelevant here - nothing of this story runs a handler.
+   */
+  private static class TransactionRunnerStub implements TransactionRunner {
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+
+      return work.get();
+
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+
+      return work.get();
+
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+
+      return false;
+
+    }
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/ProcessVersionCatalog.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/version/ProcessVersionCatalog.java
@@ -53,4 +53,55 @@ public interface ProcessVersionCatalog {
       String bpmnProcessId,
       String versionOrVersionTag);
 
+  /**
+   * The tasks of ONE deployed version of a BPMN process, read from the model the BPMS
+   * still holds - what the startup check of story 57 needs to tell whether the
+   * application still serves an older version. The specs are built exactly like the
+   * ones handed to
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#validateTaskWiring},
+   * so both directions of the wiring speak about the same thing.
+   * <p>
+   * Reading a model is BPMS-specific and not every BPMS can do it: an adapter which
+   * cannot returns <code>null</code>, which switches the check off for that adapter
+   * instead of pretending the version is fine. An adapter which CAN read models but
+   * finds nothing for that version returns an empty collection.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param version The version identifier the BPMS reported
+   * @return The tasks of that version, or <code>null</code> if this BPMS cannot say
+   */
+  default java.util.Collection<io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec> tasksOfVersion(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version) {
+
+    return null;
+
+  }
+
+  /**
+   * How many workflows still run on ONE deployed version - what decides whether an
+   * unserved task definition of that version is a warning or a defect, and whether
+   * outfading it (<code>outfaded-versions</code>) leaves workflows behind.
+   * <p>
+   * A BPMS which cannot be asked returns <code>null</code>, and the core says so once
+   * with a guiding message rather than turning an unanswerable question into a boot
+   * failure.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param version The version identifier the BPMS reported
+   * @return The number of active workflows of that version, or <code>null</code> if
+   *         this BPMS cannot say
+   */
+  default Long activeInstanceCountOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version) {
+
+    return null;
+
+  }
+
 }

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -260,4 +260,27 @@ public interface WorkflowTaskInvoker {
 
   }
 
+  /**
+   * The version the BPMS assigned to the model THIS boot deployed, reported by the
+   * adapter right after its deployment (story 57). It tells the core two things it
+   * cannot know otherwise: which versions of that process are OLDER, so the startup
+   * check knows what to look at, and which version must never be covered by
+   * <code>outfaded-versions</code> - fading out the version the application just
+   * deployed is a configuration error, and the boot says so.
+   * <p>
+   * An adapter whose BPMS counts no versions reports nothing, which switches both off.
+   *
+   * @param adapterId The adapter ID
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param version The version identifier the BPMS assigned, or <code>null</code>
+   */
+  default void registerDeployedVersion(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String version) {
+
+  }
+
 }

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -11,6 +11,7 @@ import io.quarkus.runtime.annotations.StaticInitSafe;
 import io.smallrye.config.ConfigMapping;
 import io.smallrye.config.WithDefault;
 import io.vanillabp.integration.adapter.migration.config.DeploymentFailurePolicy;
+import io.vanillabp.integration.adapter.migration.config.OutfadedVersionsInUsePolicy;
 
 /**
  * Properties common to all adapters.
@@ -142,6 +143,25 @@ public interface QuarkusMigrationAdapterProperties {
      */
     Optional<Boolean> deduplicateDeliveries();
 
+    /**
+     * The versions of a BPMN process this application does not serve any more (story
+     * 57), each written in the grammar of the <code>version</code> attribute of
+     * <code>&#64;WorkflowTask</code> and its siblings (<code>&lt;4</code>,
+     * <code>1-3</code>, <code>v1.0..v2.0</code>, a version tag). Adapter-scoped: the
+     * most specific configured level wins (workflow &gt; workflow module &gt; adapter).
+     *
+     * @return The outfaded versions
+     */
+    Optional<List<String>> outfadedVersions();
+
+    /**
+     * What happens when workflows still run on an outfaded version: <code>log</code>
+     * (the default, a FATAL message) or <code>fail</code> (the boot aborts).
+     *
+     * @return The policy
+     */
+    Optional<OutfadedVersionsInUsePolicy> outfadedVersionsInUse();
+
   }
 
   /**
@@ -190,6 +210,25 @@ public interface QuarkusMigrationAdapterProperties {
      * @return Whether deliveries are deduplicated
      */
     Optional<Boolean> deduplicateDeliveries();
+
+    /**
+     * The versions of a BPMN process this application does not serve any more (story
+     * 57), each written in the grammar of the <code>version</code> attribute of
+     * <code>&#64;WorkflowTask</code> and its siblings (<code>&lt;4</code>,
+     * <code>1-3</code>, <code>v1.0..v2.0</code>, a version tag). Adapter-scoped: the
+     * most specific configured level wins (workflow &gt; workflow module &gt; adapter).
+     *
+     * @return The outfaded versions
+     */
+    Optional<List<String>> outfadedVersions();
+
+    /**
+     * What happens when workflows still run on an outfaded version: <code>log</code>
+     * (the default, a FATAL message) or <code>fail</code> (the boot aborts).
+     *
+     * @return The policy
+     */
+    Optional<OutfadedVersionsInUsePolicy> outfadedVersionsInUse();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
@@ -66,9 +66,11 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
   WorkflowAdapterCacheProperties toCore(
       QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCacheProperties);
 
+  @Mapping(target = "outfadedVersions", qualifiedByName = "unwrapOutfadedVersions")
   AdapterConfigProperties toCore(
       QuarkusMigrationAdapterProperties.AdapterConfiguration adapterConfiguration);
 
+  @Mapping(target = "outfadedVersions", qualifiedByName = "unwrapOutfadedVersions")
   AdapterProperties toCore(
       QuarkusMigrationAdapterProperties.AdapterProperties adapterProperties);
 
@@ -120,6 +122,25 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
       final Optional<String> value) {
 
     return value.orElse(null);
+
+  }
+
+  /**
+   * Unwraps the outfaded versions ({@code Optional.empty()} becomes {@code null}, not
+   * an empty list): the core walks the levels of an adapter-scoped property and takes
+   * the first one which configured something, so "nothing here" has to stay null.
+   *
+   * @param value The optional list
+   * @return The unwrapped list or {@code null}
+   */
+  @Named("unwrapOutfadedVersions")
+  default List<String> unwrapOutfadedVersions(
+      final Optional<List<String>> value) {
+
+    return value
+        .filter(versions -> !versions.isEmpty())
+        .map(List::copyOf)
+        .orElse(null);
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/WorkflowTaskRegistryProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/WorkflowTaskRegistryProducer.java
@@ -39,11 +39,12 @@ public class WorkflowTaskRegistryProducer {
   @Unremovable
   public WorkflowTaskRegistry workflowTaskRegistry(
       final jakarta.transaction.TransactionSynchronizationRegistry transactionRegistry,
-      final SpringTransactionSupport springTransactionSupport) {
+      final SpringTransactionSupport springTransactionSupport,
+      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
 
     return new WorkflowTaskRegistry(
         new QuarkusTransactionRunner(transactionRegistry), aggregateSync, QuarkusTransactionAnnotations
-            .specs(springTransactionSupport.honored()));
+            .specs(springTransactionSupport.honored()), properties);
 
   }
 

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import io.smallrye.config.SmallRyeConfigBuilder;
 import io.vanillabp.integration.adapter.migration.config.DeploymentFailurePolicy;
+import io.vanillabp.integration.adapter.migration.config.OutfadedVersionsInUsePolicy;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
@@ -38,14 +39,18 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                       Optional<String> resourcesLocation,
                                       Optional<io.vanillabp.integration.adapter.spi.NameClashAvoidance> nameClashAvoidance,
                                       Optional<Boolean> prefixTaskDefinitionsPerProcess,
-                                      Optional<Boolean> deduplicateDeliveries) implements QuarkusMigrationAdapterProperties.AdapterConfiguration {
+                                      Optional<Boolean> deduplicateDeliveries,
+                                      Optional<List<String>> outfadedVersions,
+                                      Optional<OutfadedVersionsInUsePolicy> outfadedVersionsInUse) implements QuarkusMigrationAdapterProperties.AdapterConfiguration {
   }
 
   private record AdapterProperties(
                                    Optional<String> resourcesLocation,
                                    Optional<io.vanillabp.integration.adapter.spi.NameClashAvoidance> nameClashAvoidance,
                                    Optional<Boolean> prefixTaskDefinitionsPerProcess,
-                                   Optional<Boolean> deduplicateDeliveries) implements QuarkusMigrationAdapterProperties.AdapterProperties {
+                                   Optional<Boolean> deduplicateDeliveries,
+                                   Optional<List<String>> outfadedVersions,
+                                   Optional<OutfadedVersionsInUsePolicy> outfadedVersionsInUse) implements QuarkusMigrationAdapterProperties.AdapterProperties {
   }
 
   private record TaskProperties(
@@ -108,38 +113,48 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                 Optional.of("camunda8"), Optional.of(DeploymentFailurePolicy.WARN), Optional
                     .of("adapter-level"), Optional
                         .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.USE_PREFIX), Optional
-                            .of(false), Optional.of(false)),
+                            .of(false), Optional.of(false), Optional.of(List.of("<3")), Optional
+                                .of(OutfadedVersionsInUsePolicy.FAIL)),
             "c7", new AdapterConfiguration(
                 Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional.empty(), Optional
-                    .empty())), Map.of(
+                    .empty(), Optional.empty(), Optional.empty())), Map.of(
                         "loan-approval", new WorkflowModuleProperties(
                             Optional.of(List.of("c7")), Map.of("c7",
                                 new AdapterProperties(Optional.of("classpath:c7-bpmn"), Optional
                                     .of(io.vanillabp.integration.adapter.spi.NameClashAvoidance.NONE), Optional
-                                        .empty(), Optional.empty())), Map
-                                            .of("LoanApproval",
-                                                new WorkflowProperties(
-                                                    Optional.of(List.of("c8-cloud")), Map
-                                                        .of("c8-cloud", new AdapterProperties(Optional
-                                                            .of("workflow-level"), Optional
-                                                                .empty(), Optional.of(true), Optional.of(true))), Map
-                                                                    .of("assessRisk", new TaskProperties(Map
-                                                                        .of("c8-cloud", new AdapterProperties(Optional
-                                                                            .of("task-level"), Optional
-                                                                                .empty(), Optional
-                                                                                    .empty(), Optional
-                                                                                        .of(false))))))))), new OutboxProperties(
-                                                                                            Duration
-                                                                                                .ofSeconds(1), Duration
-                                                                                                    .ofSeconds(
-                                                                                                        2), 3, false, Duration
-                                                                                                            .ofDays(
-                                                                                                                1), new JdbcOutboxProperties(false, Optional
-                                                                                                                    .of("HOT_OUTBOX")), new MongoOutboxProperties(
-                                                                                                                        false, "hot-outbox")), new WorkflowAdapterCacheProperties(
-                                                                                                                            50_000, Duration
-                                                                                                                                .ofMinutes(
-                                                                                                                                    30)));
+                                        .empty(), Optional.empty(), Optional.empty(), Optional
+                                            .empty())), Map
+                                                .of("LoanApproval",
+                                                    new WorkflowProperties(
+                                                        Optional.of(List.of("c8-cloud")), Map
+                                                            .of("c8-cloud", new AdapterProperties(Optional
+                                                                .of("workflow-level"), Optional
+                                                                    .empty(), Optional.of(true), Optional
+                                                                        .of(true), Optional
+                                                                            .of(List.of("1-2", "legacy")), Optional
+                                                                                .empty())), Map
+                                                                                    .of("assessRisk",
+                                                                                        new TaskProperties(Map
+                                                                                            .of("c8-cloud",
+                                                                                                new AdapterProperties(Optional
+                                                                                                    .of("task-level"), Optional
+                                                                                                        .empty(), Optional
+                                                                                                            .empty(), Optional
+                                                                                                                .of(false), Optional
+                                                                                                                    .empty(), Optional
+                                                                                                                        .empty())))))))), new OutboxProperties(
+                                                                                                                            Duration
+                                                                                                                                .ofSeconds(
+                                                                                                                                    1), Duration
+                                                                                                                                        .ofSeconds(
+                                                                                                                                            2), 3, false, Duration
+                                                                                                                                                .ofDays(
+                                                                                                                                                    1), new JdbcOutboxProperties(false, Optional
+                                                                                                                                                        .of("HOT_OUTBOX")), new MongoOutboxProperties(
+                                                                                                                                                            false, "hot-outbox")), new WorkflowAdapterCacheProperties(
+                                                                                                                                                                50_000, Duration
+                                                                                                                                                                    .ofMinutes(
+                                                                                                                                                                        30)));
 
     final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
 
@@ -173,6 +188,19 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
     assertEquals(
         Boolean.FALSE,
         workflow.getTasks().get("assessRisk").getAdapters().get("c8-cloud").getDeduplicateDeliveries());
+    // story 57: the outfaded versions and their policy travel the same levels; an
+    // empty Optional has to arrive as null, so the next level decides
+    assertEquals(
+        List.of("<3"),
+        core.getAdapters().get("c8-cloud").getOutfadedVersions());
+    assertEquals(
+        OutfadedVersionsInUsePolicy.FAIL,
+        core.getAdapters().get("c8-cloud").getOutfadedVersionsInUse());
+    assertEquals(
+        List.of("1-2", "legacy"),
+        workflow.getAdapters().get("c8-cloud").getOutfadedVersions());
+    assertNull(workflow.getAdapters().get("c8-cloud").getOutfadedVersionsInUse());
+    assertNull(workflow.getTasks().get("assessRisk").getAdapters().get("c8-cloud").getOutfadedVersions());
 
     assertEquals(Duration.ofSeconds(1), core.getOutbox().getPollInterval());
     assertEquals(Duration.ofSeconds(2), core.getOutbox().getAttemptFrequency());

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -363,11 +363,13 @@ public class SpringBootMigrationAdapterAutoConfiguration {
   @Bean
   public WorkflowTaskRegistry vanillaBpWorkflowTaskRegistry(
       final org.springframework.beans.factory.ObjectProvider<org.springframework.transaction.PlatformTransactionManager> transactionManager,
-      final io.vanillabp.integration.adapter.spi.WorkflowAggregateSync aggregateSync) {
+      final io.vanillabp.integration.adapter.spi.WorkflowAggregateSync aggregateSync,
+      @org.springframework.beans.factory.annotation.Qualifier(
+        BEANNAME_MIGRATIONADAPERPROPERTIES) final MigrationAdapterProperties properties) {
 
     return new WorkflowTaskRegistry(
         new SpringTransactionRunner(transactionManager), aggregateSync, io.vanillabp.integration.workflowtask.SpringTransactionAnnotations
-            .specs());
+            .specs(), properties);
 
   }
 


### PR DESCRIPTION
Story 57 (`prompts/57-old-process-versions.md`), core half. The adapter halves are camunda7-adapter, camunda8-adapter and process-engine-api-adapter on the same branch name.

**Part one, the check version 1 had.** Once per BPMN process after its module was deployed, VanillaBP looks at the versions the BPMS still holds, reads the models of the older ones and reports the task definitions no method serves any more. Without workflows on that version it is a warning; with them an error naming how many, because each of them will hit an incident at that task.

**Part two, outfading.** `vanillabp.adapters.<id>.outfaded-versions` takes the grammar of the `version` attribute, resolves per workflow module and workflow, and belongs to one adapter because every BPMS counts its own versions. Fading out the version this boot deployed stops the start; workflows on a faded-out version are FATAL and, with `outfaded-versions-in-use: FAIL`, stop it too.

**Where the work sits.** Reading a model is BPMS-specific and stays in the adapters (two `default null` methods on `ProcessVersionCatalog`); every decision and every message is here, once. Adapters additionally report the version they deployed.

**Two rules of the reverse direction changed**, and without them part one is unusable: a method whose version range excludes the deployed version needs no task in the deployed model, and the same holds for a `@WorkflowStartedByBpms` method naming a dropped start event. What those checks caught is now a warning about a method matching no held version at all, for all three annotations.

13 new core tests, the Quarkus mapper test pins the new keys, coverage 90.01 % Spring Boot / 89.64 % Quarkus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUj1bzCMbmhZYtg6u7fWD8