### PR TITLE
The aggregate's persistence decides its outbox and delivery log (Quarkus)

### DIFF
--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/pom.xml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.vanillabp.quarkus</groupId>
+    <artifactId>processservice-integration-tests</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>mixed-persistence-tests</artifactId>
+  <name>Quarkus integration - Integration tests - Two persistences in one application</name>
+  <description>An application storing one aggregate in a relational database and another one in MongoDB: every store is attributed to the aggregate whose persistence it matches (story 84).</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>vanillabp-quarkus-integration</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp.quarkus.adapter</groupId>
+      <artifactId>dummy-adapter</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-config-yaml</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-mongodb-panache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-hibernate-orm-panache</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jdbc-h2</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-jacoco</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vanillabp</groupId>
+      <artifactId>test-utils</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/JpaAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/JpaAggregate.java
@@ -1,0 +1,19 @@
+package io.vanillabp.integration.test.mixed;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+/**
+ * The aggregate stored in the relational database of this application, written as a
+ * Hibernate ORM Panache active record.
+ */
+@Entity
+public class JpaAggregate extends PanacheEntityBase {
+
+  @Id
+  public String id;
+
+  public String status;
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/JpaWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/JpaWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.mixed;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = JpaAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "JpaProcess"))
+public class JpaWorkflowService {
+
+  @Inject
+  ProcessService<JpaAggregate> processService;
+
+  public JpaAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new JpaAggregate();
+    aggregate.id = id;
+    aggregate.status = "started";
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final JpaAggregate aggregate) {
+
+    aggregate.status = "processed";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MixedTaskWiringSource.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MixedTaskWiringSource.java
@@ -1,0 +1,27 @@
+package io.vanillabp.integration.test.mixed;
+
+import java.util.Collection;
+import java.util.List;
+
+import io.vanillabp.adapter.dummy.runtime.DummyTaskWiringSource;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Stands in for the BPMN models of this application: both processes have one task,
+ * wired to the <code>processTask</code> handler of their workflow service.
+ */
+@ApplicationScoped
+public class MixedTaskWiringSource implements DummyTaskWiringSource {
+
+  @Override
+  public Collection<BpmnTaskSpec> tasksOf(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId) {
+
+    return List.of(new BpmnTaskSpec("Activity_Process", "processTask"));
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MongoAggregate.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MongoAggregate.java
@@ -1,0 +1,19 @@
+package io.vanillabp.integration.test.mixed;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+
+import io.quarkus.mongodb.panache.PanacheMongoEntityBase;
+
+/**
+ * The aggregate stored in MongoDB, in the same workflow module as {@link JpaAggregate}.
+ * Both are active records, so neither of them is configured anywhere - which is what
+ * leaves VanillaBP with the question this application answers.
+ */
+public class MongoAggregate extends PanacheMongoEntityBase {
+
+  @BsonId
+  public String id;
+
+  public String status;
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MongoWorkflowService.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/MongoWorkflowService.java
@@ -1,0 +1,37 @@
+package io.vanillabp.integration.test.mixed;
+
+import io.vanillabp.spi.process.ProcessService;
+import io.vanillabp.spi.service.BpmnProcess;
+import io.vanillabp.spi.service.WorkflowService;
+import io.vanillabp.spi.service.WorkflowTask;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+
+@ApplicationScoped
+@WorkflowService(
+    workflowAggregateClass = MongoAggregate.class,
+    bpmnProcess = @BpmnProcess(bpmnProcessId = "MongoProcess"))
+public class MongoWorkflowService {
+
+  @Inject
+  ProcessService<MongoAggregate> processService;
+
+  public MongoAggregate startWorkflow(
+      final String id) {
+
+    final var aggregate = new MongoAggregate();
+    aggregate.id = id;
+    aggregate.status = "started";
+    return processService.startWorkflow(aggregate);
+
+  }
+
+  @WorkflowTask
+  public void processTask(
+      final MongoAggregate aggregate) {
+
+    aggregate.status = "processed";
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/PhaseTwoRecorder.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/java/io/vanillabp/integration/test/mixed/PhaseTwoRecorder.java
@@ -1,0 +1,101 @@
+package io.vanillabp.integration.test.mixed;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import io.vanillabp.adapter.dummy.runtime.DummyPhaseTwoListener;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Records what the dummy adapter did in phase two, so a test can wait for the outbox
+ * dispatcher's thread to have arrived.
+ */
+@ApplicationScoped
+public class PhaseTwoRecorder implements DummyPhaseTwoListener {
+
+  private final List<String> startedWorkflows = new CopyOnWriteArrayList<>();
+
+  private final List<String> completedTasks = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void startedWorkflowPhaseTwo(
+      final Object workflowAggregateId) {
+
+    startedWorkflows.add(String.valueOf(workflowAggregateId));
+
+  }
+
+  @Override
+  public void completedTaskPhaseTwo(
+      final Object workflowAggregateId,
+      final String taskId) {
+
+    completedTasks.add(workflowAggregateId
+        + ":"
+        + taskId);
+
+  }
+
+  public List<String> getStartedWorkflows() {
+
+    return List.copyOf(startedWorkflows);
+
+  }
+
+  public List<String> getCompletedTasks() {
+
+    return List.copyOf(completedTasks);
+
+  }
+
+  /**
+   * Waits until the workflow of the given aggregate was started in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitStartedWorkflow(
+      final String workflowAggregateId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(startedWorkflows, workflowAggregateId, timeoutMillis);
+
+  }
+
+  /**
+   * Waits until the given task was completed in phase two.
+   *
+   * @param workflowAggregateId The aggregate's ID
+   * @param taskId The task's ID
+   * @param timeoutMillis How long to wait
+   * @return Whether phase two arrived in time
+   */
+  public boolean awaitCompletedTask(
+      final String workflowAggregateId,
+      final String taskId,
+      final long timeoutMillis) throws InterruptedException {
+
+    return await(
+        completedTasks,
+        workflowAggregateId
+            + ":"
+            + taskId,
+        timeoutMillis);
+
+  }
+
+  private static boolean await(
+      final List<String> recorded,
+      final String entry,
+      final long timeoutMillis) throws InterruptedException {
+
+    final var deadline = System.currentTimeMillis() + timeoutMillis;
+    while (!recorded.contains(entry) && (System.currentTimeMillis() < deadline)) {
+      Thread.sleep(50);
+    }
+    return recorded.contains(entry);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/resources/application.yaml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    username: sa
+    jdbc:
+      url: jdbc:h2:mem:mixed-persistence;DB_CLOSE_DELAY=-1
+  hibernate-orm:
+    schema-management:
+      strategy: drop-and-create
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/resources/workflow-module-descriptor/workflow-module
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/main/resources/workflow-module-descriptor/workflow-module
@@ -1,0 +1,1 @@
+test-module

--- a/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/test/java/io/vanillabp/integration/it/MixedPersistenceStoreAttributionTest.java
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/mixed-persistence-tests/src/test/java/io/vanillabp/integration/it/MixedPersistenceStoreAttributionTest.java
@@ -1,0 +1,137 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.bson.Document;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.narayana.jta.QuarkusTransaction;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.test.mixed.JpaAggregate;
+import io.vanillabp.integration.test.mixed.JpaWorkflowService;
+import io.vanillabp.integration.test.mixed.MixedTaskWiringSource;
+import io.vanillabp.integration.test.mixed.MongoAggregate;
+import io.vanillabp.integration.test.mixed.MongoWorkflowService;
+import io.vanillabp.integration.test.mixed.PhaseTwoRecorder;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+
+/**
+ * Story 84: an application with two persistences. One aggregate is a Hibernate ORM Panache
+ * active record, the other a MongoDB Panache active record, so both platform defaults of the
+ * phase-two outbox and of the delivery log are active and none of them can serve both.
+ * <p>
+ * Before this story such an application did not boot: the startup validation resolved the
+ * outbox, found two candidates and ended with a message telling the application to attribute
+ * them itself. Now the store is read off the persistence VanillaBP resolved for each
+ * aggregate, so this test starting at all is half of the assertion. The other half is where
+ * the outbox entries went.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MixedPersistenceStoreAttributionTest {
+
+  private static final String MONGO_DATABASE = "mixed-persistence-it";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(JpaAggregate.class)
+          .addClass(JpaWorkflowService.class)
+          .addClass(MongoAggregate.class)
+          .addClass(MongoWorkflowService.class)
+          .addClass(MixedTaskWiringSource.class)
+          .addClass(PhaseTwoRecorder.class)
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/JpaProcess.bpmn")
+          .addAsResource(new StringAsset("not parsed by the dummy adapter"), "processes/dummy/MongoProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("dummy-adapter.two-phase-commit", "true")
+      .overrideConfigKey("quarkus.mongodb.database", MONGO_DATABASE)
+      .overrideConfigKey("vanillabp.outbox.poll-interval", "PT0.5S")
+      .overrideConfigKey("vanillabp.outbox.attempt-frequency", "PT0.5S");
+
+  @Inject
+  JpaWorkflowService jpaWorkflows;
+
+  @Inject
+  MongoWorkflowService mongoWorkflows;
+
+  @Inject
+  PhaseTwoRecorder recorder;
+
+  @Inject
+  DataSource dataSource;
+
+  @Inject
+  MongoClient mongoClient;
+
+  @Test
+  @DisplayName("Each aggregate's outbox entry is written into the store of its own persistence")
+  public void eachAggregateUsesTheStoreOfItsPersistence() throws Exception {
+
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> jpaWorkflows.startWorkflow("jpa-start"));
+    QuarkusTransaction
+        .requiringNew()
+        .run(() -> mongoWorkflows.startWorkflow("mongo-start"));
+
+    assertTrue(
+        recorder.awaitStartedWorkflow("jpa-start", 30_000),
+        "phase two of the relational aggregate never arrived");
+    assertTrue(
+        recorder.awaitStartedWorkflow("mongo-start", 30_000),
+        "phase two of the MongoDB aggregate never arrived");
+
+    assertEquals(
+        List.of("jpa-start"),
+        aggregateIdsInJdbcOutbox(),
+        "the relational outbox holds exactly the entry of the relational aggregate");
+    assertEquals(
+        List.of("mongo-start"),
+        aggregateIdsInMongoOutbox(),
+        "the MongoDB outbox holds exactly the entry of the MongoDB aggregate");
+
+  }
+
+  private List<String> aggregateIdsInJdbcOutbox() throws Exception {
+
+    final var ids = new ArrayList<String>();
+    try (var connection = dataSource.getConnection(); var statement = connection.prepareStatement(
+        "SELECT AGGREGATE_ID FROM VANILLABP_PHASE_TWO_OUTBOX ORDER BY AGGREGATE_ID"); var resultSet = statement
+            .executeQuery()) {
+      while (resultSet.next()) {
+        ids.add(resultSet.getString(1));
+      }
+    }
+    return ids;
+
+  }
+
+  private List<String> aggregateIdsInMongoOutbox() {
+
+    final var ids = new ArrayList<String>();
+    for (final Document document : mongoClient
+        .getDatabase(MONGO_DATABASE)
+        .getCollection("vanillabp-phase-two-outbox")
+        .find()) {
+      ids.add(document.getString("aggregateId"));
+    }
+    ids.sort(String::compareTo);
+    return ids;
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/processservice-integration-tests/pom.xml
+++ b/quarkus-integration/integration-tests/processservice-integration-tests/pom.xml
@@ -17,5 +17,6 @@
     <module>default-persistence-tests</module>
     <module>default-persistence-mongo-tests</module>
     <module>discovery-tests</module>
+    <module>mixed-persistence-tests</module>
   </modules>
 </project>

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -197,8 +197,11 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
         .unwrap(SmallRyeConfig.class)
         .getConfigMapping(QuarkusMigrationAdapterProperties.class)
         .outbox();
+    // which store an aggregate's transaction reaches: read off the persistence VanillaBP
+    // resolved for it, so an application with two persistences attributes nothing itself
+    final var persistenceTechnology = new QuarkusPersistenceTechnology(aggregatePersistences);
     final var phaseTwoOutboxResolver = new QuarkusPhaseTwoOutboxResolver(
-        phaseTwoOutboxAwares, phaseTwoOutboxes, outboxProperties
+        phaseTwoOutboxAwares, phaseTwoOutboxes, persistenceTechnology, outboxProperties
             .jdbc()
             .enabled(), outboxProperties
                 .mongo()
@@ -207,7 +210,7 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
         transactionRunnerAwares, applicationTransactionRunners, aggregatePersistences, new io.vanillabp.integration.runtime.workflowtask.QuarkusTransactionRunner(
             txRegistry));
     final var taskDeliveryLogResolver = new QuarkusTaskDeliveryLogResolver(
-        taskDeliveryLogAwares, taskDeliveryLogs, outboxProperties
+        taskDeliveryLogAwares, taskDeliveryLogs, persistenceTechnology, outboxProperties
             .jdbc()
             .enabled(), outboxProperties
                 .mongo()

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusPersistenceTechnology.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusPersistenceTechnology.java
@@ -1,0 +1,129 @@
+package io.vanillabp.integration.runtime.processservice;
+
+import java.util.List;
+import java.util.Set;
+
+import io.vanillabp.integration.adapter.migration.processservice.AwareSelection;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import jakarta.enterprise.inject.Instance;
+
+/**
+ * Detects which persistence technology manages a workflow aggregate, asked by everything
+ * which has to write something in the aggregate's OWN transaction: the phase-two outbox
+ * ({@link QuarkusPhaseTwoOutboxResolver}), the log of processed task deliveries
+ * ({@link QuarkusTaskDeliveryLogResolver}) and the coverage verdict of story 70
+ * ({@link QuarkusTransactionRunnerResolver}).
+ * <p>
+ * The counterpart on Spring Boot reads the technology off the aggregate's Spring Data
+ * repository. Here it is read off the persistence VanillaBP resolved for the aggregate:
+ * where the application wrote no {@link AggregatePersistenceAware}, VanillaBP picked one of
+ * its own implementations while the application was built (story 69) and generated the bean
+ * providing it. That choice names the store, and the generated per-aggregate subclasses are
+ * matched through their superclass.
+ * <p>
+ * The implementations are matched BY NAME: the MongoDB Panache extension is optional, so
+ * this class must not carry a reference to them nor to any MongoDB type.
+ */
+public class QuarkusPersistenceTechnology {
+
+  public enum Technology {
+    JPA,
+    MONGO,
+    /** The application brought the persistence itself, so nobody but it knows the store. */
+    UNKNOWN
+  }
+
+  /** The MongoDB-based aggregate persistence defaults of story 69. */
+  private static final Set<String> MONGO_DEFAULT_PERSISTENCES = Set
+      .of(
+          "io.vanillabp.integration.runtime.persistence.PanacheMongoRepositoryAggregatePersistence",
+          "io.vanillabp.integration.runtime.persistence.PanacheMongoActiveRecordAggregatePersistence");
+
+  /**
+   * The relational defaults of story 69. Spring Data on Quarkus is the JPA one, the
+   * extension knows no other store.
+   */
+  private static final Set<String> JDBC_DEFAULT_PERSISTENCES = Set
+      .of(
+          "io.vanillabp.integration.runtime.persistence.PanacheRepositoryAggregatePersistence",
+          "io.vanillabp.integration.runtime.persistence.PanacheActiveRecordAggregatePersistence",
+          "io.vanillabp.integration.runtime.persistence.SpringDataAggregatePersistence");
+
+  private final Instance<AggregatePersistenceAware<?>> aggregatePersistences;
+
+  public QuarkusPersistenceTechnology(
+      final Instance<AggregatePersistenceAware<?>> aggregatePersistences) {
+
+    this.aggregatePersistences = aggregatePersistences;
+
+  }
+
+  /**
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @return The technology, {@link Technology#UNKNOWN} if the aggregate is stored by a
+   *         persistence of the application
+   */
+  public Technology of(
+      final Class<?> workflowAggregateClass) {
+
+    return technologyOf(persistenceOf(workflowAggregateClass));
+
+  }
+
+  /**
+   * The persistence serving an aggregate: the most specific
+   * {@link AggregatePersistenceAware} covering its class, which is either an
+   * implementation of the application or the bean generated for one of VanillaBP's own
+   * (story 69).
+   *
+   * @param workflowAggregateClass The workflow aggregate's class
+   * @return The persistence or <code>null</code> if there is none
+   */
+  public AggregatePersistenceAware<?> persistenceOf(
+      final Class<?> workflowAggregateClass) {
+
+    final List<AggregatePersistenceAware<?>> persistences = aggregatePersistences
+        .stream()
+        .<AggregatePersistenceAware<?>>map(persistence -> persistence)
+        .toList();
+    return AwareSelection
+        .mostSpecific(
+            persistences,
+            AggregatePersistenceAware::getAggregateClass,
+            workflowAggregateClass)
+        .orElse(null);
+
+  }
+
+  /**
+   * @param persistence The persistence serving an aggregate
+   * @return Whether it is one of VanillaBP's MongoDB defaults - the only case in which
+   *         the platform knows a MongoDB session is involved
+   */
+  public static boolean isMongoDefault(
+      final AggregatePersistenceAware<?> persistence) {
+
+    return technologyOf(persistence) == Technology.MONGO;
+
+  }
+
+  private static Technology technologyOf(
+      final AggregatePersistenceAware<?> persistence) {
+
+    if (persistence == null) {
+      return Technology.UNKNOWN;
+    }
+    for (Class<?> candidate = persistence.getClass(); candidate != null; candidate = candidate
+        .getSuperclass()) {
+      if (MONGO_DEFAULT_PERSISTENCES.contains(candidate.getName())) {
+        return Technology.MONGO;
+      }
+      if (JDBC_DEFAULT_PERSISTENCES.contains(candidate.getName())) {
+        return Technology.JPA;
+      }
+    }
+    return Technology.UNKNOWN;
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusPhaseTwoOutboxResolver.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusPhaseTwoOutboxResolver.java
@@ -20,21 +20,25 @@ import jakarta.enterprise.inject.Instance;
  * <li>the single active {@link PhaseTwoOutbox} bean if exactly one exists (defaults
  * which are deactivated - <code>vanillabp.outbox.jdbc.enabled</code> /
  * <code>vanillabp.outbox.mongo.enabled</code> - or unusable - no datasource/MongoDB
- * client configured - are not considered),</li>
- * <li>with several active outbox beans a guiding {@link IllegalStateException} is
- * raised: unlike Spring Boot, Quarkus has no platform-side knowledge of which
- * persistence manages an aggregate (aggregate persistence is always provided by the
- * application, see
- * {@link io.vanillabp.integration.spi.AggregatePersistenceAware}), so the
- * application has to attribute aggregates to outboxes via {@link PhaseTwoOutboxAware}
- * beans in mixed-persistence setups.</li>
+ * client configured - are not considered), unless it is the platform default of the
+ * other technology: an entry written next to the aggregate instead of into its
+ * transaction breaks the atomicity this outbox promises, so that ends the boot,</li>
+ * <li>with several active outbox beans the platform default matching the technology
+ * which manages the aggregate ({@link QuarkusPersistenceTechnology}, read off the
+ * persistence VanillaBP resolved for it in story 69).</li>
  * </ol>
+ * An application therefore writes a {@link PhaseTwoOutboxAware} bean for two reasons
+ * only: it brought the aggregate's persistence itself, so the technology cannot be
+ * read off it, or it wants a store of its own for this aggregate. Anything else is
+ * attributed by the platform.
  */
 public class QuarkusPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
 
   private final Instance<PhaseTwoOutboxAware<?>> phaseTwoOutboxAwares;
 
   private final Instance<PhaseTwoOutbox> phaseTwoOutboxes;
+
+  private final QuarkusPersistenceTechnology persistenceTechnology;
 
   private final boolean jdbcOutboxEnabled;
 
@@ -43,11 +47,13 @@ public class QuarkusPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
   public QuarkusPhaseTwoOutboxResolver(
       final Instance<PhaseTwoOutboxAware<?>> phaseTwoOutboxAwares,
       final Instance<PhaseTwoOutbox> phaseTwoOutboxes,
+      final QuarkusPersistenceTechnology persistenceTechnology,
       final boolean jdbcOutboxEnabled,
       final boolean mongoOutboxEnabled) {
 
     this.phaseTwoOutboxAwares = phaseTwoOutboxAwares;
     this.phaseTwoOutboxes = phaseTwoOutboxes;
+    this.persistenceTechnology = persistenceTechnology;
     this.jdbcOutboxEnabled = jdbcOutboxEnabled;
     this.mongoOutboxEnabled = mongoOutboxEnabled;
 
@@ -72,7 +78,7 @@ public class QuarkusPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
           .getPhaseTwoOutbox();
     }
 
-    // 2./3. the single active outbox bean - or a guiding error if ambiguous
+    // 2./3. attribute by the technology managing the aggregate
     final var outboxes = phaseTwoOutboxes
         .stream()
         .filter(this::isActive)
@@ -80,24 +86,83 @@ public class QuarkusPhaseTwoOutboxResolver implements PhaseTwoOutboxResolver {
     if (outboxes.isEmpty()) {
       return null;
     }
-    if (outboxes.size() > 1) {
-      throw new IllegalStateException(
-          """
-              Several PhaseTwoOutbox beans exist (%s), but none can be attributed to workflow \
-              aggregate '%s'! Outbox entries must be enlisted in the transaction persisting the \
-              aggregate. To solve this either
-              - provide a bean implementing io.vanillabp.integration.spi.PhaseTwoOutboxAware \
-              for this aggregate (returning the outbox matching its persistence), or
-              - deactivate the unwanted default outbox ('vanillabp.outbox.jdbc.enabled' / \
-              'vanillabp.outbox.mongo.enabled')."""
-              .formatted(
-                  outboxes
-                      .stream()
-                      .map(outbox -> outbox.getClass().getName())
-                      .toList(),
-                  workflowAggregateClass.getName()));
+
+    final var technology = persistenceTechnology.of(workflowAggregateClass);
+
+    // 2. exactly one outbox: use it - unless it is the platform default of the other
+    // technology, which would write the entry outside the aggregate's transaction
+    if (outboxes.size() == 1) {
+      final var outbox = outboxes.getFirst();
+      if (mismatches(outbox, technology)) {
+        throw new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, outboxes));
+      }
+      return outbox;
     }
-    return outboxes.getFirst();
+
+    // 3. several outboxes: the platform default of the aggregate's technology
+    return outboxes
+        .stream()
+        .filter(outbox -> matches(outbox, technology))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, outboxes)));
+
+  }
+
+  /**
+   * Whether an outbox is the platform default serving the given technology. An outbox
+   * of the application matches nothing: only its own
+   * {@link PhaseTwoOutboxAware} bean says which aggregates it serves.
+   */
+  private static boolean matches(
+      final PhaseTwoOutbox outbox,
+      final QuarkusPersistenceTechnology.Technology technology) {
+
+    return switch (technology) {
+      case JPA -> outbox instanceof JdbcPhaseTwoOutbox;
+      case MONGO -> outbox instanceof MongoPhaseTwoOutbox;
+      case UNKNOWN -> false;
+    };
+
+  }
+
+  /**
+   * Whether an outbox is the platform default of the OTHER technology - the one case in
+   * which a single outbox bean must not be used.
+   */
+  private static boolean mismatches(
+      final PhaseTwoOutbox outbox,
+      final QuarkusPersistenceTechnology.Technology technology) {
+
+    return switch (technology) {
+      case JPA -> outbox instanceof MongoPhaseTwoOutbox;
+      case MONGO -> outbox instanceof JdbcPhaseTwoOutbox;
+      case UNKNOWN -> false;
+    };
+
+  }
+
+  private static String buildAttributionErrorMessage(
+      final Class<?> workflowAggregateClass,
+      final QuarkusPersistenceTechnology.Technology technology,
+      final List<PhaseTwoOutbox> outboxes) {
+
+    return """
+        The PhaseTwoOutbox beans %s cannot be attributed to workflow aggregate '%s' (persistence \
+        technology detected: %s)! Outbox entries must be enlisted in the transaction persisting the \
+        aggregate. To solve this either
+        - provide a bean implementing io.vanillabp.integration.spi.PhaseTwoOutboxAware for this \
+        aggregate (returning the outbox matching its persistence), or
+        - enable the platform default matching the aggregate's persistence (add the corresponding \
+        extension; check 'vanillabp.outbox.jdbc.enabled' / 'vanillabp.outbox.mongo.enabled')."""
+        .formatted(
+            outboxes
+                .stream()
+                .map(outbox -> outbox.getClass().getName())
+                .toList(),
+            workflowAggregateClass.getName(),
+            technology);
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
@@ -13,18 +13,19 @@ import jakarta.enterprise.inject.Instance;
 /**
  * Quarkus implementation of the core's {@link TaskDeliveryLogResolver}: resolves the
  * {@link TaskDeliveryLog} used for a workflow aggregate so a delivery record always rides
- * the aggregate's own transaction. It mirrors {@link QuarkusPhaseTwoOutboxResolver} -
- * including its one difference to Spring Boot: Quarkus has no platform-side knowledge of
- * which persistence manages an aggregate (aggregate persistence is always provided by the
- * application, see {@link io.vanillabp.integration.spi.AggregatePersistenceAware}), so a
- * mixed-persistence application attributes aggregates to logs via
- * {@link TaskDeliveryLogAware} beans.
+ * the aggregate's own transaction. It mirrors {@link QuarkusPhaseTwoOutboxResolver}: the
+ * most specific {@link TaskDeliveryLogAware} bean of the application wins, otherwise the
+ * platform default matching the technology which manages the aggregate
+ * ({@link QuarkusPersistenceTechnology}), and a single default clearly not matching it
+ * ends the boot rather than writing records next to the aggregate.
  */
 public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
 
   private final Instance<TaskDeliveryLogAware<?>> taskDeliveryLogAwares;
 
   private final Instance<TaskDeliveryLog> taskDeliveryLogs;
+
+  private final QuarkusPersistenceTechnology persistenceTechnology;
 
   private final boolean jdbcLogEnabled;
 
@@ -33,11 +34,13 @@ public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
   public QuarkusTaskDeliveryLogResolver(
       final Instance<TaskDeliveryLogAware<?>> taskDeliveryLogAwares,
       final Instance<TaskDeliveryLog> taskDeliveryLogs,
+      final QuarkusPersistenceTechnology persistenceTechnology,
       final boolean jdbcLogEnabled,
       final boolean mongoLogEnabled) {
 
     this.taskDeliveryLogAwares = taskDeliveryLogAwares;
     this.taskDeliveryLogs = taskDeliveryLogs;
+    this.persistenceTechnology = persistenceTechnology;
     this.jdbcLogEnabled = jdbcLogEnabled;
     this.mongoLogEnabled = mongoLogEnabled;
 
@@ -62,7 +65,7 @@ public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
           .getTaskDeliveryLog();
     }
 
-    // 2./3. the single active log bean - or a guiding error if ambiguous
+    // 2./3. attribute by the technology managing the aggregate
     final var logs = taskDeliveryLogs
         .stream()
         .filter(this::isActive)
@@ -70,24 +73,83 @@ public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
     if (logs.isEmpty()) {
       return null;
     }
-    if (logs.size() > 1) {
-      throw new IllegalStateException(
-          """
-              Several TaskDeliveryLog beans exist (%s), but none can be attributed to workflow \
-              aggregate '%s'! A delivery record must be enlisted in the transaction persisting the \
-              aggregate. To solve this either
-              - provide a bean implementing io.vanillabp.integration.spi.TaskDeliveryLogAware for \
-              this aggregate (returning the log matching its persistence), or
-              - deactivate the unwanted default ('vanillabp.outbox.jdbc.enabled' / \
-              'vanillabp.outbox.mongo.enabled')."""
-              .formatted(
-                  logs
-                      .stream()
-                      .map(deliveryLog -> deliveryLog.getClass().getName())
-                      .toList(),
-                  workflowAggregateClass.getName()));
+
+    final var technology = persistenceTechnology.of(workflowAggregateClass);
+
+    // 2. exactly one log: use it - unless it is the platform default of the other
+    // technology, which would record the delivery outside the aggregate's transaction
+    if (logs.size() == 1) {
+      final var deliveryLog = logs.getFirst();
+      if (mismatches(deliveryLog, technology)) {
+        throw new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, logs));
+      }
+      return deliveryLog;
     }
-    return logs.getFirst();
+
+    // 3. several logs: the platform default of the aggregate's technology
+    return logs
+        .stream()
+        .filter(deliveryLog -> matches(deliveryLog, technology))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException(
+            buildAttributionErrorMessage(workflowAggregateClass, technology, logs)));
+
+  }
+
+  /**
+   * Whether a log is the platform default serving the given technology. A log of the
+   * application matches nothing: only its own {@link TaskDeliveryLogAware} bean says
+   * which aggregates it serves.
+   */
+  private static boolean matches(
+      final TaskDeliveryLog deliveryLog,
+      final QuarkusPersistenceTechnology.Technology technology) {
+
+    return switch (technology) {
+      case JPA -> deliveryLog instanceof JdbcTaskDeliveryLog;
+      case MONGO -> deliveryLog instanceof MongoTaskDeliveryLog;
+      case UNKNOWN -> false;
+    };
+
+  }
+
+  /**
+   * Whether a log is the platform default of the OTHER technology - the one case in which
+   * a single log bean must not be used.
+   */
+  private static boolean mismatches(
+      final TaskDeliveryLog deliveryLog,
+      final QuarkusPersistenceTechnology.Technology technology) {
+
+    return switch (technology) {
+      case JPA -> deliveryLog instanceof MongoTaskDeliveryLog;
+      case MONGO -> deliveryLog instanceof JdbcTaskDeliveryLog;
+      case UNKNOWN -> false;
+    };
+
+  }
+
+  private static String buildAttributionErrorMessage(
+      final Class<?> workflowAggregateClass,
+      final QuarkusPersistenceTechnology.Technology technology,
+      final List<TaskDeliveryLog> logs) {
+
+    return """
+        The TaskDeliveryLog beans %s cannot be attributed to workflow aggregate '%s' (persistence \
+        technology detected: %s)! A delivery record must be enlisted in the transaction persisting \
+        the aggregate. To solve this either
+        - provide a bean implementing io.vanillabp.integration.spi.TaskDeliveryLogAware for this \
+        aggregate (returning the log matching its persistence), or
+        - enable the platform default matching the aggregate's persistence (add the corresponding \
+        extension; check 'vanillabp.outbox.jdbc.enabled' / 'vanillabp.outbox.mongo.enabled')."""
+        .formatted(
+            logs
+                .stream()
+                .map(deliveryLog -> deliveryLog.getClass().getName())
+                .toList(),
+            workflowAggregateClass.getName(),
+            technology);
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTransactionRunnerResolver.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTransactionRunnerResolver.java
@@ -35,7 +35,7 @@ public class QuarkusTransactionRunnerResolver implements TransactionRunnerResolv
 
   private final Instance<TransactionRunner> transactionRunners;
 
-  private final Instance<AggregatePersistenceAware<?>> aggregatePersistences;
+  private final QuarkusPersistenceTechnology persistenceTechnology;
 
   private final TransactionRunner platformRunner;
 
@@ -67,7 +67,7 @@ public class QuarkusTransactionRunnerResolver implements TransactionRunnerResolv
 
     this.transactionRunnerAwares = transactionRunnerAwares;
     this.transactionRunners = transactionRunners;
-    this.aggregatePersistences = aggregatePersistences;
+    this.persistenceTechnology = new QuarkusPersistenceTechnology(aggregatePersistences);
     this.platformRunner = platformRunner;
 
   }
@@ -105,8 +105,7 @@ public class QuarkusTransactionRunnerResolver implements TransactionRunnerResolv
       // the application brought the transaction and knows what it covers
       return TransactionCoverage.unknown();
     }
-    final var persistence = aggregatePersistenceOf(workflowAggregateClass);
-    if (!isMongoDefault(persistence)) {
+    if (persistenceTechnology.of(workflowAggregateClass) != QuarkusPersistenceTechnology.Technology.MONGO) {
       // JPA/Panache take part in the JTA transaction; an aggregate persistence of the
       // application is not something VanillaBP can judge
       return TransactionCoverage.unknown();
@@ -251,53 +250,6 @@ public class QuarkusTransactionRunnerResolver implements TransactionRunnerResolv
             .getClass()
             .getName()
         : declaredClass.getName();
-
-  }
-
-  private AggregatePersistenceAware<?> aggregatePersistenceOf(
-      final Class<?> workflowAggregateClass) {
-
-    final List<AggregatePersistenceAware<?>> persistences = aggregatePersistences
-        .stream()
-        .<AggregatePersistenceAware<?>>map(persistence -> persistence)
-        .toList();
-    return AwareSelection
-        .mostSpecific(
-            persistences,
-            AggregatePersistenceAware::getAggregateClass,
-            workflowAggregateClass)
-        .orElse(null);
-
-  }
-
-  /**
-   * The MongoDB-based aggregate persistence defaults of story 69, matched BY NAME: the
-   * MongoDB Panache extension is optional here, so this class must not carry a reference
-   * to them (nor to any MongoDB type).
-   */
-  private static final java.util.Set<String> MONGO_DEFAULT_PERSISTENCES = java.util.Set
-      .of(
-          "io.vanillabp.integration.runtime.persistence.PanacheMongoRepositoryAggregatePersistence",
-          "io.vanillabp.integration.runtime.persistence.PanacheMongoActiveRecordAggregatePersistence");
-
-  /**
-   * Whether the aggregate is stored by one of VanillaBP's MongoDB defaults (story 69) -
-   * the only case in which the platform knows a MongoDB session is involved. The
-   * generated per-aggregate subclasses are matched through their superclass.
-   */
-  private static boolean isMongoDefault(
-      final AggregatePersistenceAware<?> persistence) {
-
-    if (persistence == null) {
-      return false;
-    }
-    for (Class<?> candidate = persistence.getClass(); candidate != null; candidate = candidate
-        .getSuperclass()) {
-      if (MONGO_DEFAULT_PERSISTENCES.contains(candidate.getName())) {
-        return true;
-      }
-    }
-    return false;
 
   }
 

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/processservice/QuarkusStoreAttributionTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/processservice/QuarkusStoreAttributionTest.java
@@ -1,0 +1,235 @@
+package io.vanillabp.integration.runtime.test.processservice;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.runtime.delivery.JdbcTaskDeliveryLog;
+import io.vanillabp.integration.runtime.delivery.MongoTaskDeliveryLog;
+import io.vanillabp.integration.runtime.outbox.JdbcPhaseTwoOutbox;
+import io.vanillabp.integration.runtime.outbox.MongoPhaseTwoOutbox;
+import io.vanillabp.integration.runtime.persistence.PanacheActiveRecordAggregatePersistence;
+import io.vanillabp.integration.runtime.persistence.PanacheMongoActiveRecordAggregatePersistence;
+import io.vanillabp.integration.runtime.processservice.QuarkusPersistenceTechnology;
+import io.vanillabp.integration.runtime.processservice.QuarkusPhaseTwoOutboxResolver;
+import io.vanillabp.integration.runtime.processservice.QuarkusTaskDeliveryLogResolver;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import io.vanillabp.integration.spi.PhaseTwoOutboxAware;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDeliveryLogAware;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 84: an application with two persistences does not attribute its stores itself. Both
+ * defaults are registered as soon as a data source and a MongoDB client are configured, and
+ * which of them serves an aggregate is read off the persistence VanillaBP resolved for that
+ * aggregate.
+ * <p>
+ * The doubles below extend the platform defaults instead of implementing the interfaces,
+ * because that is what the resolvers recognise - and it is what the container hands them: a
+ * client proxy is a subclass, too.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class QuarkusStoreAttributionTest {
+
+  private static class OrderAggregate {
+  }
+
+  private static class ShipmentAggregate {
+  }
+
+  /** An aggregate the application persists itself, so no technology can be read off it. */
+  private static class LedgerAggregate {
+  }
+
+  private static class LedgerPersistence implements AggregatePersistenceAware<LedgerAggregate> {
+
+    @Override
+    public Class<LedgerAggregate> getAggregateClass() {
+      return LedgerAggregate.class;
+    }
+
+  }
+
+  private static final JdbcPhaseTwoOutbox JDBC_OUTBOX = new JdbcPhaseTwoOutbox() {
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+  };
+
+  private static final MongoPhaseTwoOutbox MONGO_OUTBOX = new MongoPhaseTwoOutbox() {
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+  };
+
+  private static final JdbcTaskDeliveryLog JDBC_LOG = new JdbcTaskDeliveryLog() {
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+  };
+
+  private static final MongoTaskDeliveryLog MONGO_LOG = new MongoTaskDeliveryLog() {
+
+    @Override
+    public boolean isAvailable() {
+      return true;
+    }
+
+  };
+
+  /** The persistences of an application storing one aggregate per technology. */
+  private static QuarkusPersistenceTechnology mixedPersistences() {
+
+    return new QuarkusPersistenceTechnology(
+        InstanceDouble.of(
+            List.<AggregatePersistenceAware<?>>of(
+                new PanacheActiveRecordAggregatePersistence<>(OrderAggregate.class),
+                new PanacheMongoActiveRecordAggregatePersistence<>(ShipmentAggregate.class),
+                new LedgerPersistence())));
+
+  }
+
+  private static QuarkusPhaseTwoOutboxResolver outboxResolver(
+      final List<PhaseTwoOutboxAware<?>> awares,
+      final List<PhaseTwoOutbox> outboxes) {
+
+    return new QuarkusPhaseTwoOutboxResolver(
+        InstanceDouble.of(awares), InstanceDouble.of(outboxes), mixedPersistences(), true, true);
+
+  }
+
+  private static QuarkusTaskDeliveryLogResolver deliveryLogResolver(
+      final List<TaskDeliveryLogAware<?>> awares,
+      final List<TaskDeliveryLog> logs) {
+
+    return new QuarkusTaskDeliveryLogResolver(
+        InstanceDouble.of(awares), InstanceDouble.of(logs), mixedPersistences(), true, true);
+
+  }
+
+  @Test
+  @DisplayName("With both defaults each aggregate gets the store of its own persistence")
+  public void eachAggregateGetsTheStoreOfItsPersistence() {
+
+    final var outboxes = outboxResolver(List.of(), List.of(JDBC_OUTBOX, MONGO_OUTBOX));
+    assertSame(JDBC_OUTBOX, outboxes.resolveFor(OrderAggregate.class));
+    assertSame(MONGO_OUTBOX, outboxes.resolveFor(ShipmentAggregate.class));
+
+    final var logs = deliveryLogResolver(List.of(), List.of(JDBC_LOG, MONGO_LOG));
+    assertSame(JDBC_LOG, logs.resolveFor(OrderAggregate.class));
+    assertSame(MONGO_LOG, logs.resolveFor(ShipmentAggregate.class));
+
+  }
+
+  @Test
+  @DisplayName("An aware bean of the application still wins over the attribution")
+  public void awareBeansWin() {
+
+    final var dedicated = new PhaseTwoOutbox() {
+
+      @Override
+      public boolean schedule(
+          final io.vanillabp.integration.spi.PhaseTwoCall call) {
+        return true;
+      }
+
+    };
+    final var aware = new PhaseTwoOutboxAware<OrderAggregate>() {
+
+      @Override
+      public Class<OrderAggregate> getAggregateClass() {
+        return OrderAggregate.class;
+      }
+
+      @Override
+      public PhaseTwoOutbox getPhaseTwoOutbox() {
+        return dedicated;
+      }
+
+    };
+
+    assertSame(
+        dedicated,
+        outboxResolver(List.of(aware), List.of(JDBC_OUTBOX, MONGO_OUTBOX))
+            .resolveFor(OrderAggregate.class));
+
+  }
+
+  @Test
+  @DisplayName("A single default of the other technology ends the boot instead of losing entries")
+  public void aMismatchingSingleDefaultIsRefused() {
+
+    final var outboxFailure = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> outboxResolver(List.of(), List.of(JDBC_OUTBOX)).resolveFor(ShipmentAggregate.class));
+    assertTrue(outboxFailure.getMessage().contains("MONGO"), outboxFailure.getMessage());
+
+    final var logFailure = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> deliveryLogResolver(List.of(), List.of(MONGO_LOG)).resolveFor(OrderAggregate.class));
+    assertTrue(logFailure.getMessage().contains("JPA"), logFailure.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("A single default of the aggregate's own technology is used")
+  public void aMatchingSingleDefaultIsUsed() {
+
+    assertSame(
+        JDBC_OUTBOX,
+        outboxResolver(List.of(), List.of(JDBC_OUTBOX)).resolveFor(OrderAggregate.class));
+    assertSame(
+        MONGO_LOG,
+        deliveryLogResolver(List.of(), List.of(MONGO_LOG)).resolveFor(ShipmentAggregate.class));
+
+  }
+
+  @Test
+  @DisplayName("A persistence of the application is attributed by the application, or not at all")
+  public void anApplicationOwnedPersistenceKeepsItsMessage() {
+
+    final var failure = assertThrowsExactly(
+        IllegalStateException.class,
+        () -> outboxResolver(List.of(), List.of(JDBC_OUTBOX, MONGO_OUTBOX))
+            .resolveFor(LedgerAggregate.class));
+    assertTrue(failure.getMessage().contains("UNKNOWN"), failure.getMessage());
+    assertTrue(
+        failure.getMessage().contains(PhaseTwoOutboxAware.class.getName()),
+        failure.getMessage());
+
+    // a single default is used for it, as before: nothing says it is the wrong one
+    assertSame(
+        JDBC_OUTBOX,
+        outboxResolver(List.of(), List.of(JDBC_OUTBOX)).resolveFor(LedgerAggregate.class));
+
+  }
+
+  @Test
+  @DisplayName("Without any store nothing is resolved, and that is not an error here")
+  public void withoutAnyStoreNothingIsResolved() {
+
+    org.junit.jupiter.api.Assertions
+        .assertNull(outboxResolver(List.of(), List.of()).resolveFor(OrderAggregate.class));
+    org.junit.jupiter.api.Assertions
+        .assertNull(deliveryLogResolver(List.of(), List.of()).resolveFor(OrderAggregate.class));
+
+  }
+
+}


### PR DESCRIPTION
Story 84, found while building the MongoDB use case of the blueprint `persistence-active-record` (`blueprints/GAPS.md` G21).

## The problem

An application with two persistences does not start on Quarkus. With a data source and a MongoDB client configured, both platform defaults of the phase-two outbox are active, and `QuarkusPhaseTwoOutboxResolver` could attribute neither of them to an aggregate:

```
java.lang.IllegalStateException: Several PhaseTwoOutbox beans exist ([...JdbcPhaseTwoOutbox_ClientProxy,
...MongoPhaseTwoOutbox_ClientProxy]), but none can be attributed to workflow aggregate
'blueprint.workflowmodule.credithistory.model.Aggregate'!
```

It fires in `validatePhaseTwoOutboxAtStartup`, on the embedded engine as well, because the Camunda 7 adapter starts workflows in two phases like every other adapter since story 63. The log of delivered tasks has the same ambiguity one step later.

The remedy the message offered does not fit: an attribution bean has to inject `MongoPhaseTwoOutbox` or `JdbcPhaseTwoOutbox` from `vanillabp-quarkus-integration`, an artifact a workflow module must not depend on.

## What changed

Since story 69 VanillaBP picks the persistence of an aggregate itself, so it knows the store that aggregate's transaction reaches. Spring Boot has attributed the outbox that way since story 70; Quarkus now does the same.

- `QuarkusPersistenceTechnology` answers JPA, MONGO or UNKNOWN for an aggregate, read off the resolved `AggregatePersistenceAware` and matched by name (the MongoDB Panache extension is optional). It also holds `isMongoDefault`, which moved out of `QuarkusTransactionRunnerResolver`.
- Both resolvers attribute like their Spring counterparts: an `Aware` bean of the application wins, a single default of the other technology ends the boot instead of writing entries next to the aggregate, several defaults are picked by technology, and `UNKNOWN` keeps the old message.

## Tests

- `QuarkusStoreAttributionTest`, six cases over both resolvers.
- `mixed-persistence-tests`, a new acceptance application: one Hibernate ORM Panache aggregate, one MongoDB Panache aggregate, one workflow module, a two-phase adapter. It asserts that each outbox entry landed in the store of its own aggregate. Before this change that application did not boot.
- Full build green on both platforms.

## Documentation

Wiki `Quarkus-integration`: the outbox and the delivery-log sections say how the store is attributed and when an `Aware` bean is still needed. The delivery-log paragraph also caught up with story 70, where MongoDB records join the Panache session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds8wjecxWYszNdKxZX7xtL