### PR TITLE
Find the BPMN of a workflow module tested in its own Maven module

### DIFF
--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -108,7 +108,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
    * {@link #getAdapterResourcesLocationFor(String, String)}).
    */
   @Builder.Default
-  private Map<String, String> conventionalResourcesLocations = Map.of();
+  private Map<String, List<String>> conventionalResourcesLocations = Map.of();
 
   /**
    * Applies convention-over-configuration defaults to the bound properties:
@@ -231,13 +231,20 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
         .getFirst()
         .fromMainArtifact();
 
-    final var locations = new LinkedHashMap<String, String>();
+    final var locations = new LinkedHashMap<String, List<String>>();
     modules.forEach(
         module -> locations.put(
             module.id(),
             singleModuleOfMainArtifact
-                ? "classpath*:processes"
-                : "classpath*:%s/processes".formatted(module.id())));
+                // the application IS the workflow module - but a module tested inside
+                // its own Maven module is the main artifact as well, and its files sit
+                // where the packaged application needs them: below the module ID. Both
+                // are searched, the module's own location first (story 68; the module's
+                // configuration files are found in both places for the same reason)
+                ? List.of(
+                    "classpath*:%s/processes".formatted(module.id()),
+                    "classpath*:processes")
+                : List.of("classpath*:%s/processes".formatted(module.id()))));
     conventionalResourcesLocations = locations;
 
   }
@@ -621,23 +628,46 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
       final String workflowModuleId,
       final String adapterId) {
 
+    return getAdapterResourcesLocationsFor(workflowModuleId, adapterId).getFirst();
+
+  }
+
+  /**
+   * All locations to be searched for the resources of a workflow module, in the order
+   * they are searched - the first one holding BPMN files wins (see
+   * {@code DeploymentService}). A configured location is always the only one; the
+   * convention names two where the application IS the workflow module, because a
+   * module tested inside its own Maven module is the main artifact as well while its
+   * files sit below the module ID (story 68).
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param adapterId The adapter ID
+   * @return The locations, never empty
+   */
+  public List<ResourcesLocation> getAdapterResourcesLocationsFor(
+      final String workflowModuleId,
+      final String adapterId) {
+
     final var workflowModule = getWorkflowModules().get(workflowModuleId);
     if (workflowModule != null) {
       final var adapter = workflowModule.getAdapters().get(adapterId);
       if ((adapter != null) && (adapter.getResourcesLocation() != null) && !adapter.getResourcesLocation().isBlank()) {
-        return new ResourcesLocation(adapter.getResourcesLocation(), false);
+        return List.of(new ResourcesLocation(adapter.getResourcesLocation(), false));
       }
     }
 
     final var globalResourcesLocation = getResourcesLocation();
     if ((globalResourcesLocation != null) && !globalResourcesLocation.isBlank()) {
-      return new ResourcesLocation(globalResourcesLocation, true);
+      return List.of(new ResourcesLocation(globalResourcesLocation, true));
     }
 
-    final var conventionalLocation = conventionalResourcesLocations.get(workflowModuleId);
-    if (conventionalLocation != null) {
-      return new ResourcesLocation(
-          "%s/%s".formatted(conventionalLocation, adapterId), false);
+    final var conventionalLocations = conventionalResourcesLocations.get(workflowModuleId);
+    if ((conventionalLocations != null) && !conventionalLocations.isEmpty()) {
+      return conventionalLocations
+          .stream()
+          .map(conventionalLocation -> new ResourcesLocation(
+              "%s/%s".formatted(conventionalLocation, adapterId), false))
+          .toList();
     }
 
     throw new IllegalStateException(

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/deployment/DeploymentService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/deployment/DeploymentService.java
@@ -204,7 +204,50 @@ public class DeploymentService {
           }
         });
 
+    reportWorkflowModulesWithoutResources(workflowModuleIds);
+
     warnAboutConfiguredWorkflowsUnknownToBpmnResources(workflowModuleIds, knownBpmnProcessIds);
+
+  }
+
+  /**
+   * Reports a workflow module NO adapter found resources for. Each adapter already
+   * warned about its own location, but a module none of them could serve is a
+   * different message: nothing of this module runs, and the failure a developer meets
+   * later comes from the BPMS ("no processes deployed with key ...") and names neither
+   * VanillaBP nor a location (story 68).
+   * <p>
+   * The boot continues on purpose: BPMN may arrive with an adapter deployed later
+   * (the migration case this platform exists for), and a module without resources
+   * breaks nothing by itself.
+   *
+   * @param workflowModuleIds The workflow module IDs which were deployed
+   */
+  private void reportWorkflowModulesWithoutResources(
+      final List<String> workflowModuleIds) {
+
+    workflowModuleIds
+        .stream()
+        .filter(workflowModuleId -> !bpmsProcessingContexts.containsKey(workflowModuleId))
+        .forEach(workflowModuleId -> log.error(
+            "No BPMN resources were found for workflow module '{}' - by NONE of its adapters ({}). "
+                + "No workflow of this module can be started; the BPMS would report an unknown "
+                + "process. Locations searched: {}. Check where the module's BPMN files are packaged, "
+                + "or name the location explicitly in "
+                + "'{}.workflow-modules.{}.adapters.<adapter>.resources-location'.",
+            workflowModuleId,
+            String.join(", ", properties.getDeploymentAdaptersFor(workflowModuleId)),
+            properties
+                .getDeploymentAdaptersFor(workflowModuleId)
+                .stream()
+                .flatMap(adapterId -> properties
+                    .getAdapterResourcesLocationsFor(workflowModuleId, adapterId)
+                    .stream())
+                .map(location -> "'%s'".formatted(location.location()))
+                .distinct()
+                .collect(java.util.stream.Collectors.joining(", ")),
+            MigrationAdapterProperties.PREFIX,
+            workflowModuleId));
 
   }
 
@@ -326,12 +369,27 @@ public class DeploymentService {
       final Function<String, Map<String, InputStream>> bpmnResourcesLoader,
       final Set<String> knownBpmnProcessIds) {
 
-    final var resourcesLocation = properties.getAdapterResourcesLocationFor(
+    // a configured location is the only one; the convention may name two (the
+    // application IS the workflow module, and a module tested inside its own Maven
+    // module is that as well while keeping its files below the module ID, story 68).
+    // The first location holding files wins - never both, so a process cannot be
+    // deployed twice.
+    final var candidateLocations = properties.getAdapterResourcesLocationsFor(
         workflowModuleId,
         deploymentService.getAdapterId());
-    // find all BPMN files in the resource location...
+    var searchedLocation = candidateLocations.getFirst();
+    var foundFiles = Map.<String, InputStream>of();
+    for (final var candidate : candidateLocations) {
+      final var filesOfCandidate = bpmnResourcesLoader.apply(candidate.location());
+      if (!filesOfCandidate.isEmpty()) {
+        searchedLocation = candidate;
+        foundFiles = filesOfCandidate;
+        break;
+      }
+    }
+    final var resourcesLocation = searchedLocation;
     final var bpmsProcessingContext = new BpmsProcessingContextHolder<PC>();
-    final var bpmnFiles = bpmnResourcesLoader.apply(resourcesLocation.location());
+    final var bpmnFiles = foundFiles;
     try {
       bpmnFiles
           .entrySet()
@@ -375,12 +433,18 @@ public class DeploymentService {
     // the adapter must never be called with a null processing context
     if (bpmsProcessingContext.getBpmsProcessingContext() == null) {
       log.warn(
-          "No executable BPMN processes found for workflow module '{}' at location '{}'! "
-              + "Adapter '{}' is skipped for this workflow module. If this is unintended, "
-              + "check property '{}.workflow-modules.{}.adapters.{}.resources-location' "
-              + "(or '{}.resources-location') and the BPMN files at that location.",
+          "No executable BPMN processes found for workflow module '{}' at location {}! "
+              + "Adapter '{}' is skipped for this workflow module, so none of its workflows can be "
+              + "started by that adapter. If this is unintended, check property "
+              + "'{}.workflow-modules.{}.adapters.{}.resources-location' (or '{}.resources-location') "
+              + "and the BPMN files at that location.",
           workflowModuleId,
-          resourcesLocation.location(),
+          candidateLocations.size() == 1
+              ? "'%s'".formatted(resourcesLocation.location())
+              : candidateLocations
+                  .stream()
+                  .map(candidate -> "'%s'".formatted(candidate.location()))
+                  .collect(java.util.stream.Collectors.joining(" and ")),
           deploymentService.getAdapterId(),
           MigrationAdapterProperties.PREFIX,
           workflowModuleId,

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MigrationAdapterPropertiesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MigrationAdapterPropertiesTest.java
@@ -105,7 +105,10 @@ public class MigrationAdapterPropertiesTest {
   public void testResourcesLocationOfTheApplicationsOwnWorkflowModule() {
 
     // the single workflow module declared by the application's MAIN artifact: its
-    // BPMN lives below 'processes/' - no module id in the path
+    // BPMN lives below 'processes/' - no module id in the path. Story 68: the
+    // module's OWN location is searched first, because a workflow module tested
+    // inside its own Maven module is the main artifact as well while its files sit
+    // below the module id
     final var properties = new MigrationAdapterProperties();
     properties.setAdapters(Map.of("adapter-test", AdapterConfigProperties.ofType("adapter2")));
     properties.setPrioritizedAdapters(List.of("adapter-test"));
@@ -116,10 +119,36 @@ public class MigrationAdapterPropertiesTest {
         null);
 
     assertEquals(
-        "classpath*:processes/adapter-test",
+        List.of("classpath*:the-app/processes/adapter-test", "classpath*:processes/adapter-test"),
         properties
-            .getAdapterResourcesLocationFor("the-app", "adapter-test")
-            .location());
+            .getAdapterResourcesLocationsFor("the-app", "adapter-test")
+            .stream()
+            .map(MigrationAdapterProperties.ResourcesLocation::location)
+            .toList());
+
+  }
+
+  @Test
+  public void testOneLocationOnlyForAModuleWhichIsNotTheMainArtifact() {
+
+    // a module shipped as its own artifact keeps ONE location: the root of the
+    // application is another module's business (story 68)
+    final var properties = new MigrationAdapterProperties();
+    properties.setAdapters(Map.of("adapter-test", AdapterConfigProperties.ofType("adapter2")));
+    properties.setPrioritizedAdapters(List.of("adapter-test"));
+
+    properties.validateProperties(
+        new ClasspathFacts(
+            adaptersLoaded, List.of(new ClasspathFacts.WorkflowModuleInfo("a-module", false))),
+        null);
+
+    assertEquals(
+        List.of("classpath*:a-module/processes/adapter-test"),
+        properties
+            .getAdapterResourcesLocationsFor("a-module", "adapter-test")
+            .stream()
+            .map(MigrationAdapterProperties.ResourcesLocation::location)
+            .toList());
 
   }
 

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/MissingResourcesLocationConfigurationTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/MissingResourcesLocationConfigurationTest.java
@@ -43,9 +43,19 @@ public class MissingResourcesLocationConfigurationTest {
   @Test
   public void testResourcesLocationFollowsTheConvention() {
 
-    final var resourcesLocation = properties.getAdapterResourcesLocationFor("test-module", "test");
+    final var resourcesLocations = properties.getAdapterResourcesLocationsFor("test-module", "test");
+    final var resourcesLocation = resourcesLocations.getFirst();
 
-    Assertions.assertEquals("classpath*:processes/test", resourcesLocation.location());
+    // the module is searched at its own location first and at the application's root
+    // second - a module tested inside its own Maven module is the main artifact as
+    // well while its files sit below the module id (story 68)
+    Assertions.assertEquals(
+        java.util.List.of("classpath*:test-module/processes/test", "classpath*:processes/test"),
+        resourcesLocations
+            .stream()
+            .map(
+                io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties.ResourcesLocation::location)
+            .toList());
     Assertions.assertFalse(
         resourcesLocation.vanillaBpBpmn(),
         "a derived location is adapter-specific, like a configured adapter-specific one");

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/NoWorkflowModuleConfigurationTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/NoWorkflowModuleConfigurationTest.java
@@ -47,9 +47,14 @@ public class NoWorkflowModuleConfigurationTest {
         () -> "expected a derived section for the workflow module found in classpath but got: "
             + properties.getWorkflowModules().keySet());
     Assertions.assertEquals(
-        "classpath*:processes/test",
-        properties.getAdapterResourcesLocationFor("test-module", "test").location(),
-        "the BPMN location follows the convention");
+        java.util.List.of("classpath*:test-module/processes/test", "classpath*:processes/test"),
+        properties
+            .getAdapterResourcesLocationsFor("test-module", "test")
+            .stream()
+            .map(
+                io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties.ResourcesLocation::location)
+            .toList(),
+        "the BPMN location follows the convention, the module's own location first");
 
   }
 

--- a/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/ZeroConfigurationTest.java
+++ b/quarkus-integration/deployment/src/test/java/io/vanillabp/integration/test/adapter/ZeroConfigurationTest.java
@@ -55,12 +55,17 @@ public class ZeroConfigurationTest {
         () -> "the workflow module found in classpath needs no section but got: "
             + properties.getWorkflowModules().keySet());
     // the application IS the workflow module here (the test archive is the root
-    // application archive), so its BPMN lives below 'processes/<adapter id>'
+    // application archive), so its BPMN lives below 'processes/<adapter id>' - and
+    // below '<module id>/processes/<adapter id>' when the module is being tested
+    // inside its own Maven module, which is the main artifact as well (story 68)
     Assertions.assertEquals(
-        "classpath*:processes/dummy",
+        List.of("classpath*:test-module/processes/dummy", "classpath*:processes/dummy"),
         properties
-            .getAdapterResourcesLocationFor("test-module", "dummy")
-            .location());
+            .getAdapterResourcesLocationsFor("test-module", "dummy")
+            .stream()
+            .map(
+                io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties.ResourcesLocation::location)
+            .toList());
 
   }
 

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ModuleUnderTestResourcesTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ModuleUnderTestResourcesTest.java
@@ -1,0 +1,63 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.deployment.Aggregate;
+import io.vanillabp.integration.test.deployment.AggregatePersistence;
+import io.vanillabp.integration.test.deployment.RecordingDeploymentEvents;
+import io.vanillabp.integration.test.deployment.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * Story 68: a workflow module tested inside its own Maven module IS the root
+ * application archive, so the convention used to drop the module ID and look at
+ * 'classpath*:processes/&lt;adapter&gt;' - while the files sit where the packaged
+ * application needs them, below the module ID. The module found nothing in its own
+ * test, and the failure arrived later from the BPMS.
+ * <p>
+ * Both locations are searched now, the module's own one first. No property is
+ * configured here on purpose: this is the convention doing it.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ModuleUnderTestResourcesTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("module-under-test/application.yaml", "application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingDeploymentEvents.class)
+          // where the PACKAGED application needs them: below the module ID
+          .addAsResource("bpmn/first.bpmn", "test-module/processes/demo/first.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  RecordingDeploymentEvents events;
+
+  @Test
+  @DisplayName("The module's own location is searched although the module is the main artifact")
+  public void resourcesBelowTheModuleIdAreFound() {
+
+    final var recorded = events.getEvents();
+
+    assertTrue(
+        recorded.contains("adapter:demo:readBpmn:test-module:first.bpmn"),
+        () -> "the BPMN below the module ID was not found: "
+            + recorded);
+    assertTrue(
+        recorded.contains("adapter:demo:deployResources:test-module"),
+        () -> "the module was not deployed: "
+            + recorded);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/module-under-test/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/module-under-test/application.yaml
@@ -1,0 +1,9 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:module-under-test;DB_CLOSE_DELAY=-1
+vanillabp:
+  adapters:
+    demo:
+      type: dummy


### PR DESCRIPTION
Story 68, found by the blueprint `module-single/quarkus` (`blueprints/GAPS.md` G14).

## The finding

Where BPMN files are read from follows a convention: below the module ID normally, below `processes/` where the application's main artifact declares the single workflow module.

A workflow module tested inside its **own** Maven module *is* the root application archive on Quarkus, so the convention dropped the module ID — while the files sit where the packaged application needs them, below the module ID. The module found nothing in its own test:

```
WARN No executable BPMN processes found for workflow module 'loan-approval' at location
 'classpath*:processes/camunda7'! Adapter 'camunda7' is skipped for this workflow module.
```

and the real failure arrived later, from the engine, naming neither VanillaBP nor a location (`no processes deployed with key 'loan_approval'`).

## The decision: the convention learns both

What settled it is question 5 of the prompt: the module's **configuration files** are already searched at the classpath root *and* below the module ID. Deciding differently for BPMN would need a reason, and there is none.

So where the application is the workflow module, two locations are searched — `classpath*:<module>/processes/<adapter>` first, `classpath*:processes/<adapter>` second — and the **first location holding files wins**, so a process is never deployed twice. A module shipped as its own artifact keeps its single location: the application's root belongs to another module there.

That also answers question 2: the platforms cannot tell "the application IS the module" from "the module is under test", and they no longer have to.

## The messages (question 4)

- The warning about an empty location names both searched locations.
- New: a workflow module **no** adapter found resources for is reported as an error — nothing of that module can run, and the developer would otherwise meet the BPMS' unknown-process error much later.
- The boot is deliberately not aborted: BPMN may arrive with an adapter deployed later, which is the migration case this platform exists for.

## Tests

- `ModuleUnderTestResourcesTest` (Quarkus): the root archive keeps its files below the module ID and they are found, with no property configured. Counter-checked without the second location — the deployment events stay empty.
- Two core unit tests for the candidate list (main artifact vs. own artifact).
- Three Quarkus configuration tests pinned the old single-location semantics and now assert the ordered list.

Platform build green, 234 test runs.

## Docs

`Workflow-modules` (the table plus why, pointing at the same rule for configuration files), `Workflow-modules-in-Quarkus` (the testing case spelled out) and `Workflow-modules-in-Spring-Boot`.

The blueprint `module-single/quarkus` can drop the `vanillabp` section from its test configuration and the resource filtering from its POM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25