### PR TITLE
Report two BPMN processes declared for one workflow aggregate

### DIFF
--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/ProcessServiceBuildStepProcessor.java
@@ -161,9 +161,12 @@ public class ProcessServiceBuildStepProcessor {
             }
           }
 
-          // collect information necessary for bean creation (first class found
-          // provides the primary BPMN process and the bean's identity)
-          final var annotation = annotations.getFirst();
+          // ONE ProcessService per aggregate is the SPI's injection contract, so ONE
+          // of the classes declares the process startWorkflow starts. Which one used
+          // to be whichever class was found first (story 60). Several classes
+          // declaring the SAME process are fine (handlers split across classes),
+          // different ones are ambiguous and end the build.
+          final var annotation = primaryWorkflowServiceAnnotation(annotations, workflowAggregateType);
           final var serviceClass = annotation.target().asClass();
 
           final var workflowModuleId = workflowModulesFound
@@ -388,6 +391,70 @@ public class ProcessServiceBuildStepProcessor {
         .map(AnnotationValue::asString)
         .filter(Predicate.not(String::isEmpty))
         .orElse(serviceClass.simpleName());
+
+  }
+
+  /**
+   * The annotation declaring the process of the aggregate's process service.
+   *
+   * @param annotations All {@code @WorkflowService} annotations of this aggregate
+   * @param workflowAggregateType The aggregate
+   * @return The annotation whose primary BPMN process the process service serves
+   * @throws IllegalStateException If the classes declare different primary processes
+   *         for one aggregate - which of them {@code startWorkflow} would start
+   *         cannot be decided here (the BPMN models are read later, by the adapter,
+   *         while deploying), so the application decides it by naming one process as
+   *         the primary one and the others as secondary
+   */
+  private static AnnotationInstance primaryWorkflowServiceAnnotation(
+      final List<AnnotationInstance> annotations,
+      final Type workflowAggregateType) {
+
+    // reproducible: with several classes on one process the choice must not depend on
+    // the order the archives happened to be scanned in
+    final var sorted = annotations
+        .stream()
+        .sorted(Comparator.comparing(candidate -> candidate
+            .target()
+            .asClass()
+            .name()
+            .toString()))
+        .toList();
+    final var distinctProcesses = sorted
+        .stream()
+        .map(candidate -> primaryBpmnProcessId(candidate, candidate.target().asClass()))
+        .distinct()
+        .toList();
+    if (distinctProcesses.size() > 1) {
+      final var declarations = sorted
+          .stream()
+          .map(candidate -> "  %s declares '%s'".formatted(
+              candidate
+                  .target()
+                  .asClass()
+                  .name(),
+              primaryBpmnProcessId(candidate, candidate.target().asClass())))
+          .collect(java.util.stream.Collectors.joining("\n"));
+      throw new IllegalStateException(
+          """
+              Several classes annotated with @WorkflowService declare a DIFFERENT BPMN process for \
+              the workflow aggregate '%s':
+              %s
+              VanillaBP provides one ProcessService per workflow aggregate (that is what \
+              'ProcessService<%s>' injects), so exactly one of these processes is the one \
+              'startWorkflow' starts - and picking one of them here would be a coin flip.
+              Declare the process to be started as the 'bpmnProcess' of ONE class and move the \
+              others into that class' 'secondaryBpmnProcesses' (a process called by a call \
+              activity is the typical case). Handlers of a secondary process may stay in their own \
+              class as long as that class declares the same 'bpmnProcess'."""
+              .formatted(
+                  workflowAggregateType.name(),
+                  declarations,
+                  workflowAggregateType
+                      .name()
+                      .withoutPackagePrefix()));
+    }
+    return sorted.getFirst();
 
   }
 

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/AmbiguousPrimaryProcessTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/processservice/AmbiguousPrimaryProcessTest.java
@@ -1,0 +1,102 @@
+package io.vanillabp.integration.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Story 60: one workflow aggregate has one {@code ProcessService}, so one of the
+ * classes declaring the aggregate names the process {@code startWorkflow} starts.
+ * That used to be whichever class was found first - an order coming from the file
+ * system. Two classes naming DIFFERENT processes now end the build with a message
+ * naming both.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AmbiguousPrimaryProcessTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(AmbiguousAggregate.class)
+          .addClass(AmbiguousAggregatePersistence.class)
+          .addClass(CallingWorkflowService.class)
+          .addClass(CalledWorkflowService.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .assertException(throwable -> {
+        var current = throwable;
+        while (current != null) {
+          if ((current.getMessage() != null) && current.getMessage().contains("declare a DIFFERENT BPMN process")) {
+            final var message = current.getMessage();
+            assertTrue(message.contains(CallingWorkflowService.class.getName()), message);
+            assertTrue(message.contains(CalledWorkflowService.class.getName()), message);
+            assertTrue(message.contains("LoanApproval"), message);
+            assertTrue(message.contains("RiskAssessment"), message);
+            assertTrue(message.contains("secondaryBpmnProcesses"), message);
+            return;
+          }
+          current = current.getCause();
+        }
+        fail("expected the build to report the ambiguous primary process but got: "
+            + throwable);
+      });
+
+  @Test
+  @DisplayName("Two processes declared for one aggregate end the build naming both classes")
+  public void ambiguousPrimaryProcessFailsTheBuild() {
+    // the assertion happens on the build exception (assertException above)
+  }
+
+  public static class AmbiguousAggregate {
+
+    private String id;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(
+        final String id) {
+      this.id = id;
+    }
+
+  }
+
+  @ApplicationScoped
+  public static class AmbiguousAggregatePersistence implements AggregatePersistenceAware<AmbiguousAggregate> {
+
+    @Override
+    public Class<AmbiguousAggregate> getAggregateClass() {
+
+      return AmbiguousAggregate.class;
+
+    }
+
+  }
+
+  @ApplicationScoped
+  @WorkflowService(
+      workflowAggregateClass = AmbiguousAggregate.class,
+      bpmnProcess = @BpmnProcess(bpmnProcessId = "LoanApproval"))
+  public static class CallingWorkflowService {
+  }
+
+  @ApplicationScoped
+  @WorkflowService(
+      workflowAggregateClass = AmbiguousAggregate.class,
+      bpmnProcess = @BpmnProcess(bpmnProcessId = "RiskAssessment"))
+  public static class CalledWorkflowService {
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/SharedPrimaryProcessTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/SharedPrimaryProcessTest.java
@@ -1,0 +1,98 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.runtime.processservice.ProcessServiceBaseCdiBean;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+/**
+ * Story 60, the case which stays allowed: several classes may declare the same
+ * aggregate as long as they name the SAME process - handlers of one process split
+ * across classes are not ambiguous, so nothing has to be decided and the application
+ * boots.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class SharedPrimaryProcessTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("pipeline/application.yaml", "application.yaml")
+          .addClass(SharedAggregate.class)
+          .addClass(SharedAggregatePersistence.class)
+          .addClass(FirstHalfOfTheProcess.class)
+          .addClass(SecondHalfOfTheProcess.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/LoanApproval.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  ProcessService<SharedAggregate> processService;
+
+  @Test
+  @DisplayName("Two classes serving one process build one ProcessService for that process")
+  @SuppressWarnings("unchecked")
+  public void sharedPrimaryProcessIsNotAmbiguous() {
+
+    assertNotNull(processService);
+    assertEquals(
+        "LoanApproval",
+        ((ProcessServiceBaseCdiBean<SharedAggregate>) processService).getBpmnProcessId());
+
+  }
+
+  public static class SharedAggregate {
+
+    private String id;
+
+    public String getId() {
+      return id;
+    }
+
+    public void setId(
+        final String id) {
+      this.id = id;
+    }
+
+  }
+
+  @ApplicationScoped
+  public static class SharedAggregatePersistence implements AggregatePersistenceAware<SharedAggregate> {
+
+    @Override
+    public Class<SharedAggregate> getAggregateClass() {
+
+      return SharedAggregate.class;
+
+    }
+
+  }
+
+  @ApplicationScoped
+  @WorkflowService(
+      workflowAggregateClass = SharedAggregate.class,
+      bpmnProcess = @BpmnProcess(bpmnProcessId = "LoanApproval"))
+  public static class FirstHalfOfTheProcess {
+  }
+
+  @ApplicationScoped
+  @WorkflowService(
+      workflowAggregateClass = SharedAggregate.class,
+      bpmnProcess = @BpmnProcess(bpmnProcessId = "LoanApproval"))
+  public static class SecondHalfOfTheProcess {
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
@@ -1,5 +1,6 @@
 package io.vanillabp.integration.processservice;
 
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -7,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.BeanRegistrar;
 import org.springframework.beans.factory.BeanRegistry;
@@ -131,6 +133,101 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
   }
 
   /**
+   * The class declaring the process of the aggregate's {@code ProcessService}.
+   *
+   * @param serviceClasses All classes declaring this aggregate
+   * @param workflowAggregateType The aggregate
+   * @return The class whose primary BPMN process the process service serves
+   * @throws IllegalStateException If the classes declare different primary processes
+   *         for one aggregate - which of them {@code startWorkflow} would start
+   *         cannot be decided here (the BPMN models are read later, by the adapter,
+   *         while deploying), so the application decides it by naming one process as
+   *         the primary one and the others as secondary
+   */
+  static Class<?> primaryWorkflowServiceClass(
+      final List<Class<?>> serviceClasses,
+      final Class<?> workflowAggregateType) {
+
+    return primaryWorkflowServiceClass(
+        serviceClasses,
+        workflowAggregateType,
+        ProcessServiceBeanRegistrar::primaryBpmnProcessId);
+
+  }
+
+  /**
+   * The rule itself, with the process of a class handed in - the tests use it that
+   * way, because a fixture carrying {@code @WorkflowService} would be found by the
+   * classpath scan of every other test in this module.
+   *
+   * @param serviceClasses All classes declaring this aggregate
+   * @param workflowAggregateType The aggregate
+   * @param primaryProcessOf The primary BPMN process of a class
+   * @return The class whose primary BPMN process the process service serves
+   */
+  static Class<?> primaryWorkflowServiceClass(
+      final List<Class<?>> serviceClasses,
+      final Class<?> workflowAggregateType,
+      final Function<Class<?>, String> primaryProcessOf) {
+
+    // reproducible: with several classes on one process the choice must not depend on
+    // the order the classpath scan happened to return
+    final var sorted = serviceClasses
+        .stream()
+        .sorted(Comparator.comparing(Class::getName))
+        .toList();
+    final var distinctProcesses = sorted
+        .stream()
+        .map(primaryProcessOf)
+        .distinct()
+        .toList();
+    if (distinctProcesses.size() > 1) {
+      throw new IllegalStateException(
+          ambiguousPrimaryProcessMessage(sorted, workflowAggregateType, primaryProcessOf));
+    }
+    return sorted.getFirst();
+
+  }
+
+  /**
+   * The message reporting several BPMN processes declared as the primary one for a
+   * single workflow aggregate.
+   *
+   * @param serviceClasses The classes declaring the aggregate, sorted
+   * @param workflowAggregateType The aggregate
+   * @param primaryProcessOf The primary BPMN process of a class
+   * @return The message
+   */
+  static String ambiguousPrimaryProcessMessage(
+      final List<Class<?>> serviceClasses,
+      final Class<?> workflowAggregateType,
+      final Function<Class<?>, String> primaryProcessOf) {
+
+    final var declarations = serviceClasses
+        .stream()
+        .map(serviceClass -> "  %s declares '%s'".formatted(
+            serviceClass.getName(),
+            primaryProcessOf.apply(serviceClass)))
+        .collect(Collectors.joining("\n"));
+    return """
+        Several classes annotated with @WorkflowService declare a DIFFERENT BPMN process for the \
+        workflow aggregate '%s':
+        %s
+        VanillaBP provides one ProcessService per workflow aggregate (that is what \
+        'ProcessService<%s>' injects), so exactly one of these processes is the one \
+        'startWorkflow' starts - and picking one of them here would be a coin flip.
+        Declare the process to be started as the 'bpmnProcess' of ONE class and move the others \
+        into that class' 'secondaryBpmnProcesses' (a process called by a call activity is the \
+        typical case). Handlers of a secondary process may stay in their own class as long as \
+        that class declares the same 'bpmnProcess'."""
+        .formatted(
+            workflowAggregateType.getName(),
+            declarations,
+            workflowAggregateType.getSimpleName());
+
+  }
+
+  /**
    * All BPMN process IDs a workflow service class declares: the primary
    * {@code bpmnProcess} plus every {@code secondaryBpmnProcesses} entry. Secondary
    * entries have to be explicit - there is no class-name convention for them.
@@ -172,7 +269,12 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
       final List<Class<?>> serviceClasses,
       final Class<A> workflowAggregateType) {
 
-    final var serviceClass = serviceClasses.getFirst();
+    // ONE ProcessService per aggregate is the SPI's injection contract, so ONE of
+    // the classes declares the process startWorkflow starts. Which one used to be
+    // the first the classpath scan returned - an order coming from the file system
+    // (story 60). Several classes declaring the SAME process are fine (handlers
+    // split across classes); different ones are ambiguous and end the boot.
+    final var serviceClass = primaryWorkflowServiceClass(serviceClasses, workflowAggregateType);
     final var bpmnProcessId = primaryBpmnProcessId(serviceClass);
 
     final var beanType = ParameterizedTypeReference

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/processservice/PrimaryWorkflowServiceClassTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/processservice/PrimaryWorkflowServiceClassTest.java
@@ -1,0 +1,89 @@
+package io.vanillabp.integration.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 60: one workflow aggregate has one {@code ProcessService}, so one of the
+ * classes declaring the aggregate names the process {@code startWorkflow} starts.
+ * That used to be whichever class the classpath scan returned first - an order coming
+ * from the file system.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class PrimaryWorkflowServiceClassTest {
+
+  public static class Aggregate {
+  }
+
+  /**
+   * The fixtures carry NO {@code @WorkflowService}: annotated classes on this test
+   * classpath would be found by the classpath scan of every other test in this
+   * module. Their process is handed to the rule instead.
+   */
+  public static class CallingWorkflowService {
+  }
+
+  public static class CalledWorkflowService {
+  }
+
+  public static class SecondHalfOfTheProcess {
+  }
+
+  private static final Map<Class<?>, String> PROCESSES = Map.of(
+      CallingWorkflowService.class, "LoanApproval",
+      CalledWorkflowService.class, "RiskAssessment",
+      SecondHalfOfTheProcess.class, "LoanApproval");
+
+  @Test
+  @DisplayName("Two classes naming different processes for one aggregate end the boot")
+  public void differentPrimaryProcessesAreReported() {
+
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> ProcessServiceBeanRegistrar.primaryWorkflowServiceClass(
+            List.of(CallingWorkflowService.class, CalledWorkflowService.class),
+            Aggregate.class,
+            PROCESSES::get));
+
+    final var message = failure.getMessage();
+    assertTrue(message.contains(CallingWorkflowService.class.getName()), message);
+    assertTrue(message.contains(CalledWorkflowService.class.getName()), message);
+    assertTrue(message.contains("LoanApproval"), message);
+    assertTrue(message.contains("RiskAssessment"), message);
+    // the way out is part of it: one class declares the process to be started, the
+    // others move under its secondaryBpmnProcesses
+    assertTrue(message.contains("secondaryBpmnProcesses"), message);
+
+  }
+
+  @Test
+  @DisplayName("Classes sharing one process are not ambiguous, and the choice is reproducible")
+  public void sharedPrimaryProcessIsAccepted() {
+
+    assertEquals(
+        CallingWorkflowService.class,
+        ProcessServiceBeanRegistrar.primaryWorkflowServiceClass(
+            List.of(SecondHalfOfTheProcess.class, CallingWorkflowService.class),
+            Aggregate.class,
+            PROCESSES::get),
+        "with one process the class is chosen by name, not by the order of the scan");
+    assertEquals(
+        CallingWorkflowService.class,
+        ProcessServiceBeanRegistrar.primaryWorkflowServiceClass(
+            List.of(CallingWorkflowService.class, SecondHalfOfTheProcess.class),
+            Aggregate.class,
+            PROCESSES::get));
+
+  }
+
+}


