### PR TITLE
Phase two calls the application inside a transaction VanillaBP owns

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -451,6 +451,20 @@ the local transaction, starting is split into two phases
   fails with a guiding message naming the remedies (the same message remains as a
   runtime backstop).
 
+**What phase two may expect (story 67):** the dispatch calls back into the
+application - a remote BPMS adapter loads the workflow aggregate to build what it
+sends to the BPMS - and it does so on the outbox dispatcher's own thread, where
+nothing the application relies on is active by itself. VanillaBP therefore provides
+it: the `PhaseTwoRouter` runs every dispatch through the platform's
+`TransactionRunner.requireTransaction`, which joins a transaction the store already
+opened and starts one otherwise. On Quarkus that runner additionally activates the
+CDI request context, without which an entity manager cannot be touched at all. Since
+the guarantee sits in the router, an outbox contributed by an application gets it as
+well, and stores which dispatch inside their own transaction (gruelbox on Spring
+Boot) keep theirs. Spring Boot passes no runner today: gruelbox brings the
+transaction, and Spring Data opens what it needs per call - see the platform's
+wiki page for what an application may rely on.
+
 A scheduled call is described by the immutable value type `PhaseTwoCall`
 (operation, workflow module, BPMN process, workflow-aggregate ID in serialized
 String form, elected adapter ID, operation-specific args). The dispatch chain is as

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
 import io.vanillabp.integration.spi.PhaseTwoCall;
 import io.vanillabp.integration.spi.PhaseTwoOperation;
 import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
@@ -45,9 +46,17 @@ public final class PhaseTwoRouter {
 
   private final PhaseTwoOperationRegistry operations;
 
+  /**
+   * Provides the transaction (and whatever else the platform needs, e.g. an active
+   * CDI request context on Quarkus) the dispatch runs in, or <code>null</code> if
+   * the platform's outbox implementations bring their own (Spring Boot: gruelbox
+   * dispatches inside a transaction it manages).
+   */
+  private final TransactionRunner transactionRunner;
+
   public PhaseTwoRouter() {
 
-    this(new PhaseTwoOperationRegistry());
+    this(new PhaseTwoOperationRegistry(), null);
 
   }
 
@@ -58,7 +67,33 @@ public final class PhaseTwoRouter {
   public PhaseTwoRouter(
       final PhaseTwoOperationRegistry operations) {
 
+    this(operations, null);
+
+  }
+
+  /**
+   * @param transactionRunner Provides the transaction dispatching runs in, see
+   *        {@link #transactionRunner}
+   */
+  public PhaseTwoRouter(
+      final TransactionRunner transactionRunner) {
+
+    this(new PhaseTwoOperationRegistry(), transactionRunner);
+
+  }
+
+  /**
+   * @param operations The registry to register the core operations in and to
+   *        resolve dispatched operations from
+   * @param transactionRunner Provides the transaction dispatching runs in, see
+   *        {@link #transactionRunner}
+   */
+  public PhaseTwoRouter(
+      final PhaseTwoOperationRegistry operations,
+      final TransactionRunner transactionRunner) {
+
     this.operations = operations;
+    this.transactionRunner = transactionRunner;
     registerCoreOperations();
 
   }
@@ -143,7 +178,19 @@ public final class PhaseTwoRouter {
                     call.workflowAggregateId(),
                     String.join(", ", operations.registeredNames()))));
 
