### PR TITLE
Quarkus: persist aggregates of known idioms without an own SPI implementation

### DIFF
--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/AggregateIdTypes.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/AggregateIdTypes.java
@@ -1,5 +1,6 @@
 package io.vanillabp.integration.spi;
 
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -7,9 +8,10 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Determines the ID type of a workflow aggregate by reflection - the implementation
- * behind the default of {@link AggregatePersistenceAware#getAggregateIdType()}. The
- * class hierarchy is walked considering also <i>private</i> members:
+ * Determines the ID of a workflow aggregate by reflection: its type (the
+ * implementation behind the default of
+ * {@link AggregatePersistenceAware#getAggregateIdType()}), its property name and its
+ * value. The class hierarchy is walked considering also <i>private</i> members:
  * <ol>
  * <li>a field annotated with a persistence ID annotation
  * ({@code jakarta.persistence.Id}, {@code jakarta.persistence.EmbeddedId} or
@@ -47,6 +49,82 @@ public final class AggregateIdTypes {
   public static Optional<Class<?>> determineIdType(
       final Class<?> workflowAggregateClass) {
 
+    return determineIdMember(workflowAggregateClass)
+        .map(member -> member instanceof Field field
+            ? field.getType()
+            : ((Method) member).getReturnType());
+
+  }
+
+  /**
+   * Determines the name of the aggregate's ID property using the same precedence
+   * rules as {@link #determineIdType(Class)} - the implementation behind
+   * {@link AggregatePersistenceAware#getAggregateIdName()} of the platform-provided
+   * persistence implementations. A getter contributes its property name
+   * ({@code getLoanRequestId} &rarr; {@code loanRequestId}).
+   *
+   * @param workflowAggregateClass The aggregate's class
+   * @return The name of the ID property or {@link Optional#empty()} if it cannot be
+   *         determined
+   */
+  public static Optional<String> determineIdName(
+      final Class<?> workflowAggregateClass) {
+
+    return determineIdMember(workflowAggregateClass)
+        .map(member -> member instanceof Field field
+            ? field.getName()
+            : propertyNameOf((Method) member));
+
+  }
+
+  /**
+   * Reads the aggregate's ID using the same precedence rules as
+   * {@link #determineIdType(Class)} - the implementation behind
+   * {@link AggregatePersistenceAware#getAggregateId(Object)} of the platform-provided
+   * persistence implementations. Fields are read directly (also private ones), which
+   * is what JPA and MongoDB codecs do as well.
+   *
+   * @param workflowAggregate The aggregate to read the ID from
+   * @return The ID, which may be <code>null</code> for an aggregate not persisted yet
+   *         (generated IDs)
+   * @throws IllegalStateException If the aggregate has no property qualifying as its ID
+   */
+  public static Object readId(
+      final Object workflowAggregate) {
+
+    final var member = determineIdMember(workflowAggregate.getClass())
+        .orElseThrow(() -> new IllegalStateException(
+            """
+                No ID property found for workflow aggregate '%s'! Annotate it (e.g. \
+                jakarta.persistence.Id or org.bson.codecs.pojo.annotations.BsonId), name it \
+                'id', or provide your own io.vanillabp.integration.spi.AggregatePersistenceAware \
+                implementation for this aggregate."""
+                .formatted(workflowAggregate.getClass().getName())));
+    try {
+      if (member instanceof Field field) {
+        field.setAccessible(true);
+        return field.get(workflowAggregate);
+      }
+      final var getter = (Method) member;
+      getter.setAccessible(true);
+      return getter.invoke(workflowAggregate);
+    } catch (final IllegalStateException e) {
+      throw e;
+    } catch (final Exception e) {
+      throw new IllegalStateException(
+          "Could not read the ID of workflow aggregate '%s'!"
+              .formatted(workflowAggregate.getClass().getName()), e);
+    }
+
+  }
+
+  /**
+   * The field or getter holding the aggregate's ID, see the class javadoc for the
+   * precedence rules.
+   */
+  private static Optional<AccessibleObject> determineIdMember(
+      final Class<?> workflowAggregateClass) {
+
     Method annotatedGetter = null;
     Field idNamedField = null;
     Method idNamedGetter = null;
@@ -55,7 +133,7 @@ public final class AggregateIdTypes {
       for (final var field : current.getDeclaredFields()) {
         if (isIdAnnotated(field.getAnnotations())) {
           // an annotated field is the most specific evidence - return immediately
-          return Optional.of(field.getType());
+          return Optional.of(field);
         }
         if ((idNamedField == null) && field.getName().equals("id")) {
           idNamedField = field;
@@ -74,12 +152,30 @@ public final class AggregateIdTypes {
       }
     }
     if (annotatedGetter != null) {
-      return Optional.of(annotatedGetter.getReturnType());
+      return Optional.of(annotatedGetter);
     }
     if (idNamedField != null) {
-      return Optional.of(idNamedField.getType());
+      return Optional.of(idNamedField);
     }
-    return Optional.ofNullable(idNamedGetter).map(Method::getReturnType);
+    return Optional.ofNullable(idNamedGetter);
+
+  }
+
+  /**
+   * The JavaBean property name of a getter: {@code getId} &rarr; {@code id},
+   * {@code isDone} &rarr; {@code done}.
+   */
+  private static String propertyNameOf(
+      final Method getter) {
+
+    final var name = getter.getName();
+    final var withoutPrefix = name.startsWith("is")
+        ? name.substring(2)
+        : name.substring(3);
+    if (withoutPrefix.isEmpty()) {
+      return name;
+    }
+    return Character.toLowerCase(withoutPrefix.charAt(0)) + withoutPrefix.substring(1);
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/AggregateIdTypesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/AggregateIdTypesTest.java
@@ -1,0 +1,126 @@
+package io.vanillabp.migration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import io.vanillabp.integration.spi.AggregateIdTypes;
+import jakarta.persistence.Id;
+
+/**
+ * Story 69: the ID's name and value are determined by the same walk as its type,
+ * because the persistence implementations VanillaBP provides on Quarkus answer
+ * {@code getAggregateIdName}, {@code getAggregateIdType} and {@code getAggregateId}
+ * from it.
+ */
+public class AggregateIdTypesTest {
+
+  public static class AnnotatedField {
+
+    @Id
+    private String loanRequestId;
+
+    public AnnotatedField(
+        final String loanRequestId) {
+      this.loanRequestId = loanRequestId;
+    }
+
+  }
+
+  public static class AnnotatedGetter {
+
+    private Long key;
+
+    public AnnotatedGetter(
+        final Long key) {
+      this.key = key;
+    }
+
+    @Id
+    public Long getKey() {
+      return key;
+    }
+
+  }
+
+  public static class FieldNamedId {
+
+    private Integer id;
+
+    public FieldNamedId(
+        final Integer id) {
+      this.id = id;
+    }
+
+  }
+
+  public static class GetterNamedGetId {
+
+    public String getId() {
+      return "from-getter";
+    }
+
+  }
+
+  public static class WithoutAnyId {
+
+    private String content = "no id at all";
+
+  }
+
+  @Test
+  @DisplayName("An annotated field contributes name, type and value - also a private one")
+  public void annotatedFieldAnswersEverything() {
+
+    assertEquals(Optional.of("loanRequestId"), AggregateIdTypes.determineIdName(AnnotatedField.class));
+    assertEquals(Optional.of(String.class), AggregateIdTypes.determineIdType(AnnotatedField.class));
+    assertEquals("4711", AggregateIdTypes.readId(new AnnotatedField("4711")));
+
+  }
+
+  @Test
+  @DisplayName("An annotated getter contributes its property name, not the method name")
+  public void annotatedGetterContributesThePropertyName() {
+
+    assertEquals(Optional.of("key"), AggregateIdTypes.determineIdName(AnnotatedGetter.class));
+    assertEquals(Optional.of(Long.class), AggregateIdTypes.determineIdType(AnnotatedGetter.class));
+    assertEquals(42L, AggregateIdTypes.readId(new AnnotatedGetter(42L)));
+
+  }
+
+  @Test
+  @DisplayName("Without an annotation a member named 'id' answers, field before getter")
+  public void memberNamedIdAnswers() {
+
+    assertEquals(Optional.of("id"), AggregateIdTypes.determineIdName(FieldNamedId.class));
+    assertEquals(Optional.of(Integer.class), AggregateIdTypes.determineIdType(FieldNamedId.class));
+    assertEquals(7, AggregateIdTypes.readId(new FieldNamedId(7)));
+
+    assertEquals(Optional.of("id"), AggregateIdTypes.determineIdName(GetterNamedGetId.class));
+    assertEquals("from-getter", AggregateIdTypes.readId(new GetterNamedGetId()));
+
+  }
+
+  @Test
+  @DisplayName("An ID not yet assigned is null, an aggregate without any ID property is a guiding failure")
+  public void missingIdIsReportedDifferentlyFromAnUnsetId() {
+
+    assertNull(AggregateIdTypes.readId(new AnnotatedField(null)));
+
+    assertEquals(Optional.empty(), AggregateIdTypes.determineIdName(WithoutAnyId.class));
+    assertEquals(Optional.empty(), AggregateIdTypes.determineIdType(WithoutAnyId.class));
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> AggregateIdTypes.readId(new WithoutAnyId()));
+    assertTrue(failure.getMessage().contains(WithoutAnyId.class.getName()), failure.getMessage());
+    assertTrue(failure.getMessage().contains("AggregatePersistenceAware"), failure.getMessage());
+
+  }
+
+}

--- a/quarkus-integration/README.md
+++ b/quarkus-integration/README.md
@@ -65,11 +65,20 @@ as possible at **build time**, following Quarkus' extension philosophy:
    classes with config ordinals slightly above `application.*` (properties: 251,
    YAML: 256), so module properties take precedence. The files are also registered for
    dev-mode hot reload.
-5. **Aggregate persistence:** Unlike Spring Boot there is *no* generic fallback —
-   Quarkus has no single persistence idiom. A CDI bean implementing
-   `AggregatePersistenceAware` (from [quarkus-support](./quarkus-support)) is required
-   per aggregate; the most specific generic type wins (`AggregatePersistenceResolver`,
-   Jandex-based).
+5. **Aggregate persistence:** a CDI bean implementing `AggregatePersistenceAware`
+   always wins, the most specific generic type first (`AggregatePersistenceResolver`,
+   Jandex-based). For an aggregate having none, VanillaBP asks the aggregate what it
+   is (`DefaultAggregatePersistenceResolver`, also at build time): a Panache
+   repository for it wins (Hibernate ORM or MongoDB), then the aggregate being a
+   Panache active record, then a Spring Data repository for it
+   (`quarkus-spring-data-jpa`). The chosen implementation lives in the runtime module
+   (package `runtime/persistence`), and one `@Singleton` subclass per aggregate is
+   generated with Gizmo, so the runtime lookup finds a normal CDI bean. Two
+   repositories for one aggregate fail the build; an aggregate using none of the
+   idioms fails it, too, with a message naming what was looked for. Everything about
+   the aggregate's ID (name, type, value) comes from reflection (`AggregateIdTypes`),
+   not from the persistence framework: it is needed at build and startup time, where
+   no session is guaranteed to be around.
 6. **Validation at build time:** `EnsureCollectedClassesAreBeansBuildStepProcessor`
    fails the build if collected classes (workflow services, persistence
    implementations) are not actual CDI beans.

--- a/quarkus-integration/deployment/pom.xml
+++ b/quarkus-integration/deployment/pom.xml
@@ -52,6 +52,21 @@
       <artifactId>quarkus-narayana-jta</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <!-- the persistence idioms the default aggregate persistence recognizes
+           (DefaultAggregatePersistenceResolverTest indexes the real types). NOT
+           MongoDB Panache: it activates the MongoDB client extension for every test
+           application of this module, which then wants a database configured - the
+           MongoDB idioms are covered by the integration tests instead -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-spring-data-commons-api</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/DefaultAggregatePersistenceResolver.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/DefaultAggregatePersistenceResolver.java
@@ -1,0 +1,262 @@
+package io.vanillabp.integration.deployment.processservice;
+
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Type;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+
+/**
+ * Picks the persistence VanillaBP provides for an aggregate the application did not
+ * write an {@link AggregatePersistenceAware} for. Quarkus has no single persistence
+ * idiom, so the aggregate itself is asked what it is:
+ * <ol>
+ * <li>a Panache repository for the aggregate (Hibernate ORM or MongoDB) wins,</li>
+ * <li>otherwise the aggregate being a Panache active record (Hibernate ORM or
+ * MongoDB),</li>
+ * <li>otherwise a Spring Data repository for the aggregate.</li>
+ * </ol>
+ * Nothing is guessed from the extensions present: an application has one of these
+ * artifacts for the aggregate or it has none, in which case the build fails with the
+ * message of {@code ProcessServiceBuildStepProcessor}.
+ * <p>
+ * Everything is decided on the Jandex index, so a wrong or ambiguous setup is
+ * reported at build time rather than at the first workflow.
+ */
+public final class DefaultAggregatePersistenceResolver {
+
+  /* Hibernate ORM Panache */
+  static final DotName PANACHE_ENTITY_BASE = DotName
+      .createSimple("io.quarkus.hibernate.orm.panache.PanacheEntityBase");
+
+  static final Set<DotName> PANACHE_REPOSITORIES = Set.of(
+      DotName.createSimple("io.quarkus.hibernate.orm.panache.PanacheRepository"),
+      DotName.createSimple("io.quarkus.hibernate.orm.panache.PanacheRepositoryBase"));
+
+  /* MongoDB Panache */
+  static final DotName PANACHE_MONGO_ENTITY_BASE = DotName
+      .createSimple("io.quarkus.mongodb.panache.PanacheMongoEntityBase");
+
+  static final Set<DotName> PANACHE_MONGO_REPOSITORIES = Set.of(
+      DotName.createSimple("io.quarkus.mongodb.panache.PanacheMongoRepository"),
+      DotName.createSimple("io.quarkus.mongodb.panache.PanacheMongoRepositoryBase"));
+
+  /*
+   * Spring Data: the repository interfaces an application extends. CrudRepository is
+   * the one VanillaBP calls; the others are listed because they extend it, and the
+   * artifact declaring them is not necessarily part of the index (only classes of the
+   * application and of extensions shipping a Jandex index are), so the hierarchy
+   * cannot always be walked up to CrudRepository.
+   */
+  static final Set<DotName> SPRING_DATA_REPOSITORIES = Set.of(
+      DotName.createSimple("org.springframework.data.repository.CrudRepository"),
+      DotName.createSimple("org.springframework.data.repository.ListCrudRepository"),
+      DotName.createSimple("org.springframework.data.repository.PagingAndSortingRepository"),
+      DotName.createSimple("org.springframework.data.jpa.repository.JpaRepository"));
+
+  /** Implementations provided by {@code vanillabp-quarkus-integration}. */
+  public static final String PANACHE_REPOSITORY_PERSISTENCE = "io.vanillabp.integration.runtime.persistence.PanacheRepositoryAggregatePersistence";
+
+  public static final String PANACHE_ACTIVE_RECORD_PERSISTENCE = "io.vanillabp.integration.runtime.persistence.PanacheActiveRecordAggregatePersistence";
+
+  public static final String PANACHE_MONGO_REPOSITORY_PERSISTENCE = "io.vanillabp.integration.runtime.persistence.PanacheMongoRepositoryAggregatePersistence";
+
+  public static final String PANACHE_MONGO_ACTIVE_RECORD_PERSISTENCE = "io.vanillabp.integration.runtime.persistence.PanacheMongoActiveRecordAggregatePersistence";
+
+  public static final String SPRING_DATA_PERSISTENCE = "io.vanillabp.integration.runtime.persistence.SpringDataAggregatePersistence";
+
+  private DefaultAggregatePersistenceResolver() {
+  }
+
+  /**
+   * The persistence chosen for an aggregate.
+   *
+   * @param implementationClass The VanillaBP implementation to be used
+   * @param repositoryClass The repository bean the implementation delegates to, or
+   *        <code>null</code> for the active-record implementations
+   * @param idiom Human-readable name of the idiom, used in log and error messages
+   */
+  public record DefaultPersistence(
+                                   String implementationClass,
+                                   DotName repositoryClass,
+                                   String idiom) {
+  }
+
+  /**
+   * @param index The index to look up classes in (the combined index, so classes of
+   *        extensions shipping a Jandex index are visible, too)
+   * @param aggregateType The workflow aggregate's class
+   * @return The persistence to be used or {@link Optional#empty()} if the aggregate
+   *         uses none of the known idioms
+   */
+  public static Optional<DefaultPersistence> resolve(
+      final IndexView index,
+      final DotName aggregateType) {
+
+    final var panacheRepository = repositoryFor(index, aggregateType, PANACHE_REPOSITORIES, false);
+    final var mongoRepository = repositoryFor(index, aggregateType, PANACHE_MONGO_REPOSITORIES, false);
+    if (panacheRepository.isPresent() && mongoRepository.isPresent()) {
+      throw new IllegalStateException(
+          """
+              The workflow aggregate '%s' has both a Hibernate ORM Panache repository ('%s') and a \
+              MongoDB Panache repository ('%s')! VanillaBP cannot tell which one owns the aggregate - \
+              keep one of them or provide your own io.vanillabp.integration.spi.AggregatePersistenceAware \
+              for this aggregate."""
+              .formatted(aggregateType, panacheRepository.get(), mongoRepository.get()));
+    }
+    if (panacheRepository.isPresent()) {
+      return Optional.of(new DefaultPersistence(
+          PANACHE_REPOSITORY_PERSISTENCE, panacheRepository.get(), "Hibernate ORM Panache repository"));
+    }
+    if (mongoRepository.isPresent()) {
+      return Optional.of(new DefaultPersistence(
+          PANACHE_MONGO_REPOSITORY_PERSISTENCE, mongoRepository.get(), "MongoDB Panache repository"));
+    }
+
+    final var isPanacheEntity = isSubclassOf(index, aggregateType, PANACHE_ENTITY_BASE);
+    final var isMongoEntity = isSubclassOf(index, aggregateType, PANACHE_MONGO_ENTITY_BASE);
+    if (isPanacheEntity && isMongoEntity) {
+      throw new IllegalStateException(
+          """
+              The workflow aggregate '%s' extends both PanacheEntityBase and PanacheMongoEntityBase! \
+              Provide your own io.vanillabp.integration.spi.AggregatePersistenceAware for this aggregate."""
+              .formatted(aggregateType));
+    }
+    if (isPanacheEntity) {
+      return Optional.of(new DefaultPersistence(
+          PANACHE_ACTIVE_RECORD_PERSISTENCE, null, "Hibernate ORM Panache active record"));
+    }
+    if (isMongoEntity) {
+      return Optional.of(new DefaultPersistence(
+          PANACHE_MONGO_ACTIVE_RECORD_PERSISTENCE, null, "MongoDB Panache active record"));
+    }
+
+    return repositoryFor(index, aggregateType, SPRING_DATA_REPOSITORIES, true)
+        .map(repository -> new DefaultPersistence(
+            SPRING_DATA_PERSISTENCE, repository, "Spring Data repository"));
+
+  }
+
+  /**
+   * The repository bean managing the given aggregate.
+   *
+   * @param interfacesWanted Are the repositories interfaces (Spring Data, the
+   *        implementation is generated by Quarkus) or classes (Panache)?
+   * @return The repository or {@link Optional#empty()} if there is none; several
+   *         repositories for one aggregate fail the build
+   */
+  private static Optional<DotName> repositoryFor(
+      final IndexView index,
+      final DotName aggregateType,
+      final Set<DotName> repositoryInterfaces,
+      final boolean interfacesWanted) {
+
+    final var candidates = new ArrayList<DotName>();
+    for (final var candidate : index.getKnownClasses()) {
+      if (candidate.isInterface() != interfacesWanted) {
+        continue;
+      }
+      if (!interfacesWanted && Modifier.isAbstract(candidate.flags())) {
+        continue;
+      }
+      if (repositoryInterfaces.contains(candidate.name())) {
+        continue;
+      }
+      firstTypeArgumentOf(index, candidate, repositoryInterfaces)
+          .filter(aggregateType::equals)
+          .ifPresent(entity -> candidates.add(candidate.name()));
+    }
+    if (candidates.size() > 1) {
+      throw new IllegalStateException(
+          """
+              Several repositories manage the workflow aggregate '%s': %s. VanillaBP cannot tell which \
+              one to use - keep one of them or provide your own \
+              io.vanillabp.integration.spi.AggregatePersistenceAware for this aggregate."""
+              .formatted(aggregateType, candidates));
+    }
+    return candidates
+        .stream()
+        .findFirst();
+
+  }
+
+  /**
+   * The entity type a class or interface names when extending one of the given
+   * repository interfaces, e.g. {@code Foo} for
+   * {@code class FooRepository implements PanacheRepository<Foo>}. Superclasses and
+   * super-interfaces are walked as far as the index knows them.
+   */
+  private static Optional<DotName> firstTypeArgumentOf(
+      final IndexView index,
+      final ClassInfo classInfo,
+      final Set<DotName> repositoryInterfaces) {
+
+    final var visited = new HashSet<DotName>();
+    final var toBeInspected = new LinkedList<ClassInfo>();
+    toBeInspected.add(classInfo);
+    while (!toBeInspected.isEmpty()) {
+      final var current = toBeInspected.removeFirst();
+      if (!visited.add(current.name())) {
+        continue;
+      }
+      final var supertypes = new LinkedHashSet<Type>(current.interfaceTypes());
+      if (current.superClassType() != null) {
+        supertypes.add(current.superClassType());
+      }
+      for (final var supertype : supertypes) {
+        if (repositoryInterfaces.contains(supertype.name()) && (supertype.kind() == Type.Kind.PARAMETERIZED_TYPE)) {
+          final List<Type> arguments = supertype
+              .asParameterizedType()
+              .arguments();
+          if (!arguments.isEmpty() && (arguments.getFirst().kind() == Type.Kind.CLASS)) {
+            return Optional.of(arguments
+                .getFirst()
+                .name());
+          }
+        }
+        final var supertypeInfo = index.getClassByName(supertype.name());
+        if (supertypeInfo != null) {
+          toBeInspected.add(supertypeInfo);
+        }
+      }
+    }
+    return Optional.empty();
+
+  }
+
+  /**
+   * Whether the aggregate extends the given base class, walking the superclass chain
+   * as far as the index knows it.
+   */
+  private static boolean isSubclassOf(
+      final IndexView index,
+      final DotName aggregateType,
+      final DotName baseClass) {
+
+    final var visited = new HashSet<DotName>();
+    var current = index.getClassByName(aggregateType);
+    while ((current != null) && visited.add(current.name())) {
+      final var superType = current.superClassType();
+      if (superType == null) {
+        return false;
+      }
+      if (superType.name().equals(baseClass)) {
+        return true;
+      }
+      current = index.getClassByName(superType.name());
+    }
+    return false;
+
+  }
+
+}

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
@@ -14,6 +14,7 @@ import java.util.function.Predicate;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.AnnotationValue;
 import org.jboss.jandex.ClassInfo;
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.Type;
 
 import io.quarkus.arc.Unremovable;
@@ -24,7 +25,10 @@ import io.quarkus.arc.deployment.UnremovableBeanBuildItem;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.gizmo.ClassCreator;
+import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.SignatureBuilder;
 import io.vanillabp.integration.deployment.config.MigrationAdapterPropertiesBuildItem;
 import io.vanillabp.integration.deployment.validation.EnsureClassIsBeanValidationBuildItem;
@@ -34,6 +38,7 @@ import io.vanillabp.integration.spi.AggregatePersistenceAware;
 import io.vanillabp.spi.process.ProcessService;
 import io.vanillabp.spi.service.WorkflowService;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -68,18 +73,24 @@ public class ProcessServiceBuildStepProcessor {
    * annotated by {@link WorkflowService} at class level.
    *
    * @param applicationArchivesBuildItem Information about All archives (JARs and directories) of the project
+   * @param combinedIndex The index of the application and of all indexed dependencies, used to
+   *        determine the persistence idiom of an aggregate the application provides no
+   *        {@link AggregatePersistenceAware} for
    * @param migrationAdapterProperties Properties of the migration adapter previously built and validated as a dependency
    * @param workflowModulesFound Information about all workflow modules found in the project
    * @param generatedBeanBuildItemBuildProducer {@link BuildProducer} used to collect generated {@link ProcessService} beans
+   * @param reflectiveClassBuildItemProducer {@link BuildProducer} used to register aggregates whose ID VanillaBP reads by reflection
    * @param additionalBeanBuildItemBuildProducer {@link BuildProducer} used to collect beans provided in module "runtime"
    */
   @BuildStep
   void buildProcessServices(
       final ApplicationArchivesBuildItem applicationArchivesBuildItem,
+      final CombinedIndexBuildItem combinedIndex,
       final MigrationAdapterPropertiesBuildItem migrationAdapterProperties,
       final VanillaBpWorkflowModulesBuildItem workflowModulesFound,
       final BuildProducer<EnsureClassIsBeanValidationBuildItem> ensureClassIsBeanBuildItemProducer,
       final BuildProducer<GeneratedBeanBuildItem> generatedBeanBuildItemBuildProducer,
+      final BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemProducer,
       final BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildProducer) {
 
     final var aggregatePersistenceAwares = applicationArchivesBuildItem
@@ -159,8 +170,9 @@ public class ProcessServiceBuildStepProcessor {
                   serviceClass);
           final var bpmnProcessId = primaryBpmnProcessId(annotation, serviceClass);
 
-          // find persistence support class for the aggregate class
-          final var aggregatePersistenceType = aggregatePersistenceAwares
+          // find persistence support class for the aggregate class: an implementation
+          // provided by the application always wins, the most specific one of them
+          final var applicationPersistenceType = aggregatePersistenceAwares
               .stream()
               // calculate distance of classes
               .map(awareEntry -> Map.entry(
@@ -174,25 +186,63 @@ public class ProcessServiceBuildStepProcessor {
               .filter(awareEntry -> awareEntry.getValue() != Integer.MAX_VALUE)
               // choose the most specific persistence support in terms of inheritance class distance
               .min(Comparator.comparingInt(Map.Entry::getValue))
-              // if none found, fall back to persistence support based on Spring Data Util bean
-              .map(Map.Entry::getKey)
-              .orElseThrow(() -> new IllegalStateException(
-                  "You have to provide a CDI bean implementing\n  "
-                      + AggregatePersistenceAware.class.getName()
-                      + "\nwhich is responsible to persist aggregates.\n"
-                      + "This is necessary because in Quarkus there is no unique way to do persistence of entities:\n"
-                      + "- Active record pattern: https://quarkus.io/guides/hibernate-orm-panache#solution-1-using-the-active-record-pattern\n"
-                      + "- Repository record pattern: https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern\n"
-                      + "- Spring Data pattern: https://quarkus.io/guides/spring-data-jpa"
-              ));
-          // ensure service class will be a CDI bean at runtime
-          ensureClassIsBeanBuildItemProducer
-              .produce(EnsureClassIsBeanValidationBuildItem
-                  .builder()
-                  .className(aggregatePersistenceType.name())
-                  .usageDescription("Service implementing the interface "
-                      + AggregatePersistenceAware.class.getName())
-                  .build());
+              .map(Map.Entry::getKey);
+
+          final String aggregatePersistenceClassName;
+          if (applicationPersistenceType.isPresent()) {
+            // ensure service class will be a CDI bean at runtime
+            ensureClassIsBeanBuildItemProducer
+                .produce(EnsureClassIsBeanValidationBuildItem
+                    .builder()
+                    .className(applicationPersistenceType
+                        .get()
+                        .name())
+                    .usageDescription("Service implementing the interface "
+                        + AggregatePersistenceAware.class.getName())
+                    .build());
+            aggregatePersistenceClassName = applicationPersistenceType
+                .get()
+                .name()
+                .toString();
+          } else {
+            // no implementation of the application: use the one matching the
+            // persistence idiom the aggregate is written in
+            final var defaultPersistence = DefaultAggregatePersistenceResolver
+                .resolve(combinedIndex.getIndex(), workflowAggregateType.name())
+                .orElseThrow(() -> new IllegalStateException(
+                    missingAggregatePersistenceMessage(workflowAggregateType)));
+            log.info(
+                "Using VanillaBP's {} persistence for workflow aggregate '{}'{}",
+                defaultPersistence.idiom(),
+                workflowAggregateType.name(),
+                defaultPersistence.repositoryClass() == null
+                    ? ""
+                    : " (repository '%s')".formatted(defaultPersistence.repositoryClass()));
+            aggregatePersistenceClassName = "%s.AggregatePersistence_%s".formatted(
+                workflowAggregateType
+                    .name()
+                    .packagePrefix(),
+                workflowAggregateType
+                    .name()
+                    .withoutPackagePrefix());
+            generateDefaultAggregatePersistence(
+                generatedBeanBuildItemBuildProducer,
+                aggregatePersistenceClassName,
+                defaultPersistence,
+                workflowAggregateType);
+            // the ID is read by reflection (AggregateIdTypes), which a native image
+            // has to be told about - the persistence frameworks register their
+            // entities themselves, but an aggregate may be neither
+            reflectiveClassBuildItemProducer
+                .produce(ReflectiveClassBuildItem
+                    .builder(workflowAggregateType
+                        .name()
+                        .toString())
+                    .fields()
+                    .methods()
+                    .reason("VanillaBP reads the workflow aggregate's ID by reflection")
+                    .build());
+          }
 
           // generate process service CDI bean specific to the workflow aggregate
           generateProcessService(
@@ -202,11 +252,110 @@ public class ProcessServiceBuildStepProcessor {
               "%s.ProcessService_%s".formatted(
                   workflowAggregateType.name().packagePrefix(),
                   workflowAggregateType.name().withoutPackagePrefix()),
-              aggregatePersistenceType,
+              aggregatePersistenceClassName,
               workflowAggregateType,
               String.join(";", workflowTaskRegistrations));
 
         });
+
+  }
+
+  /**
+   * The message shown when neither the application nor one of the persistence idioms
+   * VanillaBP knows answers for an aggregate. It names what was looked for, because
+   * "provide a bean" alone leaves the reader guessing which of the Quarkus ways they
+   * were expected to use.
+   */
+  private static String missingAggregatePersistenceMessage(
+      final Type workflowAggregateType) {
+
+    return """
+        VanillaBP does not know how to persist the workflow aggregate '%s'!
+        Either the aggregate uses one of the persistence idioms VanillaBP serves out of the box:
+        - a Panache repository for the aggregate (PanacheRepository/PanacheRepositoryBase, or \
+        PanacheMongoRepository/PanacheMongoRepositoryBase): https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern
+        - the aggregate itself being a Panache active record (extending PanacheEntity/PanacheEntityBase, or \
+        PanacheMongoEntity/PanacheMongoEntityBase): https://quarkus.io/guides/hibernate-orm-panache#solution-1-using-the-active-record-pattern
+        - a Spring Data repository for the aggregate (extension quarkus-spring-data-jpa): https://quarkus.io/guides/spring-data-jpa
+        None of them was found for this aggregate (mind that classes of workflow modules have to be \
+        indexed using the jandex-maven-plugin to be seen).
+        Or, for any other kind of persistence, provide a CDI bean implementing
+          %s<%s>
+        which is responsible to persist this aggregate."""
+        .formatted(
+            workflowAggregateType.name(),
+            AggregatePersistenceAware.class.getName(),
+            workflowAggregateType
+                .name()
+                .withoutPackagePrefix());
+
+  }
+
+  /**
+   * Generates the CDI bean providing one of VanillaBP's persistence implementations
+   * for a specific aggregate:
+   *
+   * <pre>
+   * &#64;Singleton
+   * public class AggregatePersistence_Aggregate extends PanacheRepositoryAggregatePersistence&lt;Aggregate&gt; {
+   *   public AggregatePersistence_Aggregate() {
+   *     super(Aggregate.class, AggregateRepository.class);
+   *   }
+   * }
+   * </pre>
+   *
+   * The generic superclass is spelled out (not raw) on purpose: the bean type has to
+   * be {@code AggregatePersistenceAware<Aggregate>} for the runtime lookup of
+   * {@link ProcessServiceBaseCdiBean} to find it.
+   *
+   * @param className The class name of the bean to build
+   * @param defaultPersistence The implementation chosen for the aggregate
+   * @param workflowAggregateType The workflow aggregate type the persistence is for
+   */
+  private void generateDefaultAggregatePersistence(
+      final BuildProducer<GeneratedBeanBuildItem> generatedBeanBuildItemBuildProducer,
+      final String className,
+      final DefaultAggregatePersistenceResolver.DefaultPersistence defaultPersistence,
+      final Type workflowAggregateType) {
+
+    final var beanClassOutput = new GeneratedBeanGizmoAdaptor(generatedBeanBuildItemBuildProducer);
+    final var implementationClass = DotName.createSimple(defaultPersistence.implementationClass());
+    final var cc = ClassCreator
+        .builder()
+        .classOutput(beanClassOutput)
+        .className(className)
+        .signature(SignatureBuilder
+            .forClass()
+            .setSuperClass(
+                parameterizedType(classType(implementationClass), classType(workflowAggregateType.name()))))
+        .build();
+
+    cc.addAnnotation(Singleton.class);
+    // the bean is never injected but looked up by its class at runtime
+    cc.addAnnotation(Unremovable.class);
+
+    final var constructor = cc.getConstructorCreator(new String[0]);
+    final var aggregateClass = constructor.loadClass(workflowAggregateType
+        .name()
+        .toString());
+    if (defaultPersistence.repositoryClass() == null) {
+      constructor.invokeSpecialMethod(
+          MethodDescriptor.ofConstructor(defaultPersistence.implementationClass(), Class.class.getName()),
+          constructor.getThis(),
+          aggregateClass);
+    } else {
+      constructor.invokeSpecialMethod(
+          MethodDescriptor.ofConstructor(
+              defaultPersistence.implementationClass(), Class.class.getName(), Class.class.getName()),
+          constructor.getThis(),
+          aggregateClass,
+          constructor.loadClass(defaultPersistence
+              .repositoryClass()
+              .toString()));
+    }
+    constructor.returnVoid();
+
+    cc.close();
 
   }
 
@@ -267,7 +416,7 @@ public class ProcessServiceBuildStepProcessor {
    * @param workflowModuleId The ID of the workflow module the service belongs to
    * @param bpmnProcessId The BPMN process ID the service is for
    * @param className The class name of the service to build
-   * @param aggregatePersistenceType The aggregate persistence type to be used by the service
+   * @param aggregatePersistenceClassName The aggregate persistence class to be used by the service
    * @param workflowAggregateType The workflow aggregate type the service is for
    */
   private void generateProcessService(
@@ -275,11 +424,10 @@ public class ProcessServiceBuildStepProcessor {
       final String workflowModuleId,
       final String bpmnProcessId,
       final String className,
-      final ClassInfo aggregatePersistenceType,
+      final String aggregatePersistenceClassName,
       final Type workflowAggregateType,
       final String workflowTaskRegistrations) {
 
-    final var aggregatePersistenceClassName = aggregatePersistenceType.name().toString();
     final var aggregateClassName = workflowAggregateType.name().toString();
 
     /*

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/DefaultAggregatePersistenceResolverTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/DefaultAggregatePersistenceResolverTest.java
@@ -1,0 +1,202 @@
+package io.vanillabp.integration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.IndexView;
+import org.jboss.jandex.Indexer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.repository.CrudRepository;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import io.vanillabp.integration.deployment.processservice.DefaultAggregatePersistenceResolver;
+
+/**
+ * Story 69: which of VanillaBP's persistence implementations serves an aggregate is
+ * decided at build time on the Jandex index. A repository for the aggregate wins,
+ * then the aggregate being an active record, then a Spring Data repository - and two
+ * repositories for one aggregate fail the build instead of being picked by chance.
+ * <p>
+ * The MongoDB flavours are not indexed here: their extension would activate the
+ * MongoDB client for every test application of this module. They are covered
+ * end-to-end by {@code default-persistence-mongo-tests}.
+ */
+public class DefaultAggregatePersistenceResolverTest {
+
+  /* -------------------------------------------------- */
+  /* Test types                                         */
+  /* -------------------------------------------------- */
+
+  public static class PlainAggregate {
+  }
+
+  public static class PlainAggregateRepository implements PanacheRepositoryBase<PlainAggregate, String> {
+  }
+
+  public static class SecondPlainAggregateRepository implements PanacheRepositoryBase<PlainAggregate, String> {
+  }
+
+  public static class LongIdAggregate {
+  }
+
+  public interface LongIdAggregateRepositoryApi extends PanacheRepository<LongIdAggregate> {
+  }
+
+  public static class LongIdAggregateRepository implements LongIdAggregateRepositoryApi {
+  }
+
+  public static class ActiveRecordAggregate extends PanacheEntityBase {
+  }
+
+  public static class ActiveRecordWithRepository extends PanacheEntityBase {
+  }
+
+  public static class ActiveRecordWithRepositoryRepository implements PanacheRepositoryBase<ActiveRecordWithRepository, String> {
+  }
+
+  public static class SpringDataAggregate {
+  }
+
+  public interface SpringDataAggregateRepository extends CrudRepository<SpringDataAggregate, String> {
+  }
+
+  public static class UnknownAggregate {
+  }
+
+  /* -------------------------------------------------- */
+  /* Tests                                              */
+  /* -------------------------------------------------- */
+
+  @Test
+  @DisplayName("A Panache repository for the aggregate is used, no matter which of its two interfaces it implements")
+  public void panacheRepositoryIsFound() throws Exception {
+
+    final var index = indexOf(
+        PlainAggregate.class,
+        PlainAggregateRepository.class,
+        LongIdAggregate.class,
+        LongIdAggregateRepositoryApi.class,
+        LongIdAggregateRepository.class);
+
+    final var forPlain = resolve(index, PlainAggregate.class);
+    assertEquals(
+        DefaultAggregatePersistenceResolver.PANACHE_REPOSITORY_PERSISTENCE,
+        forPlain.implementationClass());
+    assertEquals(dotName(PlainAggregateRepository.class), forPlain.repositoryClass());
+
+    // the repository interface of the application is not a bean - the class is
+    final var forLongId = resolve(index, LongIdAggregate.class);
+    assertEquals(dotName(LongIdAggregateRepository.class), forLongId.repositoryClass());
+
+  }
+
+  @Test
+  @DisplayName("Without a repository the aggregate itself is asked: a Panache active record persists itself")
+  public void activeRecordIsFound() throws Exception {
+
+    final var index = indexOf(ActiveRecordAggregate.class);
+
+    final var resolved = resolve(index, ActiveRecordAggregate.class);
+    assertEquals(
+        DefaultAggregatePersistenceResolver.PANACHE_ACTIVE_RECORD_PERSISTENCE,
+        resolved.implementationClass());
+    assertEquals(null, resolved.repositoryClass());
+
+  }
+
+  @Test
+  @DisplayName("A repository beats the active record of the same aggregate")
+  public void repositoryBeatsActiveRecord() throws Exception {
+
+    final var index = indexOf(ActiveRecordWithRepository.class, ActiveRecordWithRepositoryRepository.class);
+
+    final var resolved = resolve(index, ActiveRecordWithRepository.class);
+    assertEquals(
+        DefaultAggregatePersistenceResolver.PANACHE_REPOSITORY_PERSISTENCE,
+        resolved.implementationClass());
+
+  }
+
+  @Test
+  @DisplayName("A Spring Data repository answers last - the repository interface itself is the bean")
+  public void springDataRepositoryIsFound() throws Exception {
+
+    final var index = indexOf(SpringDataAggregate.class, SpringDataAggregateRepository.class);
+
+    final var resolved = resolve(index, SpringDataAggregate.class);
+    assertEquals(
+        DefaultAggregatePersistenceResolver.SPRING_DATA_PERSISTENCE,
+        resolved.implementationClass());
+    assertEquals(dotName(SpringDataAggregateRepository.class), resolved.repositoryClass());
+
+  }
+
+  @Test
+  @DisplayName("An aggregate using none of the idioms is not served")
+  public void unknownAggregateIsNotServed() throws Exception {
+
+    final var index = indexOf(UnknownAggregate.class);
+
+    assertTrue(DefaultAggregatePersistenceResolver
+        .resolve(index, dotName(UnknownAggregate.class))
+        .isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("Two repositories for one aggregate fail the build naming both")
+  public void severalRepositoriesFailTheBuild() throws Exception {
+
+    final var index = indexOf(
+        PlainAggregate.class,
+        PlainAggregateRepository.class,
+        SecondPlainAggregateRepository.class);
+
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> DefaultAggregatePersistenceResolver.resolve(index, dotName(PlainAggregate.class)));
+    assertTrue(failure.getMessage().contains(PlainAggregateRepository.class.getName()), failure.getMessage());
+    assertTrue(failure.getMessage().contains(SecondPlainAggregateRepository.class.getName()), failure.getMessage());
+
+  }
+
+  /* -------------------------------------------------- */
+  /* Helpers                                            */
+  /* -------------------------------------------------- */
+
+  private static DefaultAggregatePersistenceResolver.DefaultPersistence resolve(
+      final IndexView index,
+      final Class<?> aggregateClass) {
+
+    return DefaultAggregatePersistenceResolver
+        .resolve(index, dotName(aggregateClass))
+        .orElseThrow(() -> new AssertionError(
+            "no persistence resolved for "
+                + aggregateClass.getName()));
+
+  }
+
+  private static DotName dotName(
+      final Class<?> clazz) {
+
+    return DotName.createSimple(clazz.getName());
+
+  }
+
+  private static IndexView indexOf(
+      final Class<?>... classes) throws Exception {
+
+    final var indexer = new Indexer();
+    for (final var clazz : classes) {
+      indexer.indexClass(clazz);
+    }
+    return indexer.complete();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/aggregateperstistence-tests/src/test/java/io/vanillabp/integration/it/NoPersistenceAvailableTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/aggregateperstistence-tests/src/test/java/io/vanillabp/integration/it/NoPersistenceAvailableTest.java
@@ -34,13 +34,15 @@ public class NoPersistenceAvailableTest {
         assertInstanceOf(IllegalStateException.class, rootCause);
         assertEquals(
             """
-                You have to provide a CDI bean implementing
-                  io.vanillabp.integration.spi.AggregatePersistenceAware
-                which is responsible to persist aggregates.
-                This is necessary because in Quarkus there is no unique way to do persistence of entities:
-                - Active record pattern: https://quarkus.io/guides/hibernate-orm-panache#solution-1-using-the-active-record-pattern
-                - Repository record pattern: https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern
-                - Spring Data pattern: https://quarkus.io/guides/spring-data-jpa""",
+                VanillaBP does not know how to persist the workflow aggregate 'io.vanillabp.integration.test.Aggregate'!
+                Either the aggregate uses one of the persistence idioms VanillaBP serves out of the box:
+                - a Panache repository for the aggregate (PanacheRepository/PanacheRepositoryBase, or PanacheMongoRepository/PanacheMongoRepositoryBase): https://quarkus.io/guides/hibernate-orm-panache#solution-2-using-the-repository-pattern
+                - the aggregate itself being a Panache active record (extending PanacheEntity/PanacheEntityBase, or PanacheMongoEntity/PanacheMongoEntityBase): https://quarkus.io/guides/hibernate-orm-panache#solution-1-using-the-active-record-pattern
+                - a Spring Data repository for the aggregate (extension quarkus-spring-data-jpa): https://quarkus.io/guides/spring-data-jpa
+                None of them was found for this aggregate (mind that classes of workflow modules have to be indexed using the jandex-maven-plugin to be seen).
+                Or, for any other kind of persistence, provide a CDI bean implementing
+                  io.vanillabp.integration.spi.AggregatePersistenceAware<Aggregate>
+                which is responsible to persist this aggregate.""",
             rootCause.getMessage());
       });
 

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/pom.xml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vanillabp.quarkus</groupId>
+    <artifactId>processservice-integration-tests</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>default-persistence-mongo-tests</artifactId>
+  <name>Quarkus integration - Integration tests - Default aggregate persistence (MongoDB)</name>
+  <description>Aggregates persisted by the MongoDB Panache implementations VanillaBP provides (story 69), against a MongoDB started by Quarkus Dev Services.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>vanillabp-quarkus-integration</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp.quarkus.adapter</groupId>
+      <artifactId>dummy-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-mongodb-panache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>test-utils</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoActiveRecordAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoActiveRecordAggregate.java
@@ -1,0 +1,18 @@
+package io.vanillabp.integration.test.persistence;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntityBase;
+
+/**
+ * The aggregate of the MongoDB Panache active record idiom: no repository anywhere,
+ * the entity itself carries the persistence.
+ */
+public class MongoActiveRecordAggregate extends PanacheMongoEntityBase {
+
+  @BsonId
+  public String id;
+
+  public String status;
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoActiveRecordWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoActiveRecordWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = MongoActiveRecordAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TestProcess"))
+public class MongoActiveRecordWorkflowService {
+
+  @Inject
+  ProcessService<MongoActiveRecordAggregate> processService;
+
+  public MongoActiveRecordAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new MongoActiveRecordAggregate();
+    aggregate.id = id;
+    aggregate.status = "started";
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final MongoActiveRecordAggregate aggregate) {
+
+    aggregate.status = "processed";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryAggregate.java
@@ -1,0 +1,34 @@
+package io.vanillabp.integration.test.persistence;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+/**
+ * The aggregate of the MongoDB Panache repository idiom, managed by
+ * {@link MongoRepositoryAggregateRepository}.
+ */
+public class MongoRepositoryAggregate {
+
+  @BsonId
+  private String id;
+
+  private String status;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(
+      final String status) {
+    this.status = status;
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryAggregateRepository.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryAggregateRepository.java
@@ -1,0 +1,8 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class MongoRepositoryAggregateRepository implements PanacheMongoRepositoryBase<MongoRepositoryAggregate, String> {
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = MongoRepositoryAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TestProcess"))
+public class MongoRepositoryWorkflowService {
+
+  @Inject
+  ProcessService<MongoRepositoryAggregate> processService;
+
+  public MongoRepositoryAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new MongoRepositoryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("started");
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final MongoRepositoryAggregate aggregate) {
+
+    aggregate.setStatus("processed");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/SingleTaskWiringSource.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/SingleTaskWiringSource.java
@@ -1,0 +1,30 @@
+package io.vanillabp.integration.test.persistence;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of all applications of this module: 'TestProcess' has
+ * exactly one task, wired to the <code>processTask</code> handler every workflow
+ * service here declares.
+ */
+@ApplicationScoped
+public class SingleTaskWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "TestProcess".equals(bpmnProcessId)
+        ? List.of(new BpmnTaskSpec("Activity_Process", "processTask"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/resources/application.yaml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/resources/application.yaml
@@ -1,0 +1,10 @@
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/resources/workflow-module-descriptor/workflow-module
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/resources/workflow-module-descriptor/workflow-module
@@ -1,0 +1,1 @@
+test-module

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/MongoActiveRecordPersistenceTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/MongoActiveRecordPersistenceTest.java
@@ -1,0 +1,108 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.MongoActiveRecordAggregate;
+import io.vanillabp.integration.test.persistence.MongoActiveRecordWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: an aggregate written as a MongoDB Panache active record (no repository
+ * anywhere) is persisted by VanillaBP through Panache's operations, not through the
+ * static methods Panache generates onto the entity.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MongoActiveRecordPersistenceTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(MongoActiveRecordAggregate.class)
+          .addClass(MongoActiveRecordWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("quarkus.mongodb.database", "mongo-active-record-it");
+
+  @Inject
+  MongoActiveRecordWorkflowService workflowService;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A MongoDB Panache active record is enough: the workflow starts and its task updates the aggregate")
+  public void mongoActiveRecordPersistsTheAggregate() {
+
+    final var started = workflowService.startWorkflow("mongo-active-record");
+    assertNotNull(started);
+
+    final MongoActiveRecordAggregate stored = MongoActiveRecordAggregate.findById("mongo-active-record");
+    assertNotNull(stored, "the aggregate was not stored by the default persistence");
+    assertEquals("started", stored.status);
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "mongo-active-record"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+
+    final MongoActiveRecordAggregate afterTask = MongoActiveRecordAggregate.findById("mongo-active-record");
+    assertEquals("processed", afterTask.status, "the aggregate was loaded and saved around the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/MongoRepositoryPersistenceTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/MongoRepositoryPersistenceTest.java
@@ -1,0 +1,115 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.MongoRepositoryAggregate;
+import io.vanillabp.integration.test.persistence.MongoRepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.MongoRepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: an application storing its aggregate in a MongoDB Panache repository
+ * writes no {@code AggregatePersistenceAware} at all - VanillaBP uses the repository
+ * (persistOrUpdate, MongoDB has no session to attach to).
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MongoRepositoryPersistenceTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(MongoRepositoryAggregate.class)
+          .addClass(MongoRepositoryAggregateRepository.class)
+          .addClass(MongoRepositoryWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("quarkus.mongodb.database", "mongo-repository-it");
+
+  @Inject
+  MongoRepositoryWorkflowService workflowService;
+
+  @Inject
+  MongoRepositoryAggregateRepository repository;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A MongoDB Panache repository is enough: the workflow starts and its task updates the aggregate")
+  public void mongoRepositoryPersistsTheAggregate() {
+
+    final var started = workflowService.startWorkflow("mongo-repository");
+    assertNotNull(started);
+
+    final var stored = repository.findById("mongo-repository");
+    assertNotNull(stored, "the aggregate was not stored by the default persistence");
+    assertEquals("started", stored.getStatus());
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "mongo-repository"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+
+    assertEquals(
+        "processed",
+        repository.findById("mongo-repository").getStatus(),
+        "the aggregate was loaded and saved around the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/pom.xml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vanillabp.quarkus</groupId>
+    <artifactId>processservice-integration-tests</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>default-persistence-tests</artifactId>
+  <name>Quarkus integration - Integration tests - Default aggregate persistence</name>
+  <description>Aggregates persisted by the implementations VanillaBP provides for the persistence idioms of Quarkus (story 69), against an in-memory H2.</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>vanillabp-quarkus-integration</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp.quarkus.adapter</groupId>
+      <artifactId>dummy-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-agroal</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-spring-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>test-utils</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveRecordAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveRecordAggregate.java
@@ -1,0 +1,19 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * The aggregate of the Hibernate ORM Panache active record idiom: no repository
+ * anywhere, the entity itself carries the persistence.
+ */
+@Entity
+public class ActiveRecordAggregate extends PanacheEntityBase {
+
+  @Id
+  public String id;
+
+  public String status;
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveRecordWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveRecordWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = ActiveRecordAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TestProcess"))
+public class ActiveRecordWorkflowService {
+
+  @Inject
+  ProcessService<ActiveRecordAggregate> processService;
+
+  public ActiveRecordAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new ActiveRecordAggregate();
+    aggregate.id = id;
+    aggregate.status = "started";
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final ActiveRecordAggregate aggregate) {
+
+    aggregate.status = "processed";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ApplicationRepositoryPersistence.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ApplicationRepositoryPersistence.java
@@ -1,0 +1,78 @@
+package io.vanillabp.integration.test.persistence;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * An implementation written by the application for an aggregate which HAS a Panache
+ * repository: VanillaBP has to use this one, the escape hatch has to stay one. Every
+ * call is counted so the test can prove which implementation ran.
+ */
+@ApplicationScoped
+public class ApplicationRepositoryPersistence implements AggregatePersistenceAware<RepositoryAggregate> {
+
+  private final AtomicInteger saves = new AtomicInteger();
+
+  private final AtomicInteger loads = new AtomicInteger();
+
+  @Inject
+  RepositoryAggregateRepository repository;
+
+  public int getSaves() {
+
+    return saves.get();
+
+  }
+
+  public int getLoads() {
+
+    return loads.get();
+
+  }
+
+  @Override
+  public Class<RepositoryAggregate> getAggregateClass() {
+
+    return RepositoryAggregate.class;
+
+  }
+
+  @Override
+  public RepositoryAggregate save(
+      final RepositoryAggregate aggregate) {
+
+    saves.incrementAndGet();
+    return repository
+        .getEntityManager()
+        .merge(aggregate);
+
+  }
+
+  @Override
+  public RepositoryAggregate loadById(
+      final Object aggregateId) {
+
+    loads.incrementAndGet();
+    return repository.findById((String) aggregateId);
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final RepositoryAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public String getAggregateIdName() {
+
+    return "id";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryAggregate.java
@@ -1,0 +1,36 @@
+package io.vanillabp.integration.test.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * The aggregate of the Hibernate ORM Panache repository idiom: a plain JPA entity
+ * with an application-assigned ID, managed by {@link RepositoryAggregateRepository}.
+ */
+@Entity
+public class RepositoryAggregate {
+
+  @Id
+  private String id;
+
+  private String status;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(
+      final String status) {
+    this.status = status;
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryAggregateRepository.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryAggregateRepository.java
@@ -1,0 +1,8 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class RepositoryAggregateRepository implements PanacheRepositoryBase<RepositoryAggregate, String> {
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = RepositoryAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TestProcess"))
+public class RepositoryWorkflowService {
+
+  @Inject
+  ProcessService<RepositoryAggregate> processService;
+
+  public RepositoryAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new RepositoryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("started");
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final RepositoryAggregate aggregate) {
+
+    aggregate.setStatus("processed");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SecondRepositoryAggregateRepository.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SecondRepositoryAggregateRepository.java
@@ -1,0 +1,12 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * A second Panache repository for {@link RepositoryAggregate}, used by the test
+ * proving that VanillaBP does not pick one of two repositories at random.
+ */
+@ApplicationScoped
+public class SecondRepositoryAggregateRepository implements PanacheRepositoryBase<RepositoryAggregate, String> {
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SingleTaskWiringSource.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SingleTaskWiringSource.java
@@ -1,0 +1,30 @@
+package io.vanillabp.integration.test.persistence;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of all applications of this module: 'TestProcess' has
+ * exactly one task, wired to the <code>processTask</code> handler every workflow
+ * service here declares.
+ */
+@ApplicationScoped
+public class SingleTaskWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "TestProcess".equals(bpmnProcessId)
+        ? List.of(new BpmnTaskSpec("Activity_Process", "processTask"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataAggregate.java
@@ -1,0 +1,36 @@
+package io.vanillabp.integration.test.persistence;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * The aggregate of the Spring Data idiom (extension quarkus-spring-data-jpa),
+ * managed by {@link SpringDataAggregateRepository}.
+ */
+@Entity
+public class SpringDataAggregate {
+
+  @Id
+  private String id;
+
+  private String status;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getStatus() {
+    return status;
+  }
+
+  public void setStatus(
+      final String status) {
+    this.status = status;
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataAggregateRepository.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataAggregateRepository.java
@@ -1,0 +1,6 @@
+package io.vanillabp.integration.test.persistence;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface SpringDataAggregateRepository extends CrudRepository<SpringDataAggregate, String> {
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/SpringDataWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = SpringDataAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "TestProcess"))
+public class SpringDataWorkflowService {
+
+  @Inject
+  ProcessService<SpringDataAggregate> processService;
+
+  public SpringDataAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new SpringDataAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("started");
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final SpringDataAggregate aggregate) {
+
+    aggregate.setStatus("processed");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/resources/application.yaml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/resources/application.yaml
@@ -1,0 +1,18 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:default-persistence;DB_CLOSE_DELAY=-1
+  hibernate-orm:
+    database:
+      generation: drop-and-create
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/resources/workflow-module-descriptor/workflow-module
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/resources/workflow-module-descriptor/workflow-module
@@ -1,0 +1,1 @@
+test-module

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/AmbiguousRepositoriesTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/AmbiguousRepositoriesTest.java
@@ -1,0 +1,64 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.persistence.RepositoryAggregate;
+import io.vanillabp.integration.test.persistence.RepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.RepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SecondRepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 69: two repositories for one aggregate are not a coin flip. The build fails
+ * and the message names both of them, so the developer either keeps one or writes
+ * the {@code AggregatePersistenceAware} deciding it.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AmbiguousRepositoriesTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(RepositoryAggregate.class)
+          .addClass(RepositoryAggregateRepository.class)
+          .addClass(SecondRepositoryAggregateRepository.class)
+          .addClass(RepositoryWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .assertException(throwable -> {
+        var current = throwable;
+        while (current != null) {
+          if ((current.getMessage() != null) && current.getMessage().contains("Several repositories manage")) {
+            assertTrue(current.getMessage().contains(RepositoryAggregate.class.getName()), current.getMessage());
+            assertTrue(
+                current.getMessage().contains(RepositoryAggregateRepository.class.getName()),
+                current.getMessage());
+            assertTrue(
+                current.getMessage().contains(SecondRepositoryAggregateRepository.class.getName()),
+                current.getMessage());
+            return;
+          }
+          current = current.getCause();
+        }
+        fail("expected the guiding message about several repositories but got: "
+            + throwable);
+      });
+
+  @Test
+  @DisplayName("Two repositories for one aggregate fail the build naming both")
+  public void ambiguousRepositoriesFailTheBuild() {
+    // the assertion happens on the build exception (assertException above)
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/ApplicationPersistenceWinsTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/ApplicationPersistenceWinsTest.java
@@ -1,0 +1,121 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.ApplicationRepositoryPersistence;
+import io.vanillabp.integration.test.persistence.RepositoryAggregate;
+import io.vanillabp.integration.test.persistence.RepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.RepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: the defaults are a fallback, never a takeover. This application has a
+ * Panache repository for its aggregate AND an {@code AggregatePersistenceAware} of
+ * its own - the latter has to be the one VanillaBP calls, in both directions.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ApplicationPersistenceWinsTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(RepositoryAggregate.class)
+          .addClass(RepositoryAggregateRepository.class)
+          .addClass(ApplicationRepositoryPersistence.class)
+          .addClass(RepositoryWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  RepositoryWorkflowService workflowService;
+
+  @Inject
+  RepositoryAggregateRepository repository;
+
+  @Inject
+  ApplicationRepositoryPersistence applicationPersistence;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("An AggregatePersistenceAware of the application beats the Panache repository default")
+  public void applicationPersistenceIsUsedAlthoughARepositoryExists() {
+
+    final var started = QuarkusTransaction
+        .requiringNew()
+        .call(() -> workflowService.startWorkflow("application-owned"));
+    assertNotNull(started);
+    assertTrue(applicationPersistence.getSaves() > 0, "the application's save was not called");
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "application-owned"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+    assertTrue(applicationPersistence.getLoads() > 0, "the application's loadById was not called");
+
+    final var afterTask = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("application-owned"));
+    assertEquals("processed", afterTask.getStatus());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PanacheActiveRecordPersistenceTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PanacheActiveRecordPersistenceTest.java
@@ -1,0 +1,116 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.ActiveRecordAggregate;
+import io.vanillabp.integration.test.persistence.ActiveRecordWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: an aggregate written as a Hibernate ORM Panache active record (no
+ * repository anywhere) is persisted by VanillaBP through the entity manager of the
+ * aggregate's persistence unit. Both directions are exercised: starting a workflow
+ * stores the aggregate, and a task delivered by the BPMS loads it, runs the handler
+ * and stores the change.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PanacheActiveRecordPersistenceTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(ActiveRecordAggregate.class)
+          .addClass(ActiveRecordWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  ActiveRecordWorkflowService workflowService;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A Panache active record is enough: the workflow starts and its task updates the aggregate")
+  public void panacheActiveRecordPersistsTheAggregate() {
+
+    final var started = QuarkusTransaction
+        .requiringNew()
+        .call(() -> workflowService.startWorkflow("active-record"));
+    assertNotNull(started);
+
+    final ActiveRecordAggregate stored = QuarkusTransaction
+        .requiringNew()
+        .call(() -> ActiveRecordAggregate.findById("active-record"));
+    assertNotNull(stored, "the aggregate was not stored by the default persistence");
+    assertEquals("started", stored.status);
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "active-record"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+
+    final ActiveRecordAggregate afterTask = QuarkusTransaction
+        .requiringNew()
+        .call(() -> ActiveRecordAggregate.findById("active-record"));
+    assertEquals("processed", afterTask.status, "the aggregate was loaded and saved around the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PanacheRepositoryPersistenceTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PanacheRepositoryPersistenceTest.java
@@ -1,0 +1,121 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.RepositoryAggregate;
+import io.vanillabp.integration.test.persistence.RepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.RepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: an application storing its aggregate in a Hibernate ORM Panache
+ * repository writes no {@code AggregatePersistenceAware} at all - VanillaBP uses the
+ * repository. Both directions are exercised: starting a workflow stores the
+ * aggregate, and a task delivered by the BPMS loads it, runs the handler and stores
+ * the change.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PanacheRepositoryPersistenceTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(RepositoryAggregate.class)
+          .addClass(RepositoryAggregateRepository.class)
+          .addClass(RepositoryWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  RepositoryWorkflowService workflowService;
+
+  @Inject
+  RepositoryAggregateRepository repository;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A Panache repository is enough: the workflow starts and its task updates the aggregate")
+  public void panacheRepositoryPersistsTheAggregate() {
+
+    final var started = QuarkusTransaction
+        .requiringNew()
+        .call(() -> workflowService.startWorkflow("panache-repository"));
+    assertNotNull(started);
+
+    final var stored = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("panache-repository"));
+    assertNotNull(stored, "the aggregate was not stored by the default persistence");
+    assertEquals("started", stored.getStatus());
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "panache-repository"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+
+    final var afterTask = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("panache-repository"));
+    assertEquals("processed", afterTask.getStatus(), "the aggregate was loaded and saved around the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/SpringDataPersistenceTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/SpringDataPersistenceTest.java
@@ -1,0 +1,121 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.persistence.SpringDataAggregate;
+import io.vanillabp.integration.test.persistence.SpringDataAggregateRepository;
+import io.vanillabp.integration.test.persistence.SpringDataWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 69: an application using Spring Data repositories on Quarkus (extension
+ * quarkus-spring-data-jpa) writes no {@code AggregatePersistenceAware} at all -
+ * VanillaBP uses the repository, the same API the Spring Boot integration uses. Both directions are exercised: starting a workflow stores the
+ * aggregate, and a task delivered by the BPMS loads it, runs the handler and stores
+ * the change.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SpringDataPersistenceTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(SpringDataAggregate.class)
+          .addClass(SpringDataAggregateRepository.class)
+          .addClass(SpringDataWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  SpringDataWorkflowService workflowService;
+
+  @Inject
+  SpringDataAggregateRepository repository;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A Spring Data repository is enough: the workflow starts and its task updates the aggregate")
+  public void springDataRepositoryPersistsTheAggregate() {
+
+    final var started = QuarkusTransaction
+        .requiringNew()
+        .call(() -> workflowService.startWorkflow("spring-data"));
+    assertNotNull(started);
+
+    final var stored = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("spring-data").orElse(null));
+    assertNotNull(stored, "the aggregate was not stored by the default persistence");
+    assertEquals("started", stored.getStatus());
+
+    final var outcome = dummyAdapter()
+        .invokeTask("test-module", "TestProcess", context("processTask", "spring-data"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+
+    final var afterTask = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("spring-data").orElse(null));
+    assertEquals("processed", afterTask.getStatus(), "the aggregate was loaded and saved around the task");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/pom.xml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/pom.xml
@@ -14,6 +14,8 @@
 
   <modules>
     <module>aggregateperstistence-tests</module>
+    <module>default-persistence-tests</module>
+    <module>default-persistence-mongo-tests</module>
     <module>discovery-tests</module>
   </modules>
 </project>

--- a/quarkus-integration/runtime/pom.xml
+++ b/quarkus-integration/runtime/pom.xml
@@ -56,15 +56,37 @@
       <optional>true</optional>
     </dependency>
     <dependency>
+      <!-- optional: aggregate persistence defaults for Hibernate ORM Panache
+           (repository and active record) -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <!-- optional: aggregate persistence defaults for MongoDB Panache -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-mongodb-panache</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <!-- optional: aggregate persistence default for Spring Data repositories
+           (the API artifact only, the extension itself is the application's choice) -->
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-spring-data-commons-api</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>test-utils</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- optional: the JPA-backed aggregate persistence defaults and the tests
+           of the JDBC outbox (an application gets it from its Hibernate extension) -->
       <groupId>jakarta.persistence</groupId>
       <artifactId>jakarta.persistence-api</artifactId>
-      <scope>test</scope>
+      <optional>true</optional>
     </dependency>
   </dependencies>
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/DefaultAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/DefaultAggregatePersistence.java
@@ -1,0 +1,68 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import io.vanillabp.integration.spi.AggregateIdTypes;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+
+/**
+ * Base class of the persistence implementations VanillaBP provides for the
+ * persistence idioms of Quarkus (Hibernate ORM Panache, MongoDB Panache and Spring
+ * Data). One subclass per aggregate is generated at build time
+ * (<code>ProcessServiceBuildStepProcessor</code>) whenever the application does not
+ * provide an {@link AggregatePersistenceAware} of its own for that aggregate - an
+ * application-provided implementation always wins.
+ * <p>
+ * Everything about the aggregate's ID is answered by reflection
+ * ({@link AggregateIdTypes}) rather than by asking the persistence framework: the
+ * ID's name and type are needed at startup and at deployment, where neither a
+ * transaction nor a session is guaranteed to be around, and the rules of
+ * {@link AggregateIdTypes} (a field or getter annotated with
+ * {@code jakarta.persistence.Id}, {@code jakarta.persistence.EmbeddedId} or
+ * {@code org.bson.codecs.pojo.annotations.BsonId}, otherwise a member named
+ * <code>id</code>) match what JPA and the MongoDB codecs use anyway.
+ *
+ * @param <A> The aggregate type
+ */
+public abstract class DefaultAggregatePersistence<A> implements AggregatePersistenceAware<A> {
+
+  protected final Class<A> aggregateClass;
+
+  protected DefaultAggregatePersistence(
+      final Class<A> aggregateClass) {
+
+    this.aggregateClass = aggregateClass;
+
+  }
+
+  @Override
+  public Class<A> getAggregateClass() {
+
+    return aggregateClass;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final A aggregate) {
+
+    return AggregateIdTypes.readId(aggregate);
+
+  }
+
+  @Override
+  public String getAggregateIdName() {
+
+    return AggregateIdTypes
+        .determineIdName(aggregateClass)
+        .orElseThrow(() -> new IllegalStateException(
+            """
+                No ID property found for workflow aggregate '%s'! The configured VanillaBP \
+                adapter stores the aggregate's ID in the BPMS named like the aggregate's ID \
+                property. Annotate the property (e.g. jakarta.persistence.Id or \
+                org.bson.codecs.pojo.annotations.BsonId), name it 'id', or provide your own \
+                io.vanillabp.integration.spi.AggregatePersistenceAware implementation for this \
+                aggregate."""
+                .formatted(aggregateClass.getName())));
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/JpaPersistenceSupport.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/JpaPersistenceSupport.java
@@ -1,0 +1,52 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import java.util.function.Function;
+
+import jakarta.persistence.EntityManager;
+
+/**
+ * The JPA half of the persistence defaults: storing an aggregate the way Spring Data
+ * does it on the Spring Boot integration, so an application switching platforms sees
+ * the same behavior.
+ */
+final class JpaPersistenceSupport {
+
+  private JpaPersistenceSupport() {
+    // utility class
+  }
+
+  /**
+   * Stores the aggregate:
+   * <ol>
+   * <li>an aggregate already managed by the session is left alone (the session
+   * writes it at flush),</li>
+   * <li>an aggregate without an ID is new and gets persisted, so the caller's
+   * instance receives a generated ID,</li>
+   * <li>anything else is merged, which covers both an aggregate loaded in an earlier
+   * transaction and a new aggregate carrying an application-assigned ID (Hibernate
+   * inserts it if there is no row yet) - this is what Spring Data's
+   * <code>save</code> does, too.</li>
+   * </ol>
+   *
+   * @param aggregate The aggregate to store
+   * @param entityManager The entity manager of the aggregate's persistence unit
+   * @param idOf Reads the aggregate's ID
+   * @return The stored aggregate, attached to the session
+   */
+  static <A> A save(
+      final A aggregate,
+      final EntityManager entityManager,
+      final Function<A, Object> idOf) {
+
+    if (entityManager.contains(aggregate)) {
+      return aggregate;
+    }
+    if (idOf.apply(aggregate) == null) {
+      entityManager.persist(aggregate);
+      return aggregate;
+    }
+    return entityManager.merge(aggregate);
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheActiveRecordAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheActiveRecordAggregatePersistence.java
@@ -1,0 +1,50 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import io.quarkus.hibernate.orm.panache.Panache;
+
+/**
+ * Persistence of aggregates using the Hibernate ORM Panache active record pattern
+ * (the aggregate extends {@code PanacheEntity} or {@code PanacheEntityBase}), used
+ * whenever the application has no Panache repository and no
+ * {@link io.vanillabp.integration.spi.AggregatePersistenceAware} of its own for the
+ * aggregate.
+ * <p>
+ * The entity manager of the aggregate's persistence unit is used directly
+ * ({@link Panache#getEntityManager(Class)}) instead of the static
+ * <code>findById</code>/<code>persist</code> methods Panache generates onto the
+ * entity: those would have to be called by reflection, and the entity manager is the
+ * documented way to reach the same session.
+ *
+ * @param <A> The aggregate type
+ */
+public class PanacheActiveRecordAggregatePersistence<A> extends DefaultAggregatePersistence<A> {
+
+  public PanacheActiveRecordAggregatePersistence(
+      final Class<A> aggregateClass) {
+
+    super(aggregateClass);
+
+  }
+
+  @Override
+  public A save(
+      final A aggregate) {
+
+    return JpaPersistenceSupport.save(
+        aggregate,
+        Panache.getEntityManager(aggregateClass),
+        this::getAggregateId);
+
+  }
+
+  @Override
+  public A loadById(
+      final Object aggregateId) {
+
+    return Panache
+        .getEntityManager(aggregateClass)
+        .find(aggregateClass, aggregateId);
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheMongoActiveRecordAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheMongoActiveRecordAggregatePersistence.java
@@ -1,0 +1,45 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import io.quarkus.mongodb.panache.runtime.JavaMongoOperations;
+
+/**
+ * Persistence of aggregates using the MongoDB Panache active record pattern (the
+ * aggregate extends {@code PanacheMongoEntity} or {@code PanacheMongoEntityBase}),
+ * used whenever the application has no MongoDB Panache repository and no
+ * {@link io.vanillabp.integration.spi.AggregatePersistenceAware} of its own for the
+ * aggregate.
+ * <p>
+ * Panache's own entity methods are generated as static members onto the entity and
+ * would have to be called by reflection; the operations object behind them is public
+ * API and is used directly instead.
+ *
+ * @param <A> The aggregate type
+ */
+public class PanacheMongoActiveRecordAggregatePersistence<A> extends DefaultAggregatePersistence<A> {
+
+  public PanacheMongoActiveRecordAggregatePersistence(
+      final Class<A> aggregateClass) {
+
+    super(aggregateClass);
+
+  }
+
+  @Override
+  public A save(
+      final A aggregate) {
+
+    JavaMongoOperations.INSTANCE.persistOrUpdate(aggregate);
+    return aggregate;
+
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public A loadById(
+      final Object aggregateId) {
+
+    return (A) JavaMongoOperations.INSTANCE.findById(aggregateClass, aggregateId);
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheMongoRepositoryAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheMongoRepositoryAggregatePersistence.java
@@ -1,0 +1,62 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import io.quarkus.mongodb.panache.PanacheMongoRepositoryBase;
+import jakarta.enterprise.inject.spi.CDI;
+
+/**
+ * Persistence of aggregates managed by a MongoDB Panache repository
+ * ({@code PanacheMongoRepository} or {@code PanacheMongoRepositoryBase}), used
+ * whenever the application has such a repository for the aggregate and no
+ * {@link io.vanillabp.integration.spi.AggregatePersistenceAware} of its own.
+ * <p>
+ * MongoDB has no session, so storing is <code>persistOrUpdate</code>: the document is
+ * inserted or replaced, whichever applies, and the caller keeps its instance.
+ *
+ * @param <A> The aggregate type
+ */
+public class PanacheMongoRepositoryAggregatePersistence<A> extends DefaultAggregatePersistence<A> {
+
+  private final Class<?> repositoryClass;
+
+  private volatile PanacheMongoRepositoryBase<A, Object> repository;
+
+  public PanacheMongoRepositoryAggregatePersistence(
+      final Class<A> aggregateClass,
+      final Class<?> repositoryClass) {
+
+    super(aggregateClass);
+    this.repositoryClass = repositoryClass;
+
+  }
+
+  @Override
+  public A save(
+      final A aggregate) {
+
+    repository().persistOrUpdate(aggregate);
+    return aggregate;
+
+  }
+
+  @Override
+  public A loadById(
+      final Object aggregateId) {
+
+    return repository().findById(aggregateId);
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private PanacheMongoRepositoryBase<A, Object> repository() {
+
+    if (repository == null) {
+      repository = (PanacheMongoRepositoryBase<A, Object>) CDI
+          .current()
+          .select(repositoryClass)
+          .get();
+    }
+    return repository;
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheRepositoryAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/PanacheRepositoryAggregatePersistence.java
@@ -1,0 +1,63 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepositoryBase;
+import jakarta.enterprise.inject.spi.CDI;
+
+/**
+ * Persistence of aggregates managed by a Hibernate ORM Panache repository
+ * ({@code PanacheRepository} or {@code PanacheRepositoryBase}), used whenever the
+ * application has such a repository for the aggregate and no
+ * {@link io.vanillabp.integration.spi.AggregatePersistenceAware} of its own.
+ * <p>
+ * The repository bean is resolved on first use instead of being injected: the
+ * subclass generated per aggregate has a no-arg constructor (build-time generated
+ * bytecode) and the repository must not be touched before the CDI container is up.
+ *
+ * @param <A> The aggregate type
+ */
+public class PanacheRepositoryAggregatePersistence<A> extends DefaultAggregatePersistence<A> {
+
+  private final Class<?> repositoryClass;
+
+  private volatile PanacheRepositoryBase<A, Object> repository;
+
+  public PanacheRepositoryAggregatePersistence(
+      final Class<A> aggregateClass,
+      final Class<?> repositoryClass) {
+
+    super(aggregateClass);
+    this.repositoryClass = repositoryClass;
+
+  }
+
+  @Override
+  public A save(
+      final A aggregate) {
+
+    final var entityManager = repository().getEntityManager();
+    return JpaPersistenceSupport.save(aggregate, entityManager, this::getAggregateId);
+
+  }
+
+  @Override
+  public A loadById(
+      final Object aggregateId) {
+
+    return repository().findById(aggregateId);
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private PanacheRepositoryBase<A, Object> repository() {
+
+    if (repository == null) {
+      repository = (PanacheRepositoryBase<A, Object>) CDI
+          .current()
+          .select(repositoryClass)
+          .get();
+    }
+    return repository;
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/SpringDataAggregatePersistence.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/persistence/SpringDataAggregatePersistence.java
@@ -1,0 +1,65 @@
+package io.vanillabp.integration.runtime.persistence;
+
+import org.springframework.data.repository.CrudRepository;
+
+import jakarta.enterprise.inject.spi.CDI;
+
+/**
+ * Persistence of aggregates managed by a Spring Data repository (extension
+ * {@code quarkus-spring-data-jpa}), used whenever the application has a
+ * {@code CrudRepository} for the aggregate, no Panache repository, no Panache active
+ * record and no {@link io.vanillabp.integration.spi.AggregatePersistenceAware} of its
+ * own.
+ * <p>
+ * This is the same repository API the Spring Boot integration uses, so an application
+ * moving between the two platforms keeps the behavior of <code>save</code>.
+ *
+ * @param <A> The aggregate type
+ */
+public class SpringDataAggregatePersistence<A> extends DefaultAggregatePersistence<A> {
+
+  private final Class<?> repositoryClass;
+
+  private volatile CrudRepository<A, Object> repository;
+
+  public SpringDataAggregatePersistence(
+      final Class<A> aggregateClass,
+      final Class<?> repositoryClass) {
+
+    super(aggregateClass);
+    this.repositoryClass = repositoryClass;
+
+  }
+
+  @Override
+  public A save(
+      final A aggregate) {
+
+    return repository().save(aggregate);
+
+  }
+
+  @Override
+  public A loadById(
+      final Object aggregateId) {
+
+    return repository()
+        .findById(aggregateId)
+        .orElse(null);
+
+  }
+
+  @SuppressWarnings("unchecked")
+  private CrudRepository<A, Object> repository() {
+
+    if (repository == null) {
+      repository = (CrudRepository<A, Object>) CDI
+          .current()
+          .select(repositoryClass)
+          .get();
+    }
+    return repository;
+
+  }
+
+}


### PR DESCRIPTION
Story 69. On Spring Boot an application never has to implement `AggregatePersistenceAware`; on Quarkus it had to, for every aggregate, because Quarkus has no single persistence idiom. It has four, though, and VanillaBP can recognise each of them.

## What is served now

| The aggregate is | What VanillaBP uses |
|---|---|
| managed by a Panache repository | that repository |
| managed by a MongoDB Panache repository | that repository |
| a Panache active record (JPA or MongoDB) | the entity manager respectively Panache's operations |
| managed by a Spring Data repository (`quarkus-spring-data-jpa`) | that repository |

A repository for the aggregate wins over the aggregate being an active record, and Spring Data answers last. An `AggregatePersistenceAware` written by the application beats all of them, always.

## How

- `DefaultAggregatePersistenceResolver` decides per aggregate at build time on the combined Jandex index. No capability check: there is none for Hibernate ORM Panache or Spring Data, and an application having a repository for the aggregate has the extension anyway.
- One `@Singleton` subclass per aggregate is generated with Gizmo, with the generic superclass spelled out, so the runtime lookup over `Instance<AggregatePersistenceAware<?>>` finds it.
- Saving follows Spring Data (managed stays, no ID persists, otherwise merge), so an aggregate behaves the same on both platforms. MongoDB does `persistOrUpdate`. Active records go through `Panache.getEntityManager(Class)` respectively `JavaMongoOperations.INSTANCE` instead of reflection on the generated statics.
- Name, type and value of the aggregate's ID come from `AggregateIdTypes` (which gained `determineIdName` and `readId`), not from the persistence framework: they are needed at build and startup time where no session is guaranteed. The aggregate is registered for reflection in native images.
- Two setups end the build with a guiding message: two repositories for one aggregate (both named), and an aggregate using none of the idioms. The old "you have to provide a CDI bean" message now says what was looked for, including the Jandex hint.

## Tests

6 resolver unit tests, 4 `AggregateIdTypes` tests, the new module `default-persistence-tests` (H2: repository, active record, Spring Data, application implementation wins although a repository exists, ambiguity fails the build) and `default-persistence-mongo-tests` (Dev Services: repository and active record). `NoPersistenceAvailableTest` pins the new message. The Quarkus reactor is green.

Worth knowing for later: MongoDB Panache as a test dependency of the deployment module activates the MongoDB client extension for every test application there, after which the Mongo task delivery log wants a database at startup and 15 unrelated tests fail. The MongoDB idioms are therefore only indexed in the integration tests.

## Docs

Quarkus README item 5, a new wiki section "Persisting workflow aggregates" (plus a correction in the outbox section, which claimed Quarkus never knows which persistence manages an aggregate), `Workflow-aggregates`, the version-1 migration guide and the `vanillabp-concepts` skill.

Story 67 stays open: the defaults deliberately open no transaction of their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25