### PR TITLE
Tell adapters which processes share a workflow aggregate

### DIFF
--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -275,6 +275,34 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
 
   }
 
+  @Override
+  public boolean workflowsShareTheWorkflowAggregate(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String otherBpmnProcessId) {
+
+    final var aggregate = workflowAggregateClassOf(workflowModuleId, bpmnProcessId);
+    final var otherAggregate = workflowAggregateClassOf(workflowModuleId, otherBpmnProcessId);
+    return (aggregate != null) && aggregate.equals(otherAggregate);
+
+  }
+
+  /**
+   * The workflow aggregate a BPMN process of a workflow module works on, or
+   * <code>null</code> if no workflow service declared that process.
+   */
+  private Class<?> workflowAggregateClassOf(
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if ((entry == null) || (entry.processService == null)) {
+      return null;
+    }
+    return entry.processService.getWorkflowAggregateClass();
+
+  }
+
   private static void failOnDuplicateWiring(
       final String workflowModuleId,
       final String bpmnProcessId,

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -1495,6 +1495,83 @@ public class WorkflowTaskRegistryTest {
    * workflow-aggregate class is validated at STARTUP.
    */
   @Nested
+  @DisplayName("Processes sharing a workflow aggregate (story 61)")
+  class SharedWorkflowAggregates {
+
+    /**
+     * Registers a second BPMN process of the module on a workflow aggregate of its
+     * own - the "reuse" case, where a called process must NOT be handed the caller's
+     * identity.
+     */
+    private void registerProcessOfAnotherAggregate(
+        final String bpmnProcessId) {
+
+      final var persistenceOfOtherAggregate = new AggregatePersistenceAware<GetterAggregate>() {
+
+        @Override
+        public Class<GetterAggregate> getAggregateClass() {
+          return GetterAggregate.class;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final GetterAggregate aggregate) {
+          return aggregate.id;
+        }
+
+      };
+      final var properties = MigrationAdapterProperties
+          .builder()
+          .adapters(Map.of("test-adapter", AdapterConfigProperties.ofType("dummy")))
+          .prioritizedAdapters(List.of("test-adapter"))
+          .build();
+      properties.validateAndLink();
+      registry.registerWorkflowService(
+          MODULE,
+          bpmnProcessId,
+          GetterAggregate.class, // no @WorkflowTask methods - registration is fine
+          GetterAggregate::new,
+          beans::get,
+          new MigrationProcessService<>(
+              MODULE, bpmnProcessId, GetterAggregate.class, properties, persistenceOfOtherAggregate, List.of(
+                  new NoOpProcessService<GetterAggregate>()), null));
+
+    }
+
+    @Test
+    @DisplayName("Two processes of one aggregate share it, a process with its own does not")
+    public void aggregatesAreComparedByClass() {
+
+      // a secondary process of the same aggregate: the class declaring it named the
+      // same aggregate, which is what the adapter asks about a call activity
+      registry.registerWorkflowService(
+          MODULE,
+          "SecondaryProcess",
+          SampleService.class,
+          () -> serviceBean,
+          beans::get,
+          createProcessService());
+      registerProcessOfAnotherAggregate("ProcessOfItsOwn");
+
+      assertTrue(registry.workflowsShareTheWorkflowAggregate(MODULE, PROCESS, "SecondaryProcess"));
+      assertTrue(registry.workflowsShareTheWorkflowAggregate(MODULE, "SecondaryProcess", PROCESS));
+      assertFalse(registry.workflowsShareTheWorkflowAggregate(MODULE, PROCESS, "ProcessOfItsOwn"));
+
+    }
+
+    @Test
+    @DisplayName("A process nobody declared is not known to share anything")
+    public void unknownProcessesShareNothing() {
+
+      assertFalse(registry.workflowsShareTheWorkflowAggregate(MODULE, PROCESS, "NeverDeclared"));
+      assertFalse(registry.workflowsShareTheWorkflowAggregate(MODULE, "NeverDeclared", PROCESS));
+      assertFalse(registry.workflowsShareTheWorkflowAggregate("another-module", PROCESS, PROCESS));
+
+    }
+
+  }
+
+  @Nested
   @DisplayName("Aggregate sync (story 28b)")
   class AggregateSync {
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -169,6 +169,36 @@ public interface WorkflowTaskInvoker {
       String taskDefinitionOrActivityId);
 
   /**
+   * Whether two BPMN processes of one workflow module work on the SAME workflow
+   * aggregate - which is what the declaration says: one class declares the process
+   * to be started as its {@code bpmnProcess} and the others as
+   * {@code secondaryBpmnProcesses}.
+   * <p>
+   * Adapters ask this about a call activity: a process called on the same aggregate
+   * continues the same business case and has to reach the same aggregate, whereas a
+   * process with an aggregate of its own must not be handed the caller's identity.
+   * Camunda 7 needs the answer because it does not pass its business key - which
+   * carries the aggregate's ID - to a called process on its own (story 61).
+   * <p>
+   * The default is <code>false</code>: the core answers this, and a test double of
+   * this SPI should not invent an answer which makes an adapter change a model.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param otherBpmnProcessId The BPMN process ID to compare with
+   * @return Whether both processes serve the same workflow aggregate;
+   *         <code>false</code> if either of them is unknown
+   */
+  default boolean workflowsShareTheWorkflowAggregate(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String otherBpmnProcessId) {
+
+    return false;
+
+  }
+
+  /**
    * Whether the <code>&#64;WorkflowTask</code> method serving the given task
    * definition (or BPMN activity ID) completes its task ASYNCHRONOUSLY, which a
    * method says by declaring a <code>&#64;TaskId</code> parameter: the task stays


### PR DESCRIPTION
Prerequisite of story 61 in the Camunda 7 adapter (vanillabp/camunda7-adapter PR follows).

Camunda 7 does not pass its business key — where VanillaBP keeps the workflow aggregate's ID — to a process started by a call activity. The adapter has to inject that propagation while preparing the BPMN, but not blindly: a called process with an aggregate of **its own** would be handed the caller's identity, which is the wrong aggregate ID.

Only the core can tell the two apart, and since story 60 the declaration is unambiguous — one workflow service declares the process to be started, the others are its `secondaryBpmnProcesses`. `WorkflowTaskInvoker.workflowsShareTheWorkflowAggregate` answers it from the registry by comparing the aggregate classes.

The default is `false`: a test double of this SPI should not invent an answer which makes an adapter change a model.

Tested in `WorkflowTaskRegistryTest`: two processes of one aggregate share it, a process with an aggregate of its own does not, and a process nobody declared shares nothing.

Platform build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25