### PR TITLE
Say what happens when two branches write one workflow aggregate

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1280,3 +1280,38 @@ adapter-scoped and resolvable per workflow module and workflow.
 method whose version range excludes the version this boot deployed no longer has to match a
 task respectively a start event of the deployed model. It is reported as a warning if it
 matches no version the BPMS holds at all.
+
+## Story 59: two writers on one workflow aggregate (2026-08-15)
+
+**Platform integrations** implement one new method of the core's `TransactionRunner`:
+`isConcurrentModification(Throwable)` answers whether a failure is an optimistic locking
+conflict. Spring checks for `OptimisticLockingFailureException` (JPA as well as MongoDB),
+Quarkus walks the chain of causes for `jakarta.persistence.OptimisticLockException`, which
+JTA delivers wrapped in a `RollbackException`. The method has a default returning `false`,
+so a platform integration or test double which does not implement it keeps compiling and
+simply stays silent.
+
+**Adapters** gain one optional report:
+`WorkflowTaskInvoker#reportConcurrentTokenElements(workflowModuleId, bpmnProcessId,
+elementIds)`, called during `wireBpmn` with the elements which can put a second token into a
+running workflow - a non-interrupting boundary event, a parallel or inclusive gateway
+forking into several flows, a parallel multi-instance activity, a non-interrupting event
+subprocess. Element IDs, not a boolean: the message names what made VanillaBP say this. An
+adapter which cannot read models reports nothing, and the check stays silent then.
+
+**Applications** see two new messages and no new property:
+
+- a WARN per BPMN process whose model can produce concurrent tokens while its workflow
+  aggregate has no version attribute, naming the elements and the four ways out;
+- an ERROR when the commit of a transaction VanillaBP owns (a `@WorkflowTask` method, a
+  workflow the BPMS started on its own, the `@WorkflowEnded` notification) fails on a version
+  conflict.
+
+**There is no retry, deliberately.** The exception is passed on unchanged, so the BPMS
+applies its retry semantics and ends in an incident. A retry inside the framework would
+repeat whatever the handler did before the commit failed - a call to a remote API, for
+instance - while hiding that anything went wrong. Adding a retry property later is easy;
+taking a silent retry away from applications which grew used to it is not. The rule, the four
+ways an application can avoid the collision and its own duty on the other side of it are
+described by the wiki page
+[Workflow aggregates](https://github.com/vanillabp/adapter-platform-integration/wiki/Workflow-aggregates#two-writers-on-one-aggregate).

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -865,6 +865,42 @@ new model dropped. What used to be caught by those checks is caught by the dead-
 warning instead, which reports rather than fails: a version which does not exist YET is
 normal during a rolling deployment.
 
+## Two writers on one workflow aggregate (story 59)
+
+A workflow aggregate has one workflow, which reads like one writer - until the process holds
+a second token. Then one branch writes in the transaction VanillaBP owns for its task and the
+other in the transaction the application opens around its API call, and since a persistence
+layer writes the whole record, the branch committing second puts back what it read at its
+start. `blueprints/GAPS.md` G3 is where that was found.
+
+The core answers the part it owns, and only that part:
+
+- Recognizing the conflict belongs to the platform. The core is plain Java and must not know
+  `OptimisticLockingFailureException` or `jakarta.persistence.OptimisticLockException`, so
+  `TransactionRunner#isConcurrentModification(Throwable)` asks the platform, through the same
+  seam the transaction itself goes through. What is not platform-specific sits in
+  `AggregateWrite#causedByOptimisticLocking`: matching the exceptions of a persistence layer
+  along the chain of causes, by NAME.
+- One helper around the transaction, not one per call site.
+  `AggregateWrite#inTransaction` runs the work (`requireNew` or `inCurrent`), logs ONE guiding
+  ERROR if the failure is a conflict and rethrows it unchanged. It sits at every place the
+  core commits a transaction of its own: `MigrationProcessService#executeWorkflowTask`,
+  `BpmsInitiatedStartExecution` and `WorkflowEndedHandlers`. The operations an application
+  calls itself (`startWorkflow`, `correlateMessage`, `aggregateChanged`, the task operations)
+  save inside the CALLER's transaction, so their conflict surfaces in the application's own
+  commit. That one is the application's to catch, which is why the wiki says so instead of the
+  core pretending to handle it.
+- Nothing is retried. A handler may have called a remote API before the commit failed, so a
+  quiet retry would repeat that call and hide the failure at the same time. The adapter gets
+  the original exception and maps it to its BPMS' retry semantics.
+- The startup hint is split the way story 57 is split. The adapter reads its model and reports
+  the elements which can produce a second token
+  (`WorkflowTaskInvoker#reportConcurrentTokenElements`), the core decides what it means:
+  `ConcurrentTokenCheck` asks the aggregate class for a version attribute, by the SIMPLE name
+  of the annotation so JPA and Spring Data are covered without a dependency on either, and
+  warns once per BPMN process where there is none. An aggregate with a version attribute stays
+  quiet, because then the collision is the exception above instead of a lost write.
+
 ## Modules
 
 1. **business-spi:** (artifact `io.vanillabp:vanillabp-integration-spi`)<br>

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -471,9 +471,15 @@ public class MigrationProcessService<A> {
       }
     };
 
