### PR TITLE
Quarkus: keep the beans VanillaBP looks up by class

### DIFF
--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
@@ -320,7 +320,10 @@ class WorkflowTaskScanner {
         throw new IllegalStateException(
             """
                 No bean of the resolver class '%s' (used by the %s) is available! Define it as a \
-                bean of your application."""
+                bean of your application. If it IS one: on Quarkus the class has to be visible to \
+                the build, which keeps resolver beans alive although nothing injects them - a \
+                workflow module in its own Maven module needs a Jandex index for that (see the \
+                jandex-maven-plugin)."""
                 .formatted(resolverClass.getName(), location));
       }
       return resolver.resolve(aggregate, adaptMultiInstances(context.getMultiInstances()));

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
@@ -80,6 +80,7 @@ public class ProcessServiceBuildStepProcessor {
    * @param workflowModulesFound Information about all workflow modules found in the project
    * @param generatedBeanBuildItemBuildProducer {@link BuildProducer} used to collect generated {@link ProcessService} beans
    * @param reflectiveClassBuildItemProducer {@link BuildProducer} used to register aggregates whose ID VanillaBP reads by reflection
+   * @param unremovableBeanBuildItemProducer {@link BuildProducer} used to keep repositories alive which only VanillaBP uses
    * @param additionalBeanBuildItemBuildProducer {@link BuildProducer} used to collect beans provided in module "runtime"
    */
   @BuildStep
@@ -91,6 +92,7 @@ public class ProcessServiceBuildStepProcessor {
       final BuildProducer<EnsureClassIsBeanValidationBuildItem> ensureClassIsBeanBuildItemProducer,
       final BuildProducer<GeneratedBeanBuildItem> generatedBeanBuildItemBuildProducer,
       final BuildProducer<ReflectiveClassBuildItem> reflectiveClassBuildItemProducer,
+      final BuildProducer<UnremovableBeanBuildItem> unremovableBeanBuildItemProducer,
       final BuildProducer<AdditionalBeanBuildItem> additionalBeanBuildItemBuildProducer) {
 
     final var aggregatePersistenceAwares = applicationArchivesBuildItem
@@ -230,6 +232,17 @@ public class ProcessServiceBuildStepProcessor {
                 aggregatePersistenceClassName,
                 defaultPersistence,
                 workflowAggregateType);
+            if (defaultPersistence.repositoryClass() != null) {
+              // an application whose repository is used by VanillaBP alone injects it
+              // nowhere, and Quarkus removes beans nobody injects while building the
+              // application (story 71, the same shape as the multi-instance
+              // resolvers). Panache and Spring Data keep their repositories
+              // themselves today, so this is insurance rather than a fix - VanillaBP
+              // looks the bean up by class and should not depend on another
+              // extension's decision
+              unremovableBeanBuildItemProducer
+                  .produce(UnremovableBeanBuildItem.beanTypes(defaultPersistence.repositoryClass()));
+            }
             // the ID is read by reflection (AggregateIdTypes), which a native image
             // has to be told about - the persistence frameworks register their
             // entities themselves, but an aggregate may be neither

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/workflowtask/MultiInstanceResolverBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/workflowtask/MultiInstanceResolverBuildStepProcessor.java
@@ -1,0 +1,89 @@
+package io.vanillabp.integration.deployment.workflowtask;
+
+import java.util.LinkedHashSet;
+
+import org.jboss.jandex.DotName;
+
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.builditem.CombinedIndexBuildItem;
+import io.vanillabp.integration.deployment.validation.EnsureClassIsBeanValidationBuildItem;
+import io.vanillabp.spi.service.MultiInstanceElement;
+import io.vanillabp.spi.service.NoResolver;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Keeps the resolver beans of
+ * <code>&#64;MultiInstanceElement(resolverBean = ...)</code> alive (story 71).
+ * <p>
+ * Such a resolver is a bean nothing injects: it is named in an annotation and VanillaBP
+ * asks the container for it while the task runs. Quarkus removes beans nobody injects
+ * while it builds the application, so the lookup found nothing and every iteration of
+ * the task failed - with a message telling the developer to define a bean they had
+ * defined. Marking the class unremovable here keeps the application code free of
+ * Quarkus specifics: the same class runs unchanged on Spring Boot, where beans are
+ * never removed.
+ * <p>
+ * Collecting the class as one which HAS to be a bean does both: the platform's
+ * validation keeps every collected class unremovable
+ * ({@code EnsureCollectedClassesAreBeansBuildStepProcessor}) and fails the build when
+ * the class is no bean at all - which moves the "no bean of the resolver class" verdict
+ * from the first execution of the task to the build.
+ */
+@Slf4j
+public class MultiInstanceResolverBuildStepProcessor {
+
+  private static final String ANNOTATION_ATTRIBUTE_RESOLVER_BEAN = "resolverBean";
+
+  private static final DotName NO_RESOLVER = DotName
+      .createSimple(NoResolver.class.getName());
+
+  /**
+   * @param combinedIndex The index of the application and of all indexed dependencies
+   * @param ensureClassIsBeanBuildItemProducer Producer collecting classes required to be beans
+   */
+  @BuildStep
+  void preserveMultiInstanceResolvers(
+      final CombinedIndexBuildItem combinedIndex,
+      final BuildProducer<EnsureClassIsBeanValidationBuildItem> ensureClassIsBeanBuildItemProducer) {
+
+    final var resolvers = new LinkedHashSet<DotName>();
+    combinedIndex
+        .getIndex()
+        .getAnnotations(MultiInstanceElement.class)
+        .forEach(annotation -> {
+          final var resolverBean = annotation.value(ANNOTATION_ATTRIBUTE_RESOLVER_BEAN);
+          if (resolverBean == null) {
+            // the element is named instead (@MultiInstanceElement("partners")) - the
+            // core reports the case of naming both
+            return;
+          }
+          final var resolverClass = resolverBean
+              .asClass()
+              .name();
+          if (NO_RESOLVER.equals(resolverClass)) {
+            return;
+          }
+          resolvers.add(resolverClass);
+        });
+
+    if (resolvers.isEmpty()) {
+      return;
+    }
+
+    log.debug("Keeping the multi-instance resolver bean(s) {} - VanillaBP looks them up by class", resolvers);
+    resolvers
+        .forEach(resolverClass -> {
+          ensureClassIsBeanBuildItemProducer
+              .produce(EnsureClassIsBeanValidationBuildItem
+                  .builder()
+                  .className(resolverClass)
+                  .usageDescription("Resolver named by @"
+                      + MultiInstanceElement.class.getName()
+                      + "(resolverBean = ...)")
+                  .build());
+        });
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/IterationResolver.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/IterationResolver.java
@@ -1,0 +1,35 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import io.vanillabp.spi.service.MultiInstanceElementResolver;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * A resolver named by <code>&#64;MultiInstanceElement(resolverBean = ...)</code> and
+ * injected NOWHERE - which is the point of the test (story 71): Quarkus used to remove
+ * it while building the application, and the lookup at task time found nothing.
+ */
+@ApplicationScoped
+public class IterationResolver implements MultiInstanceElementResolver<ResolverAggregate, String> {
+
+  @Override
+  public Collection<String> getNames() {
+
+    return List.of("items");
+
+  }
+
+  @Override
+  public String resolve(
+      final ResolverAggregate workflowAggregate,
+      final Map<String, MultiInstance<Object>> multiInstances) {
+
+    final var iteration = multiInstances.get("items");
+    return "%s@%d/%d".formatted(iteration.getElement(), iteration.getIndex(), iteration.getTotal());
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/PlainIterationResolver.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/PlainIterationResolver.java
@@ -1,0 +1,31 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import io.vanillabp.spi.service.MultiInstanceElementResolver;
+
+/**
+ * A resolver which is NO bean (no scope annotation) - used by the test proving that
+ * this is said while building instead of at the first iteration of the task.
+ */
+public class PlainIterationResolver implements MultiInstanceElementResolver<ResolverAggregate, String> {
+
+  @Override
+  public Collection<String> getNames() {
+
+    return List.of("items");
+
+  }
+
+  @Override
+  public String resolve(
+      final ResolverAggregate workflowAggregate,
+      final Map<String, MultiInstance<Object>> multiInstances) {
+
+    return "never called";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/PlainResolverWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/PlainResolverWorkflowService.java
@@ -1,0 +1,24 @@
+package io.vanillabp.integration.test.deployment;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.MultiInstanceElement;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = ResolverAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "ResolverProcess"))
+public class PlainResolverWorkflowService {
+
+  @WorkflowTask
+  public void iterate(
+      final ResolverAggregate aggregate,
+      @MultiInstanceElement(resolverBean = PlainIterationResolver.class) final String iteration) {
+
+    aggregate.setResolved(iteration);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverAggregate.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverAggregate.java
@@ -1,0 +1,30 @@
+package io.vanillabp.integration.test.deployment;
+
+/**
+ * The aggregate of the multi-instance resolver test (story 71).
+ */
+public class ResolverAggregate {
+
+  private String id;
+
+  private String resolved;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(
+      final String id) {
+    this.id = id;
+  }
+
+  public String getResolved() {
+    return resolved;
+  }
+
+  public void setResolved(
+      final String resolved) {
+    this.resolved = resolved;
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverAggregatePersistence.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverAggregatePersistence.java
@@ -1,0 +1,65 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * In-memory persistence of the multi-instance resolver test's aggregate.
+ */
+@ApplicationScoped
+public class ResolverAggregatePersistence implements AggregatePersistenceAware<ResolverAggregate> {
+
+  private final Map<String, ResolverAggregate> aggregates = new ConcurrentHashMap<>();
+
+  public void seed(
+      final String id) {
+
+    final var aggregate = new ResolverAggregate();
+    aggregate.setId(id);
+    aggregates.put(id, aggregate);
+
+  }
+
+  public ResolverAggregate stored(
+      final String id) {
+
+    return aggregates.get(id);
+
+  }
+
+  @Override
+  public Class<ResolverAggregate> getAggregateClass() {
+
+    return ResolverAggregate.class;
+
+  }
+
+  @Override
+  public ResolverAggregate save(
+      final ResolverAggregate aggregate) {
+
+    aggregates.put(aggregate.getId(), aggregate);
+    return aggregate;
+
+  }
+
+  @Override
+  public Object getAggregateId(
+      final ResolverAggregate aggregate) {
+
+    return aggregate.getId();
+
+  }
+
+  @Override
+  public ResolverAggregate loadById(
+      final Object aggregateId) {
+
+    return aggregates.get((String) aggregateId);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverProcessWiringSource.java
@@ -1,0 +1,28 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN model of the multi-instance resolver test.
+ */
+@ApplicationScoped
+public class ResolverProcessWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return "ResolverProcess".equals(bpmnProcessId)
+        ? List.of(new BpmnTaskSpec("Activity_Iterate", "iterate"))
+        : List.of();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/ResolverWorkflowService.java
@@ -1,0 +1,24 @@
+package io.vanillabp.integration.test.deployment;
+
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.MultiInstanceElement;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = ResolverAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "ResolverProcess"))
+public class ResolverWorkflowService {
+
+  @WorkflowTask
+  public void iterate(
+      final ResolverAggregate aggregate,
+      @MultiInstanceElement(resolverBean = IterationResolver.class) final String iteration) {
+
+    aggregate.setResolved(iteration);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/MultiInstanceResolverBeanTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/MultiInstanceResolverBeanTest.java
@@ -1,0 +1,111 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.MultiInstanceValue;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.test.deployment.IterationResolver;
+import io.vanillabp.integration.test.deployment.ResolverAggregate;
+import io.vanillabp.integration.test.deployment.ResolverAggregatePersistence;
+import io.vanillabp.integration.test.deployment.ResolverProcessWiringSource;
+import io.vanillabp.integration.test.deployment.ResolverWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Story 71: the resolver named by
+ * <code>&#64;MultiInstanceElement(resolverBean = ...)</code> is a bean nothing injects.
+ * Quarkus removes such beans while building the application, so VanillaBP's lookup
+ * found nothing and every iteration of the task failed - with a message asking the
+ * developer to define the bean they had defined. The build step keeps it now, and the
+ * application needs no Quarkus annotation for it.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MultiInstanceResolverBeanTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("multi-instance-resolver/application.yaml", "application.yaml")
+          .addClass(ResolverAggregate.class)
+          .addClass(ResolverAggregatePersistence.class)
+          .addClass(ResolverWorkflowService.class)
+          .addClass(IterationResolver.class)
+          .addClass(ResolverProcessWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/ResolverProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  ResolverAggregatePersistence persistence;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> "demo1".equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  @Test
+  @DisplayName("A resolver bean nothing injects survives the build and resolves the iteration")
+  public void resolverBeanIsAvailableAtTaskTime() {
+
+    persistence.seed("4711");
+    final Map<String, MultiInstanceValue> multiInstances = new LinkedHashMap<>();
+    multiInstances.put("items", new MultiInstanceValue("item-2", 2, 5));
+
+    final var outcome = dummyAdapter().invokeTask("test-module", "ResolverProcess", new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return "iterate";
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return "4711";
+      }
+
+      @Override
+      public Map<String, MultiInstanceValue> getMultiInstances() {
+        return multiInstances;
+      }
+
+    });
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, outcome.kind());
+    assertEquals(
+        "item-2@2/5",
+        persistence.stored("4711").getResolved(),
+        "the resolver bean was not found - Quarkus removed it while building the application");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/MultiInstanceResolverNoBeanTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/MultiInstanceResolverNoBeanTest.java
@@ -1,0 +1,61 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.deployment.PlainIterationResolver;
+import io.vanillabp.integration.test.deployment.PlainResolverWorkflowService;
+import io.vanillabp.integration.test.deployment.ResolverAggregate;
+import io.vanillabp.integration.test.deployment.ResolverAggregatePersistence;
+import io.vanillabp.integration.test.deployment.ResolverProcessWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 71: a resolver class which is no bean at all used to surface at the first
+ * iteration of the task, one retry cycle at a time. Now the build says it, naming the
+ * class and what it is used as.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MultiInstanceResolverNoBeanTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("multi-instance-resolver/application.yaml", "application.yaml")
+          .addClass(ResolverAggregate.class)
+          .addClass(ResolverAggregatePersistence.class)
+          .addClass(PlainResolverWorkflowService.class)
+          .addClass(PlainIterationResolver.class)
+          .addClass(ResolverProcessWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/ResolverProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .assertException(throwable -> {
+        var current = throwable;
+        while (current != null) {
+          if ((current.getMessage() != null) && current.getMessage().contains("is a CDI bean")) {
+            assertTrue(
+                current.getMessage().contains(PlainIterationResolver.class.getName()),
+                current.getMessage());
+            assertTrue(current.getMessage().contains("resolverBean"), current.getMessage());
+            return;
+          }
+          current = current.getCause();
+        }
+        fail("expected the build to name the resolver which is no bean but got: "
+            + throwable);
+      });
+
+  @Test
+  @DisplayName("A resolver which is no bean fails the build naming the class")
+  public void resolverWhichIsNoBeanFailsTheBuild() {
+    // the assertion happens on the build exception (assertException above)
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/multi-instance-resolver/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/multi-instance-resolver/application.yaml
@@ -1,0 +1,15 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:multi-instance-resolver;DB_CLOSE_DELAY=-1
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/RepositoryUsedOnlyByVanillaBpTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/default-persistence-tests/src/test/java/io/vanillabp/integration/it/RepositoryUsedOnlyByVanillaBpTest.java
@@ -1,0 +1,67 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.persistence.RepositoryAggregate;
+import io.vanillabp.integration.test.persistence.RepositoryAggregateRepository;
+import io.vanillabp.integration.test.persistence.RepositoryWorkflowService;
+import io.vanillabp.integration.test.persistence.SingleTaskWiringSource;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.persistence.EntityManager;
+
+/**
+ * Story 71: an application whose repository is used by VanillaBP alone injects it
+ * nowhere. Quarkus removes beans nobody injects while building the application, and
+ * although the Panache extension keeps repositories itself today, VanillaBP looks this
+ * one up by class and marks it unremovable rather than relying on that. The aggregate
+ * is read back through the entity manager here - injecting the repository would be
+ * exactly the injection point this test must not have.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class RepositoryUsedOnlyByVanillaBpTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(RepositoryAggregate.class)
+          .addClass(RepositoryAggregateRepository.class)
+          .addClass(RepositoryWorkflowService.class)
+          .addClass(SingleTaskWiringSource.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/TestProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  RepositoryWorkflowService workflowService;
+
+  @Inject
+  EntityManager entityManager;
+
+  @Test
+  @DisplayName("The repository survives the build although only VanillaBP uses it")
+  public void repositoryNothingInjectsStillServesThePersistence() {
+
+    final var started = QuarkusTransaction
+        .requiringNew()
+        .call(() -> workflowService.startWorkflow("only-vanillabp"));
+    assertNotNull(started);
+
+    final var stored = QuarkusTransaction
+        .requiringNew()
+        .call(() -> entityManager.find(RepositoryAggregate.class, "only-vanillabp"));
+    assertNotNull(stored, "the aggregate was not stored - the repository bean did not survive the build");
+    assertEquals("started", stored.getStatus());
+
+  }
+
+}


### PR DESCRIPTION
Story 71, found by the blueprint `bpmn-multi-instance-subprocess/quarkus`, which carries an `@Unremovable` today because of it.

## The finding

A resolver named by `@MultiInstanceElement(resolverBean = ...)` is a bean nothing injects: VanillaBP asks the container for it while the task runs. Quarkus removes beans nobody injects while building the application, so the lookup found nothing and every iteration of the task failed:

```
No bean of the resolver class 'blueprint.workflowmodule.loanapproval.IterationResolver'
(used by the parameter 'iteration' of @WorkflowTask method '...#requestPartnerOffer')
is available! Define it as a bean of your application.
```

VanillaBP's own message, ending with advice the developer had already followed — the class carries `@ApplicationScoped`. The workflow did not fail fast either: the job was retried until the engine gave up.

## The fix (option 1 of the prompt, smaller than expected)

`MultiInstanceResolverBuildStepProcessor` collects the resolver classes from the index as classes which **have to be beans**. That is enough: the platform's validation already keeps every collected class unremovable, so the extra `UnremovableBeanBuildItem` I wrote first was redundant and is gone again. The application needs no Quarkus annotation and stays identical on both platforms.

Two side effects worth having:

- A resolver class which is **no bean at all** now fails the build naming the class, instead of surfacing at the first iteration of the task one retry cycle at a time.
- The runtime message names what remains as a cause after this fix: on Quarkus the class has to be visible to the build, so a workflow module in its own Maven module needs a Jandex index.

## Where else the same shape occurs

Exactly one place, and it came with story 69: the default aggregate persistence looks up the repository bean by class. Panache and Spring Data keep their repositories alive themselves, so that registration is insurance rather than a fix — the comment and the test say so rather than pretending otherwise.

## Tests

- `MultiInstanceResolverBeanTest`: a resolver nothing injects resolves the iteration. Counter-checked with the build step disabled — it then fails with exactly the message from the finding.
- `MultiInstanceResolverNoBeanTest`: a resolver which is no bean fails the build, naming the class and what it is used as.
- `RepositoryUsedOnlyByVanillaBpTest`: an application which never injects its repository still stores its aggregate.

## Docs

`Workflow-tasks` (the resolver is an ordinary bean of the application, on both platforms) and `Workflow-modules-in-Quarkus` (resolvers belong to the classes the Jandex index makes visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25