-    dispatch.dispatch(call, previouslyAttempted);
+    // phase two runs on the outbox dispatcher's own thread and calls back into the
+    // application (the aggregate has to be loaded to build what the BPMS is told).
+    // Whatever that needs - a transaction, an active CDI request context - is
+    // VanillaBP's to provide here, once for every outbox implementation, instead of
+    // in each of them.
+    if (transactionRunner == null) {
+      dispatch.dispatch(call, previouslyAttempted);
+      return;
+    }
+    transactionRunner.requireTransaction(() -> {
+      dispatch.dispatch(call, previouslyAttempted);
+      return null;
+    });
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/TransactionRunner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/transaction/TransactionRunner.java
@@ -40,13 +40,37 @@ public interface TransactionRunner {
       Supplier<T> work);
 
   /**
+   * Runs the given work in a transaction, JOINING the one active on the calling
+   * thread and starting a new one otherwise (semantics of "required").
+   * <p>
+   * This is what phase-two dispatch uses: VanillaBP calls back into the application
+   * (the workflow aggregate has to be loaded to build what the BPMS is told) from
+   * the outbox dispatcher's own thread, where the platform provides nothing on its
+   * own. An outbox implementation which dispatches inside a transaction of its own
+   * (e.g. gruelbox on Spring Boot) keeps it, everything else gets one from VanillaBP.
+   * <p>
+   * The default runs the work in a new transaction - platforms activating additional
+   * contexts (Quarkus: the CDI request context) override it.
+   *
+   * @param <T> The result type
+   * @param work The work to run
+   * @return The work's result
+   */
+  default <T> T requireTransaction(
+      final Supplier<T> work) {
+
+    return requireNew(work);
+
+  }
+
+  /**
    * Whether the transaction of the work currently running was marked rollback-only,
    * which no longer allows a commit. Only a transaction annotation of the
    * application can do that to VanillaBP's transaction, and the mark cannot be
    * cleared, in neither Spring nor JTA.
    * <p>
-   * Valid only while work handed to {@link #requireNew(Supplier)} or
-   * {@link #inCurrent(Supplier)} is running; outside of that the answer is
+   * Valid only while work handed to {@link #requireNew(Supplier)},
+   * {@link #inCurrent(Supplier)} or {@link #requireTransaction(Supplier)} is running; outside of that the answer is
    * <code>false</code>.
    *
    * @return <code>true</code> if the current transaction can no longer commit

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
@@ -11,10 +11,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
+import io.vanillabp.integration.adapter.migration.transaction.TransactionRunner;
 import io.vanillabp.integration.spi.PhaseTwoCall;
 import io.vanillabp.integration.spi.PhaseTwoOperation;
 import io.vanillabp.integration.test.utils.SuppressOutputExtension;
@@ -39,6 +41,86 @@ public class PhaseTwoRouterTest {
     when(processService.getBpmnProcessId()).thenReturn("TestProcess");
 
     testee.register(processService);
+
+  }
+
+  @Test
+  @DisplayName("Dispatch runs inside the transaction the platform provides (story 67)")
+  public void dispatchRunsInsideTheProvidedTransaction() {
+
+    when(processService.getWorkflowModuleId()).thenReturn("test-module");
+    when(processService.getBpmnProcessId()).thenReturn("TestProcess");
+    when(processService.convertAggregateId("42")).thenReturn(42L);
+
+    final var runner = new RecordingTransactionRunner();
+    final var router = new PhaseTwoRouter(runner);
+    router.register(processService);
+
+    router.dispatch(PhaseTwoCall
+        .of(
+            PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", "42", "test-adapter", Map.of()));
+
+    assertTrue(runner.dispatchedInsideTransaction, "phase two ran without the transaction the platform provided");
+
+  }
+
+  /**
+   * Stands in for a platform's transaction runner and remembers whether the work it
+   * received actually reached the process service.
+   */
+  private class RecordingTransactionRunner implements TransactionRunner {
+
+    private boolean insideTransaction;
+
+    private boolean dispatchedInsideTransaction;
+
+    @Override
+    public <T> T requireTransaction(
+        final java.util.function.Supplier<T> work) {
+
+      insideTransaction = true;
+      try {
+        final var result = work.get();
+        dispatchedInsideTransaction = insideTransaction && Mockito.mockingDetails(processService).getInvocations()
+            .stream().anyMatch(
+                invocation -> invocation.getMethod().getName().equals("startWorkflowPhaseTwo"));
+        return result;
+      } finally {
+        insideTransaction = false;
+      }
+
+    }
+
+    @Override
+    public <T> T requireNew(
+        final java.util.function.Supplier<T> work) {
+
+      throw new UnsupportedOperationException("phase two has to use requireTransaction");
+
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final java.util.function.Supplier<T> work) {
+
+      throw new UnsupportedOperationException("phase two has to use requireTransaction");
+
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+
+      return false;
+
+    }
+
+    @Override
+    public boolean isConcurrentModification(
+        final Throwable failure) {
+
+      return false;
+
+    }
 
   }
 

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyProcessServiceProducer.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyProcessServiceProducer.java
@@ -44,6 +44,15 @@ public class DummyProcessServiceProducer {
    */
   public static final String PROPERTY_TWO_PHASE_COMMIT = "dummy-adapter.two-phase-commit";
 
+  /**
+   * The property making the dummy adapter READ the workflow aggregate in phase two,
+   * the way an adapter of a remote BPMS does (it builds the variables it sends from
+   * the aggregate). Off by default, because most test doubles of
+   * {@link io.vanillabp.integration.spi.AggregatePersistenceAware} implement nothing
+   * but save; the tests of the phase-two contract (story 67) switch it on.
+   */
+  public static final String PROPERTY_READ_AGGREGATE_IN_PHASE_TWO = "dummy-adapter.read-aggregate-in-phase-two";
+
   @Produces
   public List<io.vanillabp.integration.adapter.spi.MigratableProcessService<Object>> dummyMigratableProcessServices(
       final MigrationAdapterProperties properties,
@@ -55,6 +64,10 @@ public class DummyProcessServiceProducer {
         .getConfig()
         .getOptionalValue(PROPERTY_TWO_PHASE_COMMIT, Boolean.class)
         .orElse(Boolean.FALSE);
+    final var readsAggregateInPhaseTwo = ConfigProvider
+        .getConfig()
+        .getOptionalValue(PROPERTY_READ_AGGREGATE_IN_PHASE_TWO, Boolean.class)
+        .orElse(Boolean.FALSE);
 
     return properties
         .adapterTypes()
@@ -63,7 +76,7 @@ public class DummyProcessServiceProducer {
         .filter(adapter -> ADAPTER_TYPE.equals(adapter.getValue()))
         .map(Map.Entry::getKey)
         .sorted().<io.vanillabp.integration.adapter.spi.MigratableProcessService<Object>>map(
-            adapterId -> new MigratableProcessService<>(adapterId, needsTwoPhaseCommit, phaseTwoListeners, taskAwarenessSources, viewerSources))
+            adapterId -> new MigratableProcessService<>(adapterId, needsTwoPhaseCommit, readsAggregateInPhaseTwo, phaseTwoListeners, taskAwarenessSources, viewerSources))
         .toList();
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/MigratableProcessService.java
@@ -10,6 +10,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
 
   private final boolean needsTwoPhaseCommitForStartingWorkflows;
 
+  private final boolean readsAggregateInPhaseTwo;
+
   private final Instance<DummyPhaseTwoListener> phaseTwoListeners;
 
   private final Instance<DummyTaskAwarenessSource> taskAwarenessSources;
@@ -19,12 +21,14 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
   public MigratableProcessService(
       final String adapterId,
       final boolean needsTwoPhaseCommitForStartingWorkflows,
+      final boolean readsAggregateInPhaseTwo,
       final Instance<DummyPhaseTwoListener> phaseTwoListeners,
       final Instance<DummyTaskAwarenessSource> taskAwarenessSources,
       final Instance<DummyViewerSource> viewerSources) {
 
     this.adapterId = adapterId;
     this.needsTwoPhaseCommitForStartingWorkflows = needsTwoPhaseCommitForStartingWorkflows;
+    this.readsAggregateInPhaseTwo = readsAggregateInPhaseTwo;
     this.phaseTwoListeners = phaseTwoListeners;
     this.taskAwarenessSources = taskAwarenessSources;
     this.viewerSources = viewerSources;
@@ -126,6 +130,28 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
 
   }
 
+  /**
+   * Loads the workflow aggregate the way a remote BPMS adapter does in phase two: it
+   * builds the variables it sends to the BPMS from the aggregate, so it calls the
+   * application's persistence from the outbox dispatcher's thread. Switched on by
+   * <code>dummy-adapter.read-aggregate-in-phase-two</code> (the tests of the
+   * phase-two contract, story 67); off by default because most test doubles of
+   * {@link AggregatePersistenceAware} implement nothing but save.
+   *
+   * @param aggregatePersistence The application's persistence of this aggregate
+   * @param workflowAggregateId The aggregate's ID
+   */
+  private void readAggregateLikeARemoteBpms(
+      final AggregatePersistenceAware<A> aggregatePersistence,
+      final Object workflowAggregateId) {
+
+    if (!readsAggregateInPhaseTwo) {
+      return;
+    }
+    aggregatePersistence.loadById(workflowAggregateId);
+
+  }
+
   @Override
   public void startWorkflowPhaseOne(
       final String workflowModuleId,
@@ -141,6 +167,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final String bpmnProcessId,
       final AggregatePersistenceAware<A> aggregatePersistence,
       final Object workflowAggregateId) {
+
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
 
     if (phaseTwoListeners != null) {
       phaseTwoListeners
@@ -167,6 +195,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final AggregatePersistenceAware<A> aggregatePersistence,
       final Object workflowAggregateId,
       final String taskId) {
+
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
 
     if (phaseTwoListeners != null) {
       phaseTwoListeners
@@ -196,6 +226,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final String taskId,
       final String bpmnErrorCode) {
 
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
+
     if (phaseTwoListeners != null) {
       phaseTwoListeners
           .stream()
@@ -221,6 +253,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final AggregatePersistenceAware<A> aggregatePersistence,
       final Object workflowAggregateId,
       final String taskId) {
+
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
 
     if (phaseTwoListeners != null) {
       phaseTwoListeners
@@ -249,6 +283,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final Object workflowAggregateId,
       final String taskId,
       final String bpmnErrorCode) {
+
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
 
     if (phaseTwoListeners != null) {
       phaseTwoListeners
@@ -313,6 +349,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final Object workflowAggregateId,
       final String taskId) {
 
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
+
     if (phaseTwoListeners != null) {
       phaseTwoListeners
           .stream()
@@ -341,6 +379,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final String messageName,
       final String correlationId) {
 
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
+
     if (phaseTwoListeners != null) {
       phaseTwoListeners
           .stream()
@@ -366,6 +406,8 @@ public class MigratableProcessService<A> implements io.vanillabp.integration.ada
       final AggregatePersistenceAware<A> aggregatePersistence,
       final Object workflowAggregateId,
       final String messageName) {
+
+    readAggregateLikeARemoteBpms(aggregatePersistence, workflowAggregateId);
 
     if (phaseTwoListeners != null) {
       phaseTwoListeners

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveTaskAwarenessSource.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveTaskAwarenessSource.java
@@ -1,0 +1,24 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskAwarenessSource;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Lets the dummy adapter know every task probed, so operations on a running workflow
+ * reach phase two instead of being rejected as unknown.
+ */
+@ApplicationScoped
+public class ActiveTaskAwarenessSource implements DummyTaskAwarenessSource {
+
+  @Override
+  public WorkflowAwareness awarenessOfTask(
+      final String adapterId,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    return WorkflowAwareness.ACTIVE;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/MongoRepositoryWorkflowService.java
@@ -16,6 +16,9 @@ public class MongoRepositoryWorkflowService {
   @Inject
   ProcessService<MongoRepositoryAggregate> processService;
 
+  @Inject
+  MongoRepositoryAggregateRepository repository;
+
   public MongoRepositoryAggregate startWorkflow(
       final String id) {
 
@@ -23,6 +26,22 @@ public class MongoRepositoryWorkflowService {
     aggregate.setId(id);
     aggregate.setStatus("started");
     return processService.startWorkflow(aggregate);
+
+  }
+
+  /**
+   * Completes a task of an already started workflow - used by the phase-two test:
+   * on a BPMS needing a two-phase commit this schedules phase two, which calls back
+   * into this application's persistence from the dispatcher's thread.
+   *
+   * @param id The aggregate's ID
+   * @param taskId The task's ID
+   */
+  public void completeTask(
+      final String id,
+      final String taskId) {
+
+    processService.completeTask(repository.findById(id), taskId);
 
   }
 

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/PhaseTwoRecorder.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/main/java/io/vanillabp/integration/test/persistence/PhaseTwoRecorder.java
@@ -1,0 +1,101 @@
+package io.vanillabp.integration.test.persistence;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.vanillabp.adapter.dummy.runtime.DummyPhaseTwoListener;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Records what the dummy adapter did in phase two, so a test can wait for the outbox
+ * dispatcher's thread to have arrived.
+ */
+@ApplicationScoped
+public class PhaseTwoRecorder implements DummyPhaseTwoListener {
+
+  private final List<String> startedWorkflows = new CopyOnWriteArrayList<>();
+
+  private final List<String> completedTasks = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void startedWorkflowPhaseTwo(
+      final Object workflowAggregateId) {
+
+    startedWorkflows.add(String.valueOf(workflowAggregateId));
+
+  }
+
+  @Override
+  public void completedTaskPhaseTwo(
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    completedTasks.add(workflowAggregateId
+        + ":"
+        + taskId);
+
+  }
+
+  public List<String> getStartedWorkflows() {
+
+    return List.copyOf(startedWorkflows);
+
+  }
+
+  public List<String> getCompletedTasks() {
+
+    return List.copyOf(completedTasks);
+
+  }
+
+  /**
+   * Waits until the workflow of the given aggregate was started in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitStartedWorkflow(
+      final String workflowAggregateId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(startedWorkflows, workflowAggregateId, timeoutMillis);
+
+  }
+
+  /**
+   * Waits until the given task was completed in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param taskId The task's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitCompletedTask(
+      final String workflowAggregateId,
+      final String taskId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(
+        completedTasks,
+        workflowAggregateId
+            + ":"
+            + taskId,
+        timeoutMillis);
+
+  }
+
+  private static boolean await(
+      final List<String> recorded,
+      final String entry,
+      final long timeoutMillis) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + timeoutMillis;
+    while (!recorded.contains(entry) && (System.currentTimeMillis() < deadline)) {
+      Thread.sleep(50);
+    }
+    return recorded.contains(entry);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/PhaseTwoMongoContextTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-mongo-tests/src/test/java/io/vanillabp/integration/it/PhaseTwoMongoContextTest.java
@@ -1,0 +1,88 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.persistence.ActiveTaskAwarenessSource;
+import io.vanillabp.integration.test.persistence.MongoRepositoryAggregate;
+import io.vanillabp.integration.test.persistence.MongoRepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.MongoRepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.PhaseTwoRecorder;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * Story 67 for the second store: the MongoDB outbox dispatcher runs phase two on its
+ * own thread as well, and the same promise applies there - VanillaBP provides the
+ * transaction and the active CDI request context its call back into the application
+ * needs. MongoDB itself needs no session, so this test guards the routing rather
+ * than a reproduction: both dispatched operations have to arrive.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PhaseTwoMongoContextTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(MongoRepositoryAggregate.class)
+          .addClass(MongoRepositoryAggregateRepository.class)
+          .addClass(MongoRepositoryWorkflowService.class)
+          .addClass(PhaseTwoRecorder.class)
+          .addClass(ActiveTaskAwarenessSource.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("dummy-adapter.two-phase-commit", "true")
+      // the dummy adapter then reads the aggregate in phase two, like a remote BPMS
+      .overrideConfigKey("dummy-adapter.read-aggregate-in-phase-two", "true")
+      .overrideConfigKey("quarkus.mongodb.database", "phase-two-context-it")
+      .overrideConfigKey("vanillabp.outbox.poll-interval", "PT0.5S")
+      .overrideConfigKey("vanillabp.outbox.attempt-frequency", "PT0.5S");
+
+  @Inject
+  MongoRepositoryWorkflowService workflowService;
+
+  @Inject
+  MongoRepositoryAggregateRepository repository;
+
+  @Inject
+  PhaseTwoRecorder recorder;
+
+  @Test
+  @DisplayName("Phase two of the MongoDB outbox reads the aggregate as well")
+  public void phaseTwoReadsTheAggregateOfAMongoApplication() throws Exception {
+
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> workflowService.startWorkflow("phase-two-start"));
+
+    assertTrue(
+        recorder.awaitStartedWorkflow("phase-two-start", 30_000),
+        "phase two of starting the workflow never arrived - it failed on the dispatcher's thread");
+
+    final var stored = repository.findById("phase-two-start");
+    assertNotNull(stored);
+    assertEquals("started", stored.getStatus());
+
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> workflowService.completeTask("phase-two-start", "Activity_Process"));
+
+    assertTrue(
+        recorder.awaitCompletedTask("phase-two-start", "Activity_Process", 30_000),
+        "phase two of completing the task never arrived - it failed on the dispatcher's thread");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveTaskAwarenessSource.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/ActiveTaskAwarenessSource.java
@@ -1,0 +1,24 @@
+package io.vanillabp.integration.test.persistence;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskAwarenessSource;
+import io.vanillabp.integration.adapter.spi.WorkflowAwareness;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Lets the dummy adapter know every task probed, so operations on a running workflow
+ * reach phase two instead of being rejected as unknown.
+ */
+@ApplicationScoped
+public class ActiveTaskAwarenessSource implements DummyTaskAwarenessSource {
+
+  @Override
+  public WorkflowAwareness awarenessOfTask(
+      final String adapterId,
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    return WorkflowAwareness.ACTIVE;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/PhaseTwoRecorder.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/PhaseTwoRecorder.java
@@ -1,0 +1,101 @@
+package io.vanillabp.integration.test.persistence;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.vanillabp.adapter.dummy.runtime.DummyPhaseTwoListener;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Records what the dummy adapter did in phase two, so a test can wait for the outbox
+ * dispatcher's thread to have arrived.
+ */
+@ApplicationScoped
+public class PhaseTwoRecorder implements DummyPhaseTwoListener {
+
+  private final List<String> startedWorkflows = new CopyOnWriteArrayList<>();
+
+  private final List<String> completedTasks = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void startedWorkflowPhaseTwo(
+      final Object workflowAggregateId) {
+
+    startedWorkflows.add(String.valueOf(workflowAggregateId));
+
+  }
+
+  @Override
+  public void completedTaskPhaseTwo(
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    completedTasks.add(workflowAggregateId
+        + ":"
+        + taskId);
+
+  }
+
+  public List<String> getStartedWorkflows() {
+
+    return List.copyOf(startedWorkflows);
+
+  }
+
+  public List<String> getCompletedTasks() {
+
+    return List.copyOf(completedTasks);
+
+  }
+
+  /**
+   * Waits until the workflow of the given aggregate was started in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitStartedWorkflow(
+      final String workflowAggregateId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(startedWorkflows, workflowAggregateId, timeoutMillis);
+
+  }
+
+  /**
+   * Waits until the given task was completed in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param taskId The task's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitCompletedTask(
+      final String workflowAggregateId,
+      final String taskId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(
+        completedTasks,
+        workflowAggregateId
+            + ":"
+            + taskId,
+        timeoutMillis);
+
+  }
+
+  private static boolean await(
+      final List<String> recorded,
+      final String entry,
+      final long timeoutMillis) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + timeoutMillis;
+    while (!recorded.contains(entry) && (System.currentTimeMillis() < deadline)) {
+      Thread.sleep(50);
+    }
+    return recorded.contains(entry);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/main/java/io/vanillabp/integration/test/persistence/RepositoryWorkflowService.java
@@ -16,6 +16,9 @@ public class RepositoryWorkflowService {
   @Inject
   ProcessService<RepositoryAggregate> processService;
 
+  @Inject
+  RepositoryAggregateRepository repository;
+
   public RepositoryAggregate startWorkflow(
       final String id) {
 
@@ -23,6 +26,22 @@ public class RepositoryWorkflowService {
     aggregate.setId(id);
     aggregate.setStatus("started");
     return processService.startWorkflow(aggregate);
+
+  }
+
+  /**
+   * Completes a task of an already started workflow - used by the phase-two test:
+   * on a BPMS needing a two-phase commit this schedules phase two, which calls back
+   * into this application's persistence from the dispatcher's thread.
+   *
+   * @param id The aggregate's ID
+   * @param taskId The task's ID
+   */
+  public void completeTask(
+      final String id,
+      final String taskId) {
+
+    processService.completeTask(repository.findById(id), taskId);
 
   }
 

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PhaseTwoJpaContextTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/PhaseTwoJpaContextTest.java
@@ -1,0 +1,95 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.persistence.ActiveTaskAwarenessSource;
+import io.vanillabp.integration.test.persistence.PhaseTwoRecorder;
+import io.vanillabp.integration.test.persistence.RepositoryAggregate;
+import io.vanillabp.integration.test.persistence.RepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.RepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * Story 67: phase two runs on the outbox dispatcher's own thread and calls back into
+ * the application - a remote BPMS adapter loads the aggregate to build what it sends
+ * to the BPMS. On Quarkus that thread had neither a transaction nor an active CDI
+ * request context, so an aggregate stored with an entity manager could not be read:
+ * the dispatch failed with a {@code ContextNotActiveException} and was retried until
+ * the entry was blocked, while the application looked healthy (the API had answered,
+ * the aggregate was in the database) and the workflow never appeared in the BPMS.
+ * <p>
+ * The dummy adapter is forced into the two-phase start here and reads the aggregate
+ * like a remote BPMS does. Both dispatched operations of a JPA-backed application are
+ * covered: starting the workflow and completing a task.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PhaseTwoJpaContextTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(RepositoryAggregate.class)
+          .addClass(RepositoryAggregateRepository.class)
+          .addClass(RepositoryWorkflowService.class)
+          .addClass(PhaseTwoRecorder.class)
+          .addClass(ActiveTaskAwarenessSource.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("dummy-adapter.two-phase-commit", "true")
+      // the dummy adapter then reads the aggregate in phase two, like a remote BPMS
+      .overrideConfigKey("dummy-adapter.read-aggregate-in-phase-two", "true")
+      .overrideConfigKey("vanillabp.outbox.poll-interval", "PT0.5S")
+      .overrideConfigKey("vanillabp.outbox.attempt-frequency", "PT0.5S");
+
+  @Inject
+  RepositoryWorkflowService workflowService;
+
+  @Inject
+  RepositoryAggregateRepository repository;
+
+  @Inject
+  PhaseTwoRecorder recorder;
+
+  @Test
+  @DisplayName("Phase two can read the aggregate: VanillaBP provides transaction and request context")
+  public void phaseTwoReadsTheAggregateOfAJpaApplication() throws Exception {
+
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> workflowService.startWorkflow("phase-two-start"));
+
+    assertTrue(
+        recorder.awaitStartedWorkflow("phase-two-start", 30_000),
+        "phase two of starting the workflow never arrived - it failed on the dispatcher's thread");
+
+    final var stored = QuarkusTransaction
+        .requiringNew()
+        .call(() -> repository.findById("phase-two-start"));
+    assertNotNull(stored);
+    assertEquals("started", stored.getStatus());
+
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> workflowService.completeTask("phase-two-start", "Activity_Process"));
+
+    assertTrue(
+        recorder.awaitCompletedTask("phase-two-start", "Activity_Process", 30_000),
+        "phase two of completing the task never arrived - it failed on the dispatcher's thread");
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
@@ -1,25 +1,34 @@
 package io.vanillabp.integration.runtime.processservice;
 
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
+import io.vanillabp.integration.runtime.workflowtask.QuarkusTransactionRunner;
 import io.vanillabp.integration.spi.PhaseTwoOperationRegistry;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.enterprise.inject.Produces;
 import jakarta.inject.Singleton;
+import jakarta.transaction.TransactionSynchronizationRegistry;
 
 /**
  * Produces the core-owned {@link PhaseTwoRouter} as CDI bean: the generated
  * process-service beans (see {@link ProcessServiceBaseCdiBean}) register themselves
  * with the router at bean creation, and the phase-two outbox dispatcher routes
  * committed outbox entries through it.
+ * <p>
+ * The router gets a {@link QuarkusTransactionRunner}: dispatching happens on the
+ * outbox dispatcher's own thread and calls the application's aggregate persistence,
+ * which needs a transaction and an active CDI request context - neither of which
+ * exists on that thread. Providing it here covers VanillaBP's two outboxes and any
+ * outbox an application contributes.
  */
 @ApplicationScoped
 public class PhaseTwoRouterProducer {
 
   @Produces
   @Singleton
-  public PhaseTwoRouter phaseTwoRouter() {
+  public PhaseTwoRouter phaseTwoRouter(
+      final TransactionSynchronizationRegistry transactionRegistry) {
 
-    return new PhaseTwoRouter();
+    return new PhaseTwoRouter(new QuarkusTransactionRunner(transactionRegistry));
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/QuarkusTransactionRunner.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/workflowtask/QuarkusTransactionRunner.java
@@ -13,7 +13,10 @@ import jakarta.transaction.TransactionSynchronizationRegistry;
  * <code>&#64;WorkflowTask</code> handlers: JTA via {@link QuarkusTransaction}.
  * Additionally the CDI request context is activated around the work - handlers are
  * invoked on adapter threads (e.g. job-executor or polling-worker threads) where no
- * request context is active, and Panache/Hibernate session access requires one.
+ * request context is active, and Panache/Hibernate session access requires one. The
+ * same runner provides both to phase-two dispatch, which calls the application's
+ * persistence from the outbox dispatcher's thread (see
+ * {@link #requireTransaction(Supplier)}).
  */
 public class QuarkusTransactionRunner implements TransactionRunner {
 
@@ -52,6 +55,18 @@ public class QuarkusTransactionRunner implements TransactionRunner {
               valid for embedded BPMS invoking handlers inside the engine's transaction.""");
     }
     return withRequestContext(work);
+
+  }
+
+  @Override
+  public <T> T requireTransaction(
+      final Supplier<T> work) {
+
+    // joining instead of suspending: an outbox of the application may well dispatch
+    // inside a transaction of its own, and phase two belongs into it then
+    return withRequestContext(() -> QuarkusTransaction
+        .joiningExisting()
+        .call(work::get));
 
   }
 


### PR DESCRIPTION
Story 67, found by the blueprint `module-single/quarkus`.

## The problem

Phase two runs on the outbox dispatcher's own thread and calls back into the application: a remote BPMS adapter loads the workflow aggregate to build what it sends to the BPMS. On Quarkus that thread had neither a transaction nor an active CDI request context, so an aggregate stored with an entity manager could not be read:

```
WARN [JdbcPhaseTwoOutboxDispatcher] Dispatching phase two (START_WORKFLOW) ... will retry:
 jakarta.enterprise.context.ContextNotActiveException: Cannot use the EntityManager/Session
 because neither a transaction nor a CDI request context is active.
```

The entry was retried until it was blocked. Meanwhile the API had answered, the aggregate was in the database, and the workflow simply never appeared in the BPMS.

## The fix

The context is VanillaBP's to provide, and it belongs where every store passes through rather than in each of them. `PhaseTwoRouter` runs each dispatch through `TransactionRunner.requireTransaction`, a new default method which joins an active transaction and starts one otherwise.

- **Quarkus** supplies the runner: a JTA transaction plus the activated CDI request context, the same one the task path already used.
- **Spring Boot** deliberately supplies none. gruelbox dispatches inside a transaction it manages, and Spring Data opens per call what it needs; forcing `requiresNew` there would have broken applications whose only transaction manager is not the one the aggregate lives in.
- An outbox contributed by an application inherits the guarantee, because the router owns it.

Every phase-two operation and both Quarkus stores went through that one router already, which is why one place is enough — recovery after a restart included.

## Tests

- `PhaseTwoJpaContextTest` (H2): starting a workflow and completing a task both reach phase two with the aggregate readable. Counter-checked: without the router change it fails with "phase two never arrived".
- `PhaseTwoMongoContextTest` (Dev Services) for the second store.
- A core unit test pinning that the dispatch runs inside the runner the platform supplied.

The dummy adapter can now read the aggregate in phase two the way a remote BPMS does, switched on with `dummy-adapter.read-aggregate-in-phase-two`. It is off by default: most persistence test doubles implement nothing but `save`, and that is precisely why this gap survived so long.

## Docs

`migration-adapter/README.md` (what phase two may expect), `Workflow-aggregates` ("when VanillaBP calls you, it owns a transaction", plus the two limits) and both platform wiki pages.

## What this does not fix

The transaction is the platform's own. MongoDB does not take part in it, and a persistence bringing transactions of its own (Kafka, an event store) has no hook to bracket VanillaBP's calls. That is story 70, raised while this one was being implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25