-    return context.runInCurrentTransaction()
-        ? transactionRunner.inCurrent(transactionalWork)
-        : transactionRunner.requireNew(transactionalWork);
+    return io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .inTransaction(
+            transactionRunner,
+            context.runInCurrentTransaction(),
+            workflowModuleId,
+            bpmnProcessId,
+            context.getWorkflowAggregateId(),
+            "processing task '%s'".formatted(context.getTaskDefinition()),
+            transactionalWork);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/AggregateWrite.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/AggregateWrite.java
@@ -1,0 +1,144 @@
+package io.vanillabp.integration.adapter.migration.transaction;
+
+import java.util.function.Supplier;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Runs work the core wraps in a transaction of its OWN (processing a task, building
+ * the aggregate of a workflow the BPMS started, reporting the end of a workflow) and
+ * says what a version conflict on saving the workflow aggregate means (story 59).
+ * <p>
+ * As soon as a BPMN process holds more than one token, two branches write the same
+ * workflow aggregate: one in the transaction VanillaBP owns, the other in a
+ * transaction the application opens around an API call. An aggregate carrying a
+ * version attribute turns that collision into an exception instead of a silent
+ * overwrite - and the exception surfaces at the COMMIT VanillaBP performs, where the
+ * application cannot catch it.
+ * <p>
+ * <b>VanillaBP does not retry.</b> A handler may have called a remote API before the
+ * commit failed, and a quiet retry inside the framework would repeat that call while
+ * hiding that anything went wrong. So the conflict is named by one guiding message and
+ * the exception is propagated UNCHANGED: the adapter maps it to its BPMS' retry
+ * semantics (a retry until the attempts are used up, then an incident). Where the work
+ * ran in the BPMS' own transaction ({@link TransactionRunner#inCurrent(Supplier)},
+ * Camunda 7 embedded) the engine owns the commit and VanillaBP never sees the
+ * conflict at all.
+ */
+public final class AggregateWrite {
+
+  private static final Logger log = LoggerFactory.getLogger(AggregateWrite.class);
+
+  private AggregateWrite() {
+  }
+
+  /**
+   * Runs the given work in a transaction and reports a version conflict on the way
+   * out.
+   *
+   * @param <T> The result type
+   * @param transactionRunner The platform's transaction runner, which also
+   *          classifies the failure (only the platform knows its exceptions)
+   * @param inCurrentTransaction Whether to join the caller's transaction instead of
+   *          starting a new one
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowAggregateId The workflow aggregate's ID
+   * @param operation What was going on, in a form fitting "... failed": e.g.
+   *          "processing task 'approve'"
+   * @param work The work to run
+   * @return The work's result
+   */
+  public static <T> T inTransaction(
+      final TransactionRunner transactionRunner,
+      final boolean inCurrentTransaction,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Object workflowAggregateId,
+      final String operation,
+      final Supplier<T> work) {
+
+    try {
+      return inCurrentTransaction
+          ? transactionRunner.inCurrent(work)
+          : transactionRunner.requireNew(work);
+    } catch (final RuntimeException failure) {
+      if (transactionRunner.isConcurrentModification(failure)) {
+        log
+            .error(
+                """
+                    {} of workflow aggregate '{}' (BPMN process '{}' of workflow module '{}') failed \
+                    on a version conflict: another writer changed that aggregate meanwhile, so \
+                    nothing this run changed was saved. VanillaBP does not retry - the BPMS decides \
+                    what happens next (its retries, and an incident once they are used up), and a \
+                    repeated run repeats everything the method did outside the transaction as well. \
+                    Two writers appear as soon as a workflow has more than one token (e.g. a \
+                    non-interrupting boundary event) or the application changes the aggregate \
+                    through its own API while the workflow runs. The wiki page 'Workflow \
+                    aggregates' describes the four ways to avoid the collision.""",
+                capitalized(operation),
+                workflowAggregateId == null
+                    ? "not assigned yet"
+                    : workflowAggregateId,
+                bpmnProcessId,
+                workflowModuleId);
+      }
+      throw failure;
+    }
+
+  }
+
+  /**
+   * The exceptions a persistence layer raises on a version conflict, matched by NAME
+   * along the chain of causes - a service both platform implementations of
+   * {@link TransactionRunner#isConcurrentModification(Throwable)} use for the part
+   * which is not platform-specific at all: JPA reports
+   * <code>jakarta.persistence.OptimisticLockException</code> whether it runs under
+   * Spring or under JTA, and Hibernate's own
+   * <code>org.hibernate.StaleObjectStateException</code> travels as its cause.
+   * <p>
+   * Names instead of types, because the core is plain Java: it must not gain a
+   * dependency on JPA, Hibernate or MongoDB to recognize their exceptions.
+   *
+   * @param failure The exception the transactional work or its commit produced
+   * @return Whether a version conflict is somewhere in the chain of causes
+   */
+  public static boolean causedByOptimisticLocking(
+      final Throwable failure) {
+
+    var candidate = failure;
+    while (candidate != null) {
+      final var name = candidate
+          .getClass()
+          .getName();
+      if (OPTIMISTIC_LOCKING_EXCEPTIONS.contains(name)) {
+        return true;
+      }
+      candidate = candidate.getCause() == candidate
+          ? null
+          : candidate.getCause();
+    }
+    return false;
+
+  }
+
+  private static final java.util.Set<String> OPTIMISTIC_LOCKING_EXCEPTIONS = java.util.Set
+      .of(
+          "jakarta.persistence.OptimisticLockException",
+          "javax.persistence.OptimisticLockException",
+          "org.hibernate.StaleObjectStateException",
+          "org.hibernate.StaleStateException",
+          "io.quarkus.mongodb.panache.common.exception.OptimisticLockException");
+
+  private static String capitalized(
+      final String operation) {
+
+    if ((operation == null) || operation.isEmpty()) {
+      return "Saving";
+    }
+    return Character.toUpperCase(operation.charAt(0)) + operation.substring(1);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/ConcurrentTokenCheck.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/ConcurrentTokenCheck.java
@@ -1,0 +1,145 @@
+package io.vanillabp.integration.adapter.migration.transaction;
+
+import java.lang.reflect.AnnotatedElement;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The startup hint about two writers on one workflow aggregate (story 59): a BPMN
+ * process which can hold more than one token at a time has branches writing the same
+ * workflow aggregate, and without a version attribute the branch committing second
+ * writes back what it read when it started - silently, since an ORM saves the whole
+ * record.
+ * <p>
+ * Reading a model is the adapter's job (only it can parse its BPMN dialect), deciding
+ * what the finding means is the core's: the adapter reports the elements which can put
+ * a second token into a running workflow, and the core knows the aggregate class.
+ * <p>
+ * A version attribute silences the hint - the collision then raises an exception
+ * instead of overwriting, which is what {@link AggregateWrite} reports. So does an
+ * adapter which cannot read its models (the Process-Engine-API): it reports nothing,
+ * and nothing is guessed from the absence.
+ */
+public class ConcurrentTokenCheck {
+
+  private static final Logger log = LoggerFactory.getLogger(ConcurrentTokenCheck.class);
+
+  /**
+   * The annotations marking the attribute a persistence layer increments per write,
+   * matched by NAME: the core is plain Java and must not gain a dependency on JPA or
+   * Spring Data. Every persistence layer VanillaBP supports calls it
+   * <code>Version</code> (<code>jakarta.persistence</code>,
+   * <code>org.springframework.data.annotation</code>), so the SIMPLE name decides -
+   * an unknown persistence layer following the same convention is recognized as well,
+   * and the outcome of a false positive is a hint not given.
+   */
+  private static final String VERSION_ANNOTATION = "Version";
+
+
+  /**
+   * The (workflow module, BPMN process) pairs already reported - the hint is a design
+   * message, not a linter running per deployed file.
+   */
+  private final Set<String> reported = java.util.concurrent.ConcurrentHashMap.newKeySet();
+
+  /**
+   * Reports the elements an adapter found in a BPMN process which can put a second
+   * token into a running workflow, and warns if that process' workflow aggregate has
+   * no version attribute.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @param elementIds The BPMN element IDs producing the second token
+   */
+  public void reportConcurrentTokenElements(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Class<?> workflowAggregateClass,
+      final Collection<String> elementIds) {
+
+    if ((elementIds == null) || elementIds.isEmpty() || (workflowAggregateClass == null)) {
+      return;
+    }
+    if (hasVersionAttribute(workflowAggregateClass)) {
+      return;
+    }
+    if (!reported.add(workflowModuleId
+        + "#"
+        + bpmnProcessId)) {
+      return;
+    }
+
+    log
+        .warn(
+            """
+                The BPMN process '{}' of workflow module '{}' can hold more than one token at a time \
+                ({}), but its workflow aggregate '{}' has no version attribute (@Version): two \
+                branches load the aggregate, change different things and save it - and since the \
+                persistence layer writes the whole record, whatever the branch committing first \
+                changed is lost without any error. Ways out: one entity per phase of the workflow, \
+                @DynamicUpdate where the branches write different attributes, a version attribute \
+                plus a retry in the transaction your application opens, or an additive relation \
+                instead of a mutated attribute. The wiki page 'Workflow aggregates' compares them. \
+                A version attribute turns the collision into an exception VanillaBP reports and the \
+                BPMS retries, which is why this message is about its absence.""",
+            bpmnProcessId,
+            workflowModuleId,
+            elementIds
+                .stream()
+                .distinct()
+                .sorted()
+                .collect(Collectors.joining("', '", "e.g. '", "'")),
+            workflowAggregateClass.getName());
+
+  }
+
+  /**
+   * Whether the given class or one of its super classes declares an attribute the
+   * persistence layer uses for optimistic locking - answered by the NAMES of the
+   * annotations (JPA, Spring Data), so the core stays free of both.
+   *
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @return Whether a version attribute was found
+   */
+  public static boolean hasVersionAttribute(
+      final Class<?> workflowAggregateClass) {
+
+    var type = workflowAggregateClass;
+    while ((type != null) && (type != Object.class)) {
+      final var annotated = java.util.stream.Stream
+          .concat(
+              java.util.Arrays.stream(type.getDeclaredFields()),
+              java.util.Arrays.stream(type.getDeclaredMethods()))
+          .map(AnnotatedElement.class::cast)
+          .toList();
+      if (annotated
+          .stream()
+          .anyMatch(ConcurrentTokenCheck::isVersionAnnotated)) {
+        return true;
+      }
+      type = type.getSuperclass();
+    }
+    return false;
+
+  }
+
+  private static boolean isVersionAnnotated(
+      final AnnotatedElement element) {
+
+    return List
+        .of(element.getAnnotations())
+        .stream()
+        .map(annotation -> annotation
+            .annotationType()
+            .getSimpleName())
+        .anyMatch(VERSION_ANNOTATION::equals);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/TransactionRunner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/TransactionRunner.java
@@ -53,4 +53,30 @@ public interface TransactionRunner {
    */
   boolean isRollbackOnly();
 
+  /**
+   * Whether the given failure says that the workflow aggregate was changed by
+   * another writer in between (an optimistic locking conflict on an aggregate
+   * carrying a version attribute). Only the platform can tell: Spring reports it as
+   * <code>OptimisticLockingFailureException</code> (JPA as well as MongoDB), JTA on
+   * Quarkus wraps <code>jakarta.persistence.OptimisticLockException</code> in a
+   * <code>RollbackException</code>. Implementations unwrap the causes, because both
+   * platforms wrap.
+   * <p>
+   * The answer decides whether the guiding message of
+   * {@link AggregateWrite} is logged - nothing else: the exception is propagated
+   * unchanged either way, VanillaBP never retries a conflict itself.
+   *
+   * @param failure The exception the transactional work or its commit produced
+   * @return Whether it is a version conflict; <code>false</code> if the platform
+   *         cannot tell
+   */
+  default boolean isConcurrentModification(
+      final Throwable failure) {
+
+    // a platform which does not classify silences the message rather than inventing
+    // an answer - test doubles of this interface are the typical case
+    return false;
+
+  }
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -304,11 +304,15 @@ public class WorkflowEndedHandlers {
       return null;
     };
 
-    if (context.runInCurrentTransaction()) {
-      transactionRunner.inCurrent(transactionalWork);
-    } else {
-      transactionRunner.requireNew(transactionalWork);
-    }
+    io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .inTransaction(
+            transactionRunner,
+            context.runInCurrentTransaction(),
+            processService.getWorkflowModuleId(),
+            processService.getBpmnProcessId(),
+            context.getWorkflowAggregateId(),
+            "reporting the end of the workflow",
+            transactionalWork);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartExecution.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowstart/BpmsInitiatedStartExecution.java
@@ -47,9 +47,15 @@ public final class BpmsInitiatedStartExecution {
         handler,
         context);
 
-    return context.runInCurrentTransaction()
-        ? transactionRunner.inCurrent(transactionalWork)
-        : transactionRunner.requireNew(transactionalWork);
+    return io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .inTransaction(
+            transactionRunner,
+            context.runInCurrentTransaction(),
+            processService.getWorkflowModuleId(),
+            processService.getBpmnProcessId(),
+            context.getNaturalIdentity(),
+            "the BPMS-initiated start at start event '%s'".formatted(context.getStartEventId()),
+            transactionalWork);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -120,6 +120,12 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
   private final List<String> rollbackRuleRemedies;
 
   /**
+   * The hint about BPMN processes producing concurrent tokens while their workflow
+   * aggregate has no version attribute (story 59).
+   */
+  private final io.vanillabp.integration.adapter.migration.transaction.ConcurrentTokenCheck concurrentTokenCheck = new io.vanillabp.integration.adapter.migration.transaction.ConcurrentTokenCheck();
+
+  /**
    * The process versions this application declares obsolete (story 57).
    */
   private final OutfadedProcessVersions outfadedVersions;
@@ -307,6 +313,27 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
       final String second) {
 
     return (first != null) && first.equals(second);
+
+  }
+
+  @Override
+  public void reportConcurrentTokenElements(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Collection<String> elementIds) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((entry == null) || (entry.processService == null)) {
+      // a process no @WorkflowService class serves is reported by the wiring
+      // validation already - there is no aggregate class to ask here
+      return;
+    }
+    concurrentTokenCheck
+        .reportConcurrentTokenElements(
+            workflowModuleId,
+            bpmnProcessId,
+            entry.processService.getWorkflowAggregateClass(),
+            elementIds);
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/transaction/AggregateWriteConflictTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/transaction/AggregateWriteConflictTest.java
@@ -1,0 +1,440 @@
+package io.vanillabp.migration.test.transaction;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.transaction.AggregateWrite;
+import io.vanillabp.integration.adapter.migration.transaction.ConcurrentTokenCheck;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * Story 59: two branches of one workflow write the same workflow aggregate. What is
+ * pinned here is the CORE's part of it:
+ * <ul>
+ * <li>a version conflict on the commit VanillaBP owns is recognized by asking the
+ * platform, named by one guiding message and then propagated UNCHANGED - nothing is
+ * retried, the BPMS decides what happens next;</li>
+ * <li>a failure the platform does not classify as a conflict passes without any
+ * message;</li>
+ * <li>elements which can produce a second token are warned about while wiring - once
+ * per BPMN process, and only where the aggregate has no version attribute, since a
+ * version attribute turns the silent overwrite into the exception above.</li>
+ * </ul>
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregateWriteConflictTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String TASK = "task";
+
+  /**
+   * Stands in for <code>jakarta.persistence.Version</code> respectively
+   * <code>org.springframework.data.annotation.Version</code>, which the core must not
+   * depend on - it recognizes them by their name.
+   */
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({
+      ElementType.FIELD, ElementType.METHOD
+  })
+  public @interface Version {
+  }
+
+  public static class Aggregate {
+
+    String id;
+
+    int invocations;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  public static class VersionedAggregate extends Aggregate {
+
+    @Version
+    long version;
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  /**
+   * A platform whose commit fails: the work runs, and what the commit produces is
+   * thrown at the caller of the runner - which is where a version conflict of a
+   * persistence layer appears.
+   */
+  static class FailingCommitTransactionRunner implements TransactionRunner {
+
+    private final RuntimeException commitFailure;
+
+    private final boolean classifyAsConflict;
+
+    int classifierAsked = 0;
+
+    FailingCommitTransactionRunner(
+        final RuntimeException commitFailure,
+        final boolean classifyAsConflict) {
+      this.commitFailure = commitFailure;
+      this.classifyAsConflict = classifyAsConflict;
+    }
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      work.get();
+      throw commitFailure;
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+    @Override
+    public boolean isConcurrentModification(
+        final Throwable failure) {
+      ++classifierAsked;
+      return classifyAsConflict;
+    }
+
+  }
+
+  public static class Service {
+
+    @WorkflowTask(taskDefinition = TASK)
+    public void task(
+        final Aggregate aggregate) {
+
+      ++aggregate.invocations;
+
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  @Test
+  @DisplayName("A version conflict is named once and the exception reaches the adapter unchanged")
+  public void conflictIsReportedAndPropagated() {
+
+    final var conflict = new IllegalStateException("Row was updated by another transaction");
+    final var transactionRunner = new FailingCommitTransactionRunner(conflict, true);
+    final var registry = registry(transactionRunner);
+    final var aggregate = storeAggregate("aggregate-1");
+
+    final var messages = new java.util.ArrayList<String>();
+    final var thrown = assertThrows(
+        IllegalStateException.class,
+        () -> loggedBy(
+            AggregateWrite.class,
+            messages,
+            () -> registry.invokeWorkflowTask(MODULE, PROCESS, context("aggregate-1"))));
+
+    // the exception is NOT wrapped: adapters map it to their BPMS' retry semantics
+    assertSame(conflict, thrown);
+    assertEquals(1, transactionRunner.classifierAsked);
+    // no retry inside VanillaBP - the handler ran exactly once
+    assertEquals(1, aggregate.invocations);
+    assertEquals(1, messages.size());
+    final var message = messages.getFirst();
+    assertTrue(message.contains(MODULE), message);
+    assertTrue(message.contains(PROCESS), message);
+    assertTrue(message.contains("aggregate-1"), message);
+    assertTrue(message.contains(TASK), message);
+    assertTrue(message.contains("does not retry"), message);
+    assertTrue(message.contains("Workflow aggregates"), message);
+
+  }
+
+  @Test
+  @DisplayName("A failure which is no version conflict passes without a message")
+  public void otherFailuresArePassedThroughSilently() {
+
+    final var failure = new IllegalArgumentException("something else");
+    final var transactionRunner = new FailingCommitTransactionRunner(failure, false);
+    final var registry = registry(transactionRunner);
+    storeAggregate("aggregate-2");
+
+    final var messages = new java.util.ArrayList<String>();
+    final var thrown = assertThrows(
+        IllegalArgumentException.class,
+        () -> loggedBy(
+            AggregateWrite.class,
+            messages,
+            () -> registry.invokeWorkflowTask(MODULE, PROCESS, context("aggregate-2"))));
+
+    assertSame(failure, thrown);
+    assertEquals(1, transactionRunner.classifierAsked);
+    assertTrue(messages.isEmpty(), messages.toString());
+
+  }
+
+  @Test
+  @DisplayName("A platform which does not classify keeps quiet instead of guessing")
+  public void aPlatformWithoutAClassifierStaysSilent() {
+
+    final var runner = new TransactionRunner() {
+
+      @Override
+      public <T> T requireNew(
+          final Supplier<T> work) {
+        return work.get();
+      }
+
+      @Override
+      public <T> T inCurrent(
+          final Supplier<T> work) {
+        return work.get();
+      }
+
+      @Override
+      public boolean isRollbackOnly() {
+        return false;
+      }
+
+    };
+
+    assertFalse(runner.isConcurrentModification(new IllegalStateException("conflict")));
+
+  }
+
+  @Test
+  @DisplayName("Reported concurrent tokens warn about an aggregate without a version attribute")
+  public void concurrentTokensWithoutVersionAttributeAreWarnedAbout() {
+
+    final var registry = registry(new FailingCommitTransactionRunner(new IllegalStateException(), false));
+
+    final var messages = new java.util.ArrayList<String>();
+    loggedBy(
+        ConcurrentTokenCheck.class,
+        messages,
+        () -> registry
+            .reportConcurrentTokenElements(MODULE, PROCESS, List.of("Event_Reminder", "Gateway_Fork")));
+
+    assertEquals(1, messages.size());
+    final var message = messages.getFirst();
+    assertTrue(message.contains("Event_Reminder"), message);
+    assertTrue(message.contains("Gateway_Fork"), message);
+    assertTrue(message.contains(Aggregate.class.getName()), message);
+    assertTrue(message.contains("@DynamicUpdate"), message);
+    assertTrue(message.contains("Workflow aggregates"), message);
+
+  }
+
+  @Test
+  @DisplayName("The warning is given once per BPMN process, no matter how often an adapter reports")
+  public void theWarningIsGivenOncePerProcess() {
+
+    final var registry = registry(new FailingCommitTransactionRunner(new IllegalStateException(), false));
+
+    final var messages = new java.util.ArrayList<String>();
+    loggedBy(
+        ConcurrentTokenCheck.class,
+        messages,
+        () -> {
+          registry.reportConcurrentTokenElements(MODULE, PROCESS, List.of("Event_Reminder"));
+          registry.reportConcurrentTokenElements(MODULE, PROCESS, List.of("Event_Reminder"));
+        });
+
+    assertEquals(1, messages.size());
+
+  }
+
+  @Test
+  @DisplayName("An aggregate carrying a version attribute stays quiet, and so does a silent adapter")
+  public void nothingIsWarnedAboutWhereThereIsNothingToSay() {
+
+    final var registry = registry(new FailingCommitTransactionRunner(new IllegalStateException(), false));
+
+    final var messages = new java.util.ArrayList<String>();
+    loggedBy(
+        ConcurrentTokenCheck.class,
+        messages,
+        () -> {
+          // an adapter which cannot read models reports nothing
+          registry.reportConcurrentTokenElements(MODULE, PROCESS, List.of());
+          // a BPMN process no workflow service serves (reported by the wiring check)
+          registry.reportConcurrentTokenElements(MODULE, "UnknownProcess", List.of("Gateway_Fork"));
+        });
+
+    assertTrue(messages.isEmpty(), messages.toString());
+    // the version attribute of a super class counts as well
+    assertTrue(ConcurrentTokenCheck.hasVersionAttribute(VersionedAggregate.class));
+    assertFalse(ConcurrentTokenCheck.hasVersionAttribute(Aggregate.class));
+
+  }
+
+  @Test
+  @DisplayName("The exceptions of a version conflict are recognized along the chain of causes")
+  public void optimisticLockingIsRecognizedByName() {
+
+    assertTrue(
+        AggregateWrite
+            .causedByOptimisticLocking(
+                new IllegalStateException(
+                    "commit failed", new jakarta.persistence.OptimisticLockException("Row 4711"))));
+    assertFalse(AggregateWrite.causedByOptimisticLocking(new IllegalStateException("something else")));
+    assertFalse(AggregateWrite.causedByOptimisticLocking(null));
+
+  }
+
+  private MigrationProcessService<Aggregate> processService() {
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of("test-adapter", AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of("test-adapter"))
+        .build();
+    properties.validateAndLink();
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn("test-adapter");
+
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null);
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final TransactionRunner transactionRunner) {
+
+    final var registry = new WorkflowTaskRegistry(transactionRunner);
+    registry
+        .registerWorkflowService(MODULE, PROCESS, Service.class, Service::new, type -> null, processService());
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  private TaskInvocationContext context(
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return TASK;
+      }
+
+    };
+
+  }
+
+  /**
+   * Collects the messages the given class logged at WARN or above while the work ran
+   * ("normal" logging is switched off during tests).
+   */
+  private void loggedBy(
+      final Class<?> loggingClass,
+      final List<String> messages,
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggingClass);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAndStopAllAppenders();
+      logWatcher.list
+          .stream()
+          .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+          .map(event -> event.getFormattedMessage())
+          .forEach(messages::add);
+    }
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -42,6 +42,34 @@ public interface WorkflowTaskInvoker {
       Collection<BpmnTaskSpec> tasks);
 
   /**
+   * Reports the elements of a BPMN process which can put a SECOND token into a
+   * running workflow - a non-interrupting boundary event, a parallel or inclusive
+   * gateway forking into several flows, a parallel multi-instance activity, a
+   * non-interrupting event subprocess. Called during <code>wireBpmn</code>, since
+   * only the adapter can read its BPMN dialect.
+   * <p>
+   * What it means is the core's decision (story 59): concurrent tokens mean two
+   * branches writing the same workflow aggregate, and an aggregate without a version
+   * attribute loses the writes of whichever branch commits first, without any error.
+   * The core knows the aggregate class, so it warns once per BPMN process - naming
+   * the elements reported here, which is why this method takes IDs rather than a
+   * boolean.
+   * <p>
+   * An adapter whose BPMS cannot be asked about its models reports nothing; the check
+   * stays silent then instead of guessing.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The PLAIN BPMN process ID
+   * @param elementIds The IDs of the elements producing a second token
+   */
+  default void reportConcurrentTokenElements(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final Collection<String> elementIds) {
+
+  }
+
+  /**
    * Validates - after ALL BPMN processes of a workflow module were wired - that
    * every <code>&#64;WorkflowTask</code> method matched a task of at least ONE of
    * the module's BPMN processes (a workflow service class may declare several

--- a/quarkus-integration/integration-tests/deployment-integration-tests/pom.xml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/pom.xml
@@ -54,6 +54,13 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jdbc-h2</artifactId>
     </dependency>
+    <!-- the version-conflict acceptance test (story 59) needs a real ORM: what is
+         proven there is what Hibernate raises when the version of a row moved on,
+         and how JTA wraps it on the way out -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConcurrentBranch.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConcurrentBranch.java
@@ -1,0 +1,38 @@
+package io.vanillabp.integration.test.deployment.conflict;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.Transactional.TxType;
+
+/**
+ * The second writer of the version-conflict acceptance test (story 59): it changes the
+ * same workflow aggregate in a transaction of ITS OWN and commits, while VanillaBP's
+ * transaction is still open. That is the shape of the collision without a race - what
+ * a parallel branch of a workflow does in real life, made sequential so the test
+ * cannot flake.
+ */
+@ApplicationScoped
+public class ConcurrentBranch {
+
+  @Inject
+  EntityManager entityManager;
+
+  /**
+   * Changes the aggregate in a separate transaction which is committed on return, so
+   * the version of the row is higher than the one VanillaBP's transaction read.
+   *
+   * @param aggregateId The aggregate's ID
+   */
+  @Transactional(TxType.REQUIRES_NEW)
+  public void changeInOwnTransaction(
+      final String aggregateId) {
+
+    final var aggregate = entityManager.find(ConflictAggregate.class, aggregateId);
+    aggregate.setContent("changed by the other branch");
+    entityManager.flush();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictAggregate.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictAggregate.java
@@ -1,0 +1,53 @@
+package io.vanillabp.integration.test.deployment.conflict;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+/**
+ * The workflow aggregate of the version-conflict acceptance test (story 59): a JPA
+ * entity carrying the version attribute which turns two writers into an exception
+ * instead of a silent overwrite. Under JTA that exception arrives wrapped, which is
+ * what this test is about.
+ */
+@Entity
+@Table(name = "CONFLICT_TEST_AGGREGATE")
+public class ConflictAggregate {
+
+  @Id
+  private String id;
+
+  private String content;
+
+  @Version
+  private Long version;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getContent() {
+    return content;
+  }
+
+  public void setContent(
+      final String content) {
+    this.content = content;
+  }
+
+  public Long getVersion() {
+    return version;
+  }
+
+  public void setVersion(
+      final Long version) {
+    this.version = version;
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictAggregatePersistence.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictAggregatePersistence.java
@@ -1,0 +1,92 @@
+package io.vanillabp.integration.test.deployment.conflict;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+
+/**
+ * JPA persistence of the version-conflict acceptance test's aggregate - the real
+ * thing, since the point of the test is what Hibernate does when the version of a row
+ * moved on while VanillaBP's transaction was open.
+ */
+@ApplicationScoped
+public class ConflictAggregatePersistence implements AggregatePersistenceAware<ConflictAggregate> {
+
+  @Inject
+  EntityManager entityManager;
+
+  @Override
+  public Class<ConflictAggregate> getAggregateClass() {
+
+    return ConflictAggregate.class;
+
+  }
+
+  @Override
+  public Class<?> getAggregateIdType() {
+
+    return String.class;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final ConflictAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public ConflictAggregate save(
+      final ConflictAggregate aggregate) {
+
+    return entityManager.merge(aggregate);
+
+  }
+
+  @Override
+  public ConflictAggregate loadById(
+      final Object aggregateId) {
+
+    return entityManager.find(ConflictAggregate.class, aggregateId);
+
+  }
+
+  /**
+   * Stores an aggregate as if a workflow had been started, in a transaction of its
+   * own.
+   *
+   * @param id The aggregate's ID
+   */
+  @Transactional
+  public void seed(
+      final String id) {
+
+    final var aggregate = new ConflictAggregate();
+    aggregate.setId(id);
+    aggregate.setContent("new");
+    entityManager.persist(aggregate);
+
+  }
+
+  /**
+   * The content stored for the given aggregate, read in a transaction of its own.
+   *
+   * @param id The aggregate's ID
+   * @return The content committed to the database
+   */
+  @Transactional
+  public String storedContent(
+      final String id) {
+
+    final var aggregate = entityManager.find(ConflictAggregate.class, id);
+    return aggregate == null
+        ? null
+        : aggregate.getContent();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictProcessWiringSource.java
@@ -1,0 +1,31 @@
+package io.vanillabp.integration.test.deployment.conflict;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of the version-conflict acceptance test: supplies the
+ * tasks of 'ConflictProcess' matching the handlers of {@link ConflictWorkflowService}.
+ */
+@ApplicationScoped
+public class ConflictProcessWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "ConflictProcess".equals(bpmnProcessId)
+        ? List.of(
+            new BpmnTaskSpec("Activity_Conflict", "conflictingTask"),
+            new BpmnTaskSpec("Activity_Undisturbed", "undisturbedTask"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/conflict/ConflictWorkflowService.java
@@ -1,0 +1,40 @@
+package io.vanillabp.integration.test.deployment.conflict;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * The workflow service of the version-conflict acceptance test (story 59). Both
+ * handlers change the aggregate; only {@link #conflictingTask} lets the other branch
+ * commit in between, which makes VanillaBP's own commit fail.
+ */
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = ConflictAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "ConflictProcess"))
+public class ConflictWorkflowService {
+
+  @Inject
+  ConcurrentBranch concurrentBranch;
+
+  @WorkflowTask(taskDefinition = "conflictingTask")
+  public void conflictingTask(
+      final ConflictAggregate aggregate) {
+
+    aggregate.setContent("changed by the task");
+    concurrentBranch.changeInOwnTransaction(aggregate.getId());
+
+  }
+
+  @WorkflowTask(taskDefinition = "undisturbedTask")
+  public void undisturbedTask(
+      final ConflictAggregate aggregate) {
+
+    aggregate.setContent("changed by the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateWriteConflictTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/AggregateWriteConflictTest.java
@@ -1,0 +1,189 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.migration.transaction.AggregateWrite;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.deployment.conflict.ConcurrentBranch;
+import io.vanillabp.integration.test.deployment.conflict.ConflictAggregate;
+import io.vanillabp.integration.test.deployment.conflict.ConflictAggregatePersistence;
+import io.vanillabp.integration.test.deployment.conflict.ConflictProcessWiringSource;
+import io.vanillabp.integration.test.deployment.conflict.ConflictWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 59 on Quarkus, with a real JPA aggregate carrying <code>@Version</code>: while
+ * the <code>&#64;WorkflowTask</code> handler runs, a second writer changes the same row
+ * in a transaction of its own and commits - two branches of one workflow, made
+ * sequential so nothing here depends on a race.
+ * <p>
+ * Under JTA the conflict never arrives as itself: Hibernate raises it while flushing at
+ * the commit, Narayana reports a <code>RollbackException</code> and
+ * <code>QuarkusTransaction</code> wraps that again. So this test proves the unwrapping
+ * as much as the message.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AggregateWriteConflictTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "ConflictProcess";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("aggregate-conflict/application.yaml", "application.yaml")
+          .addClass(ConflictAggregate.class)
+          .addClass(ConflictAggregatePersistence.class)
+          .addClass(ConcurrentBranch.class)
+          .addClass(ConflictWorkflowService.class)
+          .addClass(ConflictProcessWiringSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/ConflictProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  ConflictAggregatePersistence persistence;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  @Test
+  @DisplayName("A version conflict in VanillaBP's own commit is named and reaches the adapter")
+  public void aVersionConflictIsReportedAndPropagated() {
+
+    final var dummyAdapter = dummyAdapter();
+    persistence.seed("6001");
+
+    final var messages = new java.util.ArrayList<String>();
+    final var thrown = assertThrows(
+        RuntimeException.class,
+        () -> loggedBy(
+            messages,
+            () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("conflictingTask", "6001"))));
+
+    // the exception the platform recognized: an optimistic locking failure somewhere
+    // in the chain of causes, which is how JTA delivers it
+    assertTrue(AggregateWrite.causedByOptimisticLocking(thrown), thrown.toString());
+    assertEquals(1, messages.size(), messages.toString());
+    final var message = messages.getFirst();
+    assertTrue(message.contains(MODULE), message);
+    assertTrue(message.contains(PROCESS), message);
+    assertTrue(message.contains("6001"), message);
+    assertTrue(message.contains("conflictingTask"), message);
+    assertTrue(message.contains("does not retry"), message);
+
+    // what the other branch wrote survived, what this run changed did not
+    assertEquals("changed by the other branch", persistence.storedContent("6001"));
+
+  }
+
+  @Test
+  @DisplayName("A task nobody writes against commits as usual and says nothing")
+  public void anUndisturbedTaskStaysSilent() {
+
+    final var dummyAdapter = dummyAdapter();
+    persistence.seed("6002");
+
+    final var messages = new java.util.ArrayList<String>();
+    final var outcome = new WorkflowTaskOutcome[1];
+    loggedBy(
+        messages,
+        () -> outcome[0] = dummyAdapter.invokeTask(MODULE, PROCESS, context("undisturbedTask", "6002")));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome[0].kind());
+    assertTrue(messages.isEmpty(), messages.toString());
+    assertEquals("changed by the task", persistence.storedContent("6002"));
+
+  }
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  private void loggedBy(
+      final List<String> messages,
+      final Runnable work) {
+
+    final var handler = new java.util.logging.Handler() {
+
+      @Override
+      public void publish(
+          final java.util.logging.LogRecord record) {
+        if (record.getLevel().intValue() >= java.util.logging.Level.WARNING.intValue()) {
+          final var parameters = record.getParameters();
+          messages
+              .add(
+                  (parameters == null) || (parameters.length == 0)
+                      ? record.getMessage()
+                      : String.format(record.getMessage(), parameters));
+        }
+      }
+
+      @Override
+      public void flush() {
+      }
+
+      @Override
+      public void close() {
+      }
+
+    };
+    final var logger = java.util.logging.Logger.getLogger(AggregateWrite.class.getName());
+    logger.addHandler(handler);
+    try {
+      work.run();
+    } finally {
+      logger.removeHandler(handler);
+    }
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/aggregate-conflict/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/aggregate-conflict/application.yaml
@@ -1,0 +1,17 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:aggregate-conflict;DB_CLOSE_DELAY=-1
+  hibernate-orm:
+    schema-management:
+      strategy: drop-and-create
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/QuarkusTransactionRunner.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/QuarkusTransactionRunner.java
@@ -65,6 +65,19 @@ public class QuarkusTransactionRunner implements TransactionRunner {
 
   }
 
+  @Override
+  public boolean isConcurrentModification(
+      final Throwable failure) {
+
+    // under JTA the conflict never arrives as itself: Hibernate raises it while
+    // flushing at commit, the transaction manager reports a RollbackException and
+    // QuarkusTransaction wraps that again - so the chain of causes is what is asked,
+    // which the core does by name (it must not depend on JPA)
+    return io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .causedByOptimisticLocking(failure);
+
+  }
+
   private <T> T withRequestContext(
       final Supplier<T> work) {
 

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/workflowtask/QuarkusConcurrentModificationTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/workflowtask/QuarkusConcurrentModificationTest.java
@@ -1,0 +1,47 @@
+package io.vanillabp.integration.runtime.test.workflowtask;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.runtime.workflowtask.QuarkusTransactionRunner;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Which failures Quarkus reports as "somebody else changed the workflow aggregate"
+ * (story 59). Under JTA the conflict arrives wrapped twice, so what is asserted here is
+ * the walk along the causes; no transaction is needed for it, which is why the runner is
+ * built without a registry.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class QuarkusConcurrentModificationTest {
+
+  private final QuarkusTransactionRunner runner = new QuarkusTransactionRunner(null);
+
+  @Test
+  @DisplayName("The conflict is found however deep JTA wrapped it")
+  public void wrappedOptimisticLockExceptionsAreRecognized() {
+
+    assertTrue(runner.isConcurrentModification(new jakarta.persistence.OptimisticLockException("Row 4711")));
+    assertTrue(
+        runner
+            .isConcurrentModification(
+                new RuntimeException(
+                    "transaction failed", new jakarta.transaction.RollbackException(
+                        "rolled back").initCause(new jakarta.persistence.OptimisticLockException("Row 4711")))));
+
+  }
+
+  @Test
+  @DisplayName("Everything else is somebody else's failure")
+  public void otherFailuresAreNotConflicts() {
+
+    assertFalse(runner.isConcurrentModification(new IllegalStateException("the handler threw")));
+    assertFalse(runner.isConcurrentModification(null));
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TestApplication.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/TestApplication.java
@@ -19,6 +19,29 @@ public class TestApplication {
 
   }
 
+  /**
+   * The tasks of the version-conflict acceptance test (story 59) - the dummy adapter
+   * has no model to read them from.
+   *
+   * @return The wiring of the BPMN process 'ConflictProcess'
+   */
+  @Bean
+  public io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource conflictTaskWiringSource() {
+
+    return (
+        adapterId,
+        workflowModuleId,
+        bpmnProcessId) -> "ConflictProcess".equals(bpmnProcessId)
+            ? java.util.List
+                .of(
+                    new io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec(
+                        "Activity_Conflict", "conflictingTask"),
+                    new io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec(
+                        "Activity_Undisturbed", "undisturbedTask"))
+            : java.util.List.of();
+
+  }
+
   @Bean
   public SteerableTaskAwarenessSource steerableTaskAwarenessSource() {
 

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/AggregateWriteConflictTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/AggregateWriteConflictTest.java
@@ -1,0 +1,157 @@
+package io.vanillabp.integration.test.outbox.conflict;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.integration.adapter.migration.transaction.AggregateWrite;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.outbox.TestApplication;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 59 on Spring Boot, with a real JPA aggregate carrying <code>@Version</code>:
+ * while the <code>@WorkflowTask</code> handler runs, a second writer changes the same
+ * row in a transaction of its own and commits - the shape of two branches of one
+ * workflow, made sequential so nothing here depends on a race.
+ * <p>
+ * VanillaBP's commit then fails: the platform recognizes the conflict, one guiding
+ * message names it, and the exception reaches the adapter unchanged, which is what
+ * lets the BPMS apply its retry semantics.
+ */
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(SuppressOutputExtension.class)
+@SuppressOutputExtension.SuppressBackgroundOutput
+public class AggregateWriteConflictTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "ConflictProcess";
+
+  @Autowired
+  private ConflictAggregateRepository repository;
+
+  @Autowired
+  private DeploymentService dummyAdapter;
+
+  @Test
+  @DisplayName("A version conflict in VanillaBP's own commit is named and reaches the adapter")
+  public void aVersionConflictIsReportedAndPropagated() {
+
+    final var aggregate = new ConflictAggregate();
+    aggregate.setContent("new");
+    final var aggregateId = repository
+        .save(aggregate)
+        .getId();
+
+    final var messages = new java.util.ArrayList<String>();
+    final var thrown = assertThrows(
+        OptimisticLockingFailureException.class,
+        () -> loggedBy(
+            messages,
+            () -> dummyAdapter
+                .invokeTask(MODULE, PROCESS, context("conflictingTask", aggregateId))));
+
+    assertEquals(1, messages.size(), messages.toString());
+    final var message = messages.getFirst();
+    assertTrue(message.contains(MODULE), message);
+    assertTrue(message.contains(PROCESS), message);
+    assertTrue(message.contains(aggregateId.toString()), message);
+    assertTrue(message.contains("conflictingTask"), message);
+    assertTrue(message.contains("does not retry"), message);
+    // not wrapped: the adapter needs the exception its BPMS' retry semantics know
+    assertTrue(
+        thrown.getMessage().contains(ConflictAggregate.class.getName()),
+        thrown.getMessage());
+
+    // what the other branch wrote survived, what this run changed did not
+    assertEquals(
+        "changed by the other branch",
+        repository
+            .findById(aggregateId)
+            .orElseThrow()
+            .getContent());
+
+  }
+
+  @Test
+  @DisplayName("A task nobody writes against commits as usual and says nothing")
+  public void anUndisturbedTaskStaysSilent() {
+
+    final var aggregate = new ConflictAggregate();
+    aggregate.setContent("new");
+    final var aggregateId = repository
+        .save(aggregate)
+        .getId();
+
+    final var messages = new java.util.ArrayList<String>();
+    final var outcome = new WorkflowTaskOutcome[1];
+    loggedBy(
+        messages,
+        () -> outcome[0] = dummyAdapter
+            .invokeTask(MODULE, PROCESS, context("undisturbedTask", aggregateId)));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome[0].kind());
+    assertTrue(messages.isEmpty(), messages.toString());
+    assertEquals(
+        "changed by the task",
+        repository
+            .findById(aggregateId)
+            .orElseThrow()
+            .getContent());
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final Long aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId.toString();
+      }
+
+    };
+
+  }
+
+  private void loggedBy(
+      final List<String> messages,
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(AggregateWrite.class);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAndStopAllAppenders();
+      logWatcher.list
+          .stream()
+          .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+          .map(event -> event.getFormattedMessage())
+          .forEach(messages::add);
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConcurrentBranch.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConcurrentBranch.java
@@ -1,0 +1,44 @@
+package io.vanillabp.integration.test.outbox.conflict;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * The second writer of the version-conflict acceptance test (story 59): it changes the
+ * same workflow aggregate in a transaction of ITS OWN and commits, while VanillaBP's
+ * transaction is still open. That is the shape of the collision without a race - what
+ * a parallel branch of a workflow does in real life, made sequential so the test
+ * cannot flake.
+ */
+@Component
+public class ConcurrentBranch {
+
+  private final ConflictAggregateRepository repository;
+
+  public ConcurrentBranch(
+      final ConflictAggregateRepository repository) {
+
+    this.repository = repository;
+
+  }
+
+  /**
+   * Changes the aggregate in a separate transaction which is committed on return, so
+   * the version of the row is higher than the one VanillaBP's transaction read.
+   *
+   * @param aggregateId The aggregate's ID
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void changeInOwnTransaction(
+      final Long aggregateId) {
+
+    final var aggregate = repository
+        .findById(aggregateId)
+        .orElseThrow();
+    aggregate.setContent("changed by the other branch");
+    repository.saveAndFlush(aggregate);
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictAggregate.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictAggregate.java
@@ -1,0 +1,32 @@
+package io.vanillabp.integration.test.outbox.conflict;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * The workflow aggregate of the version-conflict acceptance test (story 59): a JPA
+ * entity carrying the version attribute which turns two writers into an exception
+ * instead of a silent overwrite.
+ */
+@Entity
+@Table(name = "CONFLICT_TEST_AGGREGATE")
+@Getter
+@Setter
+public class ConflictAggregate {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String content;
+
+  @Version
+  private Long version;
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictAggregateRepository.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictAggregateRepository.java
@@ -1,0 +1,7 @@
+package io.vanillabp.integration.test.outbox.conflict;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ConflictAggregateRepository extends JpaRepository<ConflictAggregate, Long> {
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictWorkflowService.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/conflict/ConflictWorkflowService.java
@@ -1,0 +1,46 @@
+package io.vanillabp.integration.test.outbox.conflict;
+
+import org.springframework.stereotype.Service;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * The workflow service of the version-conflict acceptance test (story 59). Both
+ * handlers change the aggregate; only {@link #conflictingTask} lets the other branch
+ * commit in between, which makes VanillaBP's own commit fail.
+ */
+@Service
+@WorkflowService(
+    workflowAggregateClass = ConflictAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "ConflictProcess"))
+public class ConflictWorkflowService {
+
+  private final ConcurrentBranch concurrentBranch;
+
+  public ConflictWorkflowService(
+      final ConcurrentBranch concurrentBranch) {
+
+    this.concurrentBranch = concurrentBranch;
+
+  }
+
+  @WorkflowTask(taskDefinition = "conflictingTask")
+  public void conflictingTask(
+      final ConflictAggregate aggregate) {
+
+    aggregate.setContent("changed by the task");
+    concurrentBranch.changeInOwnTransaction(aggregate.getId());
+
+  }
+
+  @WorkflowTask(taskDefinition = "undisturbedTask")
+  public void undisturbedTask(
+      final ConflictAggregate aggregate) {
+
+    aggregate.setContent("changed by the task");
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/resources/test-module/processes/dummy/ConflictProcess.bpmn
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/resources/test-module/processes/dummy/ConflictProcess.bpmn
@@ -1,0 +1,1 @@
+<definitions/>

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/workflowtask/SpringTransactionRunner.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/workflowtask/SpringTransactionRunner.java
@@ -58,6 +58,31 @@ public class SpringTransactionRunner implements TransactionRunner {
 
   }
 
+  @Override
+  public boolean isConcurrentModification(
+      final Throwable failure) {
+
+    // OptimisticLockingFailureException is Spring's translation for every
+    // persistence technology it integrates - JPA (ObjectOptimisticLockingFailure-
+    // Exception) as well as MongoDB. The causes are walked because the conflict
+    // arrives wrapped as often as not: the commit of the transaction template wraps
+    // what the persistence provider threw while flushing.
+    var candidate = failure;
+    while (candidate != null) {
+      if (candidate instanceof org.springframework.dao.OptimisticLockingFailureException) {
+        return true;
+      }
+      candidate = candidate.getCause() == candidate
+          ? null
+          : candidate.getCause();
+    }
+    // a provider exception which never passed Spring's translation (e.g. thrown by
+    // an application's own repository code) means the same thing
+    return io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .causedByOptimisticLocking(failure);
+
+  }
+
   private <T> T run(
       final Supplier<T> work,
       final int propagation) {

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/workflowtask/SpringConcurrentModificationTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/workflowtask/SpringConcurrentModificationTest.java
@@ -1,0 +1,77 @@
+package io.vanillabp.integration.test.workflowtask;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.workflowtask.SpringTransactionRunner;
+
+/**
+ * Which failures Spring Boot reports as "somebody else changed the workflow aggregate"
+ * (story 59). The transaction runner is asked without any transaction manager, since
+ * the classification looks at the exception alone.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SpringConcurrentModificationTest {
+
+  private final SpringTransactionRunner runner = new SpringTransactionRunner(null);
+
+  @Test
+  @DisplayName("Spring's own translation is recognized, wrapped as well as bare")
+  public void springsTranslationIsRecognized() {
+
+    assertTrue(runner.isConcurrentModification(new ObjectOptimisticLockingFailureException("Aggregate", 4711L)));
+    // MongoDB reports the base type rather than the JPA-flavored subclass
+    assertTrue(runner.isConcurrentModification(new OptimisticLockingFailureException("version 3 expected")));
+    assertTrue(
+        runner
+            .isConcurrentModification(
+                new IllegalStateException("commit failed", new OptimisticLockingFailureException("stale"))));
+
+  }
+
+  @Test
+  @DisplayName("A provider exception which never passed Spring's translation counts too")
+  public void untranslatedProviderExceptionsCount() {
+
+    assertTrue(
+        runner
+            .isConcurrentModification(
+                new IllegalStateException(
+                    "commit failed", new jakarta.persistence.OptimisticLockException("Row 4711"))));
+
+  }
+
+  @Test
+  @DisplayName("Everything else is somebody else's failure")
+  public void otherFailuresAreNotConflicts() {
+
+    assertFalse(runner.isConcurrentModification(new IllegalStateException("the handler threw")));
+    assertFalse(runner.isConcurrentModification(null));
+
+  }
+
+  @Test
+  @DisplayName("A self-referencing cause does not spin")
+  public void aSelfReferencingCauseTerminates() {
+
+    final var selfReferencing = new RuntimeException("looping") {
+
+      @Override
+      public synchronized Throwable getCause() {
+        return this;
+      }
+
+    };
+
+    assertFalse(runner.isConcurrentModification(selfReferencing));
+
+  }
+
+}


### PR DESCRIPTION
Story 59. Stacked on #34 (story 57) — base is `feature/old-process-versions`, so the diff shows this story alone. Retarget to `main` once #34 is merged.

**The finding.** As soon as a process holds more than one token, two branches write the same workflow aggregate: one in the transaction VanillaBP owns for its task, the other in the transaction the application opens around its API call. A persistence layer writes the whole record, so the branch committing second puts back what it read at its start. No exception, no log line, a correctly running process, lost data (blueprints' `GAPS.md` G3).

VanillaBP creates the second writer, so it says so. It does not resolve the collision, and it **deliberately does not retry**: a handler may have called a remote API before the commit failed, and a quiet retry would repeat that call while hiding the failure.

**What is in here**

- `TransactionRunner#isConcurrentModification` — the platform answers whether a failure is an optimistic locking conflict (Spring: `OptimisticLockingFailureException`, JPA as well as MongoDB; Quarkus: the chain of causes, since JTA wraps `jakarta.persistence.OptimisticLockException` in a `RollbackException`). What is not platform-specific sits in `AggregateWrite#causedByOptimisticLocking` and matches by NAME, so the core keeps its distance from JPA.
- `AggregateWrite#inTransaction` — one helper at every place the core commits a transaction of its own (task execution, BPMS-initiated start, workflow-ended notification): runs the work, logs ONE guiding ERROR naming module, process, aggregate and task, rethrows the exception unchanged.
- `WorkflowTaskInvoker#reportConcurrentTokenElements` — a default no-op an adapter fills with the elements which can put a second token into a workflow. `ConcurrentTokenCheck` asks the aggregate class for a version attribute (by the SIMPLE annotation name, covering JPA and Spring Data) and warns once per BPMN process where there is none.

**Deviation from the prompt, stated:** part three lists the phase-two paths as well, but those do not save an aggregate; the operations an application calls itself (`startWorkflow`, `correlateMessage`, `aggregateChanged`, the task operations) save inside the CALLER's transaction, so their conflict surfaces in the application's own commit. The wiki says that rather than the core pretending to handle it.

**Tests.** Core unit tests (classifier consulted, message content, exception unchanged, handler ran exactly once, the warning once per process and silent with a version attribute or without a report), a classifier test per platform, and an acceptance test per platform against a REAL conflict: a JPA aggregate with `@Version` whose second writer commits in its own transaction while the handler runs — sequential, no race. The Quarkus one proves the unwrapping under JTA. Full build green.

**Docs.** Wiki `Workflow-aggregates` gets the section "Two writers on one aggregate" plus a pointer from `Workflow-tasks`; `UPGRADE.md` and `migration-adapter/README.md` carry the SPI additions and the reason there is no retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUj1bzCMbmhZYtg6u7fWD8