### PR DESCRIPTION
Story 60, found by the blueprint `bpmn-call-activity-decomposition` (`blueprints/GAPS.md` G5).

## The finding

VanillaBP builds one `ProcessService` per workflow aggregate — that is the SPI's injection contract (`ProcessService<MyAggregate>`). Its BPMN process was the one declared by the first class the classpath scan returned, and that order comes from the file system.

Two classes annotated with `@WorkflowService` on the same aggregate — the pattern the SPI README showed for decomposing a process with a call activity — therefore decided by accident which process `startWorkflow` starts. In the blueprint the *called* process won, and it looked healthy: the workflow ran, its tasks ran, only half the business case happened and the aggregate stayed half filled.

## The decision: report it, do not guess

A deterministic rule was considered ("the process no call activity of this workflow module calls") and dropped: it cannot be evaluated where the decision is made. The process service is built while beans are registered (Spring Boot) respectively while the application is built (Quarkus); the BPMN models are read later, by the adapter, during deployment.

So the ambiguity ends the boot (Quarkus: the build) with a message naming both classes, the process each of them declares, and the way out: one class declares the process to be started as its `bpmnProcess`, the others move into that class' `secondaryBpmnProcesses`.

**Still allowed**, because it is not ambiguous: several classes declaring the *same* process for one aggregate — handlers of one process split across classes. Which of them gives the bean its identity is now decided by class name instead of by scan order.

## Tests

- `AmbiguousPrimaryProcessTest` (Quarkus): the build fails, the message names both classes and both processes.
- `SharedPrimaryProcessTest` (Quarkus): two classes on one process boot and yield one `ProcessService` for that process.
- `PrimaryWorkflowServiceClassTest` (Spring Boot): both cases, plus the reproducible choice.

Worth knowing: the Spring fixtures first carried `@WorkflowService` and were therefore found by the classpath scan of every other test in that module — nine tests of `VanillaBpConfigurationBindingTest` failed, correctly. The rule now takes the process of a class as a function, so the test needs no annotated fixtures.

## Docs

The SPI README of `spi-for-java` recommended exactly the pattern that now fails; it shows the one-class form with `secondaryBpmnProcesses`, the allowed split of handlers, and what does not work (separate PR in that repository). Here: the wiki page `Workflow-tasks` and the version-1 migration guide, since a version-1 application may well be built the old way.

Platform build green, 233 test runs across both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25