### PR TITLE
One way to ask where a workflow module's resources live

### DIFF
--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/ClasspathFacts.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/ClasspathFacts.java
@@ -33,7 +33,7 @@ public record ClasspathFacts(
    *          module keeps its BPMN below <code>processes/</code>, whereas a
    *          workflow module shipped as its own artifact namespaces them below
    *          its module ID (see
-   *          {@link MigrationAdapterProperties#getAdapterResourcesLocationFor(String, String)}).
+   *          {@link MigrationAdapterProperties#getAdapterResourcesLocationsFor(String, String)}).
    */
   public record WorkflowModuleInfo(
                                    String id,

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -105,7 +105,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
    * {@link #normalize(ClasspathFacts)} (story 34's convention). Key is the
    * workflow module ID, value the location WITHOUT the adapter ID (which is
    * appended per adapter, see
-   * {@link #getAdapterResourcesLocationFor(String, String)}).
+   * {@link #getAdapterResourcesLocationsFor(String, String)}).
    */
   @Builder.Default
   private Map<String, List<String>> conventionalResourcesLocations = Map.of();
@@ -146,7 +146,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
    * section gets an empty one - a module needs no configuration any more.</li>
    * <li><b>Resources locations:</b> the location BPMN is read from follows the
    * convention documented at
-   * {@link #getAdapterResourcesLocationFor(String, String)}.</li>
+   * {@link #getAdapterResourcesLocationsFor(String, String)}.</li>
    * </ol>
    *
    * @param facts What the platform knows about the application without any
@@ -220,7 +220,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
 
   /**
    * Derives the conventional resources location of every workflow module found in
-   * the classpath (see {@link #getAdapterResourcesLocationFor(String, String)} for
+   * the classpath (see {@link #getAdapterResourcesLocationsFor(String, String)} for
    * the convention itself).
    */
   private void deriveConventionalResourcesLocations(
@@ -614,35 +614,23 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
    * <td><code>classpath*:&lt;workflow-module-id&gt;/processes/&lt;adapter-id&gt;</code></td></tr>
    * <tr><td>exactly one workflow module, declared by the application's MAIN
    * artifact</td>
-   * <td><code>classpath*:processes/&lt;adapter-id&gt;</code></td></tr>
+   * <td><code>classpath*:&lt;workflow-module-id&gt;/processes/&lt;adapter-id&gt;</code>,
+   * and <code>classpath*:processes/&lt;adapter-id&gt;</code> if the first holds
+   * nothing</td></tr>
    * </table>
    * A conventional location is adapter-specific like a configured one.</li>
    * </ol>
+   * The locations are returned in the order they are searched, and the first one
+   * holding BPMN files wins (see {@code DeploymentService}) - so a process is never
+   * deployed twice. A configured location is always the only one; the convention
+   * names two where the application IS the workflow module, because a module tested
+   * inside its own Maven module is the main artifact as well while its files sit
+   * below the module ID (story 68).
    *
    * @param workflowModuleId The workflow module ID
    * @param adapterId The adapter ID
-   * @return The location and whether the location contains VanillaBP BPMN (true)
-   *         or BPMN specific to the target BPMS (false).
-   */
-  public ResourcesLocation getAdapterResourcesLocationFor(
-      final String workflowModuleId,
-      final String adapterId) {
-
-    return getAdapterResourcesLocationsFor(workflowModuleId, adapterId).getFirst();
-
-  }
-
-  /**
-   * All locations to be searched for the resources of a workflow module, in the order
-   * they are searched - the first one holding BPMN files wins (see
-   * {@code DeploymentService}). A configured location is always the only one; the
-   * convention names two where the application IS the workflow module, because a
-   * module tested inside its own Maven module is the main artifact as well while its
-   * files sit below the module ID (story 68).
-   *
-   * @param workflowModuleId The workflow module ID
-   * @param adapterId The adapter ID
-   * @return The locations, never empty
+   * @return The locations to search, never empty, each carrying whether it contains
+   *         VanillaBP BPMN (true) or BPMN specific to the target BPMS (false)
    */
   public List<ResourcesLocation> getAdapterResourcesLocationsFor(
       final String workflowModuleId,
@@ -1034,7 +1022,8 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
     knownWorkflowModuleIds.forEach(
         workflowModuleId -> {
           final var prioritizedAdaptersOfModule = getPrioritizedAdaptersFor(workflowModuleId, null);
-          prioritizedAdaptersOfModule.forEach(adapterId -> getAdapterResourcesLocationFor(workflowModuleId, adapterId));
+          prioritizedAdaptersOfModule
+              .forEach(adapterId -> getAdapterResourcesLocationsFor(workflowModuleId, adapterId));
           getBpmnProcessIdsForWorkflowModule(workflowModuleId)
               .forEach(
                   bpmnProcessId -> {
@@ -1042,7 +1031,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
                         workflowModuleId,
                         bpmnProcessId
                     );
-                    prioritizedAdapters.forEach(adapterId -> getAdapterResourcesLocationFor(
+                    prioritizedAdapters.forEach(adapterId -> getAdapterResourcesLocationsFor(
                         workflowModuleId,
                         adapterId));
                   });

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MigrationAdapterPropertiesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MigrationAdapterPropertiesTest.java
@@ -95,7 +95,9 @@ public class MigrationAdapterPropertiesTest {
 
     properties.validateProperties(adaptersLoaded, List.of("fake-module"));
 
-    final var resourcesLocation = properties.getAdapterResourcesLocationFor("fake-module", "adapter-test");
+    final var resourcesLocations = properties.getAdapterResourcesLocationsFor("fake-module", "adapter-test");
+    assertEquals(1, resourcesLocations.size(), "a module of its own artifact has ONE conventional location");
+    final var resourcesLocation = resourcesLocations.getFirst();
     assertEquals("classpath*:fake-module/processes/adapter-test", resourcesLocation.location());
     assertFalse(resourcesLocation.vanillaBpBpmn(), "a derived location is adapter-specific");
 
@@ -172,11 +174,15 @@ public class MigrationAdapterPropertiesTest {
     properties.validateProperties(adaptersLoaded, List.of("configured-module", "global-module"));
 
     // the adapter-specific location wins over everything
-    final var specific = properties.getAdapterResourcesLocationFor("configured-module", "adapter-test");
+    final var specific = properties
+        .getAdapterResourcesLocationsFor("configured-module", "adapter-test")
+        .getFirst();
     assertEquals("classpath*:specific", specific.location());
     assertFalse(specific.vanillaBpBpmn());
     // the global location wins over the convention (VanillaBP-neutral BPMN)
-    final var global = properties.getAdapterResourcesLocationFor("global-module", "adapter-test");
+    final var global = properties
+        .getAdapterResourcesLocationsFor("global-module", "adapter-test")
+        .getFirst();
     assertEquals("classpath*:global-bpmn", global.location());
     assertTrue(global.vanillaBpBpmn());
 
@@ -460,7 +466,8 @@ public class MigrationAdapterPropertiesTest {
     assertEquals(
         "classpath*:test-module/processes/only-adapter",
         properties
-            .getAdapterResourcesLocationFor("test-module", "only-adapter")
+            .getAdapterResourcesLocationsFor("test-module", "only-adapter")
+            .getFirst()
             .location());
 
   }

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/ConfigurationConventionsTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/ConfigurationConventionsTest.java
@@ -163,7 +163,8 @@ public class ConfigurationConventionsTest {
       Assertions.assertEquals(
           "classpath*:test-module/processes/dummy",
           properties
-              .getAdapterResourcesLocationFor("test-module", "dummy")
+              .getAdapterResourcesLocationsFor("test-module", "dummy")
+              .getFirst()
               .location());
 
       // the BPMN of that location really was deployed by the derived adapter
@@ -222,7 +223,8 @@ public class ConfigurationConventionsTest {
       Assertions.assertEquals(
           "classpath*:test-module/processes/dummy2",
           properties
-              .getAdapterResourcesLocationFor("test-module", "dummy2")
+              .getAdapterResourcesLocationsFor("test-module", "dummy2")
+              .getFirst()
               .location());
 
     }

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/config/VanillaBpConfigurationBindingTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/config/VanillaBpConfigurationBindingTest.java
@@ -137,7 +137,9 @@ public class VanillaBpConfigurationBindingTest {
           assertEquals(
               List.of("test"),
               properties.getPrioritizedAdaptersFor("test-module"));
-          final var resourcesLocation = properties.getAdapterResourcesLocationFor("test-module", "test");
+          final var resourcesLocation = properties
+              .getAdapterResourcesLocationsFor("test-module", "test")
+              .getFirst();
           assertEquals("classpath:bpms-specific", resourcesLocation.location());
           assertFalse(resourcesLocation.vanillaBpBpmn());
 


### PR DESCRIPTION
Follow-up to story 68, asked for in review: is the single-value getter still needed?

It is not. `getAdapterResourcesLocationFor` returned the *first* of the locations story 68 introduced — a meaning nobody guesses right, and three tests pinned the old one and broke. After story 68 its only production caller was the property validation in the same class, which works just as well with the list. No adapter and no platform module used it.

So it is gone, and everything asks `getAdapterResourcesLocationsFor`. Test call sites that genuinely expect one location say `.getFirst()`; the one asserting the convention checks the whole ordered list. The javadoc table now names both locations instead of claiming `classpath*:processes/<adapter-id>` alone.

Platform build green, 234 test runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25