### PR TITLE
Pin a released changelog, so nobody can edit it afterwards (story 75, addendum)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,6 +55,12 @@ jobs:
         run: |
           mvn --batch-mode --update-snapshots versions:set -DprocessAllModules=true -DnewVersion=${{ github.event.inputs.release_version }}
           find . -name pom.xml.versionsBackup -delete
+      - name: Pin the schema changelog of this version
+        run: |
+          # latest.xml becomes <version>.xml, the master changelog points at it and a checksum is
+          # written next to it - from then on the build fails if the file is ever edited, because a
+          # changeset which was applied to a database must not change
+          schema/bin/schema-version.sh pin ${{ github.event.inputs.release_version }}
       - name: Check for SNAPSHOT dependencies
         run: |
           SNAPSHOT_POMS=$(grep -R "<.*>.*SNAPSHOT<\/.*>" . --include=pom.xml || true)
@@ -101,6 +107,10 @@ jobs:
           IFS='.' read -r major minor patch <<< "$RELEASE_VERSION"
           NEXT_PATCH=$((patch + 1))
           echo "NEXT_SNAPSHOT=$major.$minor.${NEXT_PATCH}-SNAPSHOT" >> $GITHUB_ENV
+      - name: Open the schema changelog of the next version
+        run: |
+          NEXT_VERSION=${NEXT_SNAPSHOT%-SNAPSHOT}
+          schema/bin/schema-version.sh open "${NEXT_VERSION}"
       - name: Set next snapshot version
         run: |
           mvn --batch-mode --update-snapshots versions:set -DprocessAllModules=true -DnewVersion=${{ env.NEXT_SNAPSHOT }}

--- a/schema/README.md
+++ b/schema/README.md
@@ -16,10 +16,13 @@ the JAR from the classpath.
 
 ## What is in it
 
-|                                 Path                                  |                      What it is                       |
-|-----------------------------------------------------------------------|-------------------------------------------------------|
-| `vanillabp/schema/changelog.xml`                                      | the changelog, database-agnostic, the source of truth |
-| `vanillabp/schema/flyway/<database>/V<version>__vanillabp_schema.sql` | the same statements as SQL, generated at build time   |
+|                                 Path                                  |                          What it is                          |
+|-----------------------------------------------------------------------|--------------------------------------------------------------|
+| `vanillabp/schema/changelog.xml`                                      | the master: properties and includes, NO changeset of its own |
+| `vanillabp/schema/<version>.xml`                                      | the changesets of a released version, immutable and pinned   |
+| `vanillabp/schema/<version>.xml.sha256`                               | the checksum which pins it                                   |
+| `vanillabp/schema/latest.xml`                                         | the changesets of the version under development              |
+| `vanillabp/schema/flyway/<database>/V<version>__vanillabp_schema.sql` | the same statements as SQL, generated at build time          |
 
 Two tables are described: the phase-two outbox (`VANILLABP_PHASE_TWO_OUTBOX`) and the log of
 processed task deliveries (`VANILLABP_TASK_DELIVERY`). Not described: `TXNO_OUTBOX` of the Spring
@@ -50,13 +53,40 @@ The four untested ones ship because the Camunda 7 engine serves them, so Vanilla
 narrower of the two. Their files say in their header that they were generated, and the wiki says
 which ones a test covers.
 
+## Why the versions live in separate files
+
+A changeset which was applied to somebody's database must never change afterwards: Liquibase
+compares checksums and refuses to run, and getting an installation back from there is manual work in
+someone else's production database. Writing that rule down is not enough in an open-source project,
+so the layout enforces it:
+
+- the master changelog carries no changeset at all, only properties and one include per version,
+- a released version sits in its own file with a `.sha256` next to it, and `ChangelogRulesTest` fails
+  the build when that file no longer matches, when a version file has no checksum, or when a
+  changeset appears in the master,
+- everything under development goes into `latest.xml`, the only file without a checksum.
+
+All files here declare the same `logicalFilePath`, which is why the release can rename `latest.xml`
+to its version: Liquibase identifies a changeset by that logical path, its id and its author, so the
+physical file name never reaches a database.
+
+## Releasing, and opening the next version
+
+`schema/bin/schema-version.sh` does both halves and `.github/workflows/release.yaml` calls it:
+
+```bash
+schema/bin/schema-version.sh pin 2.0.0     # latest.xml -> 2.0.0.xml, include updated, checksum written
+schema/bin/schema-version.sh open 2.1.0    # a new, empty latest.xml, included again
+```
+
 ## Adding a change in a later version
 
-- Never edit or renumber a changeset which was released. Append a new one.
-- Its id is `vanillabp-<table>-<version>`, its `labels` attribute is that version.
+- Put it into `latest.xml`. Never edit a released file - the build says so if you do.
+- The changeset id is `vanillabp-<table>-<version>`, its `labels` attribute is that version.
 - Add one `liquibase-maven-plugin` execution per database for the new version in `pom.xml`, with
   `labelFilter` set to it. That is what keeps a Flyway file per release holding only that release's
-  statements - Flyway applies files, not diffs.
+  statements - Flyway applies files, not diffs - and it is deliberately a visible, reviewed change
+  rather than a loop over whatever happens to lie around.
 
 ## How the build produces the SQL
 

--- a/schema/bin/schema-version.sh
+++ b/schema/bin/schema-version.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+#
+# Fixes the changelog of a release, and opens the next one. Called by .github/workflows/release.yaml;
+# safe to run by hand.
+#
+#   schema-version.sh pin 2.0.0    renames latest.xml to 2.0.0.xml, points the master changelog at it
+#                                  and writes 2.0.0.xml.sha256 - from then on the build fails if the
+#                                  file is edited
+#   schema-version.sh open 2.1.0   creates an empty latest.xml for the next version and includes it
+#
+# Why: a changeset which was applied to somebody's database must never change afterwards, because
+# Liquibase compares checksums and refuses to run. Splitting the versions into files and pinning the
+# released ones turns that rule into something the build enforces.
+set -euo pipefail
+
+command="${1:-}"
+version="${2:-}"
+script_dir="$(dirname "${BASH_SOURCE[0]}")"
+schema_dir="${script_dir}/../src/main/resources/vanillabp/schema"
+master="${schema_dir}/changelog.xml"
+latest="${schema_dir}/latest.xml"
+
+usage() {
+  echo "usage: $(basename "$0") {pin|open} <version>" >&2
+  exit 2
+}
+
+checksum_of() {
+  sha256sum "$1" | cut -d' ' -f1
+}
+
+case "${command}" in
+
+  pin)
+    [ -n "${version}" ] || usage
+    [ -f "${latest}" ] || { echo "no latest.xml in ${schema_dir} - is this release already pinned?" >&2; exit 1; }
+    released="${schema_dir}/${version}.xml"
+    [ -e "${released}" ] && { echo "${released} exists already - a released changelog is never overwritten" >&2; exit 1; }
+
+    mv "${latest}" "${released}"
+    # the include of latest.xml becomes the include of the released file, and it moves above the
+    # comment which marks where the next one goes
+    python3 - "${master}" "${version}" <<'PYTHON'
+import sys
+master, version = sys.argv[1], sys.argv[2]
+text = open(master).read()
+latest_include = '  <!-- the version under development -->\n  <include file="vanillabp/schema/latest.xml"/>\n'
+if latest_include not in text:
+    raise SystemExit('the include of latest.xml is not where it was expected in %s' % master)
+released_include = '  <include file="vanillabp/schema/%s.xml"/>\n' % version
+marker = '  <!-- released versions, oldest first; the release adds a line here and never touches an existing\n       one -->\n'
+if marker not in text:
+    raise SystemExit('the marker for released versions is missing in %s' % master)
+text = text.replace(marker, marker + released_include, 1)
+text = text.replace('\n' + latest_include, '', 1)
+open(master, 'w').write(text)
+PYTHON
+
+    checksum_of "${released}" > "${released}.sha256"
+    echo "pinned ${version}.xml with checksum $(cat "${released}.sha256")"
+    ;;
+
+  open)
+    [ -n "${version}" ] || usage
+    [ -e "${latest}" ] && { echo "${latest} exists already" >&2; exit 1; }
+
+    cat > "${latest}" <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The changesets of VanillaBP ${version}, the version under development. Append changesets here;
+  never touch a file of a released version, its checksum is pinned (see the module's README).
+
+  Every file here declares the SAME logicalFilePath, which is why the release can rename this file
+  to its version without changing anything Liquibase records.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+    logicalFilePath="vanillabp/schema">
+
+  <!-- no change to the schema in ${version} yet -->
+
+</databaseChangeLog>
+XML
+
+    python3 - "${master}" <<'PYTHON'
+import sys
+master = sys.argv[1]
+text = open(master).read()
+include = '  <!-- the version under development -->\n  <include file="vanillabp/schema/latest.xml"/>\n'
+if include in text:
+    raise SystemExit(0)
+closing = '\n</databaseChangeLog>\n'
+if closing not in text:
+    raise SystemExit('unexpected end of %s' % master)
+text = text.replace(closing, '\n' + include + closing, 1)
+open(master, 'w').write(text)
+PYTHON
+    echo "opened ${version} in latest.xml"
+    ;;
+
+  *)
+    usage
+    ;;
+
+esac

--- a/schema/src/main/resources/vanillabp/schema/changelog.xml
+++ b/schema/src/main/resources/vanillabp/schema/changelog.xml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  The tables VanillaBP needs, described for Liquibase and NOT as SQL.
+  The tables VanillaBP needs, described for Liquibase and NOT as SQL. The SQL files next to this
+  changelog are GENERATED from it (see the module's README), so there is exactly one place where a
+  column is described.
 
-  Why not SQL: the databases nobody tests here inherit Liquibase's own testing of its type
-  mapping instead of our guesses. The SQL files next to this changelog are GENERATED from it
-  (see the module's README), so there is exactly one place where a column is described.
-
-  Rules for changing this file:
-  - a changeset which was released is never edited and never renumbered - append a new one,
-  - its id names the table and the VanillaBP version which introduced the change,
-  - its LABEL is that version, which is what lets the build generate one Flyway file per release
-    holding only that release's statements,
-  - a table name an application configured is a property, so a renamed table needs no fork.
+  THIS FILE CONTAINS NO CHANGESET, and a test makes sure it stays that way. It defines the
+  properties and includes one file per VanillaBP version: the released ones, which are immutable and
+  pinned by a checksum, and latest.xml, which is the version under development. A changeset that was
+  applied somewhere must never change - the checksum of a released file is what enforces it, and
+  keeping the versions in separate files is what makes the rule easy to follow.
 
   Not in here: the outbox of the Spring Boot integration (TXNO_OUTBOX). That schema belongs to
   gruelbox and its own migrator - see the wiki.
@@ -20,91 +17,16 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
-  <!-- override with -Dliquibase.vanillabp.outbox.table / in your own changelog which includes
-       this one, to match 'vanillabp.outbox.jdbc.table-name' -->
-  <property name="vanillabp.outbox.table" value="VANILLABP_PHASE_TWO_OUTBOX" />
+  <!-- override in your own changelog which includes this one, to match
+       'vanillabp.outbox.jdbc.table-name' -->
+  <property name="vanillabp.outbox.table" value="VANILLABP_PHASE_TWO_OUTBOX"/>
   <!-- matches 'vanillabp.delivery.jdbc.table-name' -->
-  <property name="vanillabp.delivery.table" value="VANILLABP_TASK_DELIVERY" />
+  <property name="vanillabp.delivery.table" value="VANILLABP_TASK_DELIVERY"/>
 
-  <changeSet author="VanillaBP" id="vanillabp-phase-two-outbox-2.0.0" labels="2.0.0">
-    <comment>
-      The phase-two outbox of a remote BPMS: one entry per operation which may only reach the BPMS
-      after the caller's transaction committed. IDEMPOTENCY_KEY is unique, which is what makes a
-      duplicate schedule a no-op; its 512 characters stay below MySQL's index key-length limit.
-    </comment>
-    <createTable tableName="${vanillabp.outbox.table}">
-      <column name="ID" type="VARCHAR(36)">
-        <constraints primaryKey="true" nullable="false" />
-      </column>
-      <column name="WORKFLOW_MODULE_ID" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="BPMN_PROCESS_ID" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="OPERATION" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="AGGREGATE_ID" type="VARCHAR(1024)" />
-      <column name="ADAPTER_ID" type="VARCHAR(255)" />
-      <column name="ARGS" type="VARCHAR(2048)" />
-      <column name="IDEMPOTENCY_KEY" type="VARCHAR(512)">
-        <constraints unique="true" />
-      </column>
-      <column name="STATUS" type="VARCHAR(16)">
-        <constraints nullable="false" />
-      </column>
-      <column name="CREATED_AT" type="TIMESTAMP">
-        <constraints nullable="false" />
-      </column>
-      <column name="ATTEMPTS" type="INT">
-        <constraints nullable="false" />
-      </column>
-      <column name="NEXT_ATTEMPT_AT" type="TIMESTAMP">
-        <constraints nullable="false" />
-      </column>
-      <column name="DONE_AT" type="TIMESTAMP" />
-    </createTable>
-    <!-- MySQL's TIMESTAMP ends in 2038 and auto-initializes, which is why the runtime creates
-         DATETIME(6) there as well - an application which starts with the runtime's tables and
-         later switches to this changelog has to end up with the same columns. -->
-    <modifySql dbms="mysql,mariadb">
-      <replace replace="timestamp" with="datetime(6)" />
-    </modifySql>
-  </changeSet>
+  <!-- released versions, oldest first; the release adds a line here and never touches an existing
+       one -->
 
-  <changeSet author="VanillaBP" id="vanillabp-task-delivery-2.0.0" labels="2.0.0">
-    <comment>
-      The log of processed task deliveries: what a BPMS repeating a delivery is answered from. The
-      delivery key is the BPMS' identity of the delivery, 512 characters for the same index reason.
-    </comment>
-    <createTable tableName="${vanillabp.delivery.table}">
-      <column name="DELIVERY_KEY" type="VARCHAR(512)">
-        <constraints primaryKey="true" nullable="false" />
-      </column>
-      <column name="WORKFLOW_MODULE_ID" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="BPMN_PROCESS_ID" type="VARCHAR(255)">
-        <constraints nullable="false" />
-      </column>
-      <column name="AGGREGATE_ID" type="VARCHAR(1024)" />
-      <column name="TASK_DEFINITION" type="VARCHAR(255)" />
-      <column name="OUTCOME" type="VARCHAR(32)">
-        <constraints nullable="false" />
-      </column>
-      <column name="BPMN_ERROR_CODE" type="VARCHAR(255)" />
-      <column name="BPMN_ERROR_NAME" type="VARCHAR(255)" />
-      <column name="RECORDED_AT" type="TIMESTAMP">
-        <constraints nullable="false" />
-      </column>
-    </createTable>
-    <!-- MySQL's TIMESTAMP ends in 2038 and auto-initializes, which is why the runtime creates
-         DATETIME(6) there as well - an application which starts with the runtime's tables and
-         later switches to this changelog has to end up with the same columns. -->
-    <modifySql dbms="mysql,mariadb">
-      <replace replace="timestamp" with="datetime(6)" />
-    </modifySql>
-  </changeSet>
+  <!-- the version under development -->
+  <include file="vanillabp/schema/latest.xml"/>
 
 </databaseChangeLog>

--- a/schema/src/main/resources/vanillabp/schema/latest.xml
+++ b/schema/src/main/resources/vanillabp/schema/latest.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The changesets of ONE version of VanillaBP. Released files carry a checksum next to them
+  (<name>.xml.sha256) and the build fails when the file no longer matches it: a changeset which was
+  applied somewhere must never change, and in an open-source project a rule nobody enforces is a
+  rule which will be broken by accident.
+
+  This file is the one under development. The release renames it to the version it releases and
+  writes the checksum; a new, empty latest.xml opens the next version. The rename does not change
+  what Liquibase records, because every file here declares the same logicalFilePath - that is what
+  the attribute is for.
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
+    logicalFilePath="vanillabp/schema">
+
+  <changeSet author="VanillaBP" id="vanillabp-phase-two-outbox-2.0.0" labels="2.0.0">
+    <comment>
+      The phase-two outbox of a remote BPMS: one entry per operation which may only reach the BPMS
+      after the caller's transaction committed. IDEMPOTENCY_KEY is unique, which is what makes a
+      duplicate schedule a no-op; its 512 characters stay below MySQL's index key-length limit.
+    </comment>
+    <createTable tableName="${vanillabp.outbox.table}">
+      <column name="ID" type="VARCHAR(36)">
+        <constraints primaryKey="true" nullable="false" />
+      </column>
+      <column name="WORKFLOW_MODULE_ID" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="BPMN_PROCESS_ID" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="OPERATION" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="AGGREGATE_ID" type="VARCHAR(1024)" />
+      <column name="ADAPTER_ID" type="VARCHAR(255)" />
+      <column name="ARGS" type="VARCHAR(2048)" />
+      <column name="IDEMPOTENCY_KEY" type="VARCHAR(512)">
+        <constraints unique="true" />
+      </column>
+      <column name="STATUS" type="VARCHAR(16)">
+        <constraints nullable="false" />
+      </column>
+      <column name="CREATED_AT" type="TIMESTAMP">
+        <constraints nullable="false" />
+      </column>
+      <column name="ATTEMPTS" type="INT">
+        <constraints nullable="false" />
+      </column>
+      <column name="NEXT_ATTEMPT_AT" type="TIMESTAMP">
+        <constraints nullable="false" />
+      </column>
+      <column name="DONE_AT" type="TIMESTAMP" />
+    </createTable>
+    <!-- MySQL's TIMESTAMP ends in 2038 and auto-initializes, which is why the runtime creates
+         DATETIME(6) there as well - an application which starts with the runtime's tables and
+         later switches to this changelog has to end up with the same columns. -->
+    <modifySql dbms="mysql,mariadb">
+      <replace replace="timestamp" with="datetime(6)" />
+    </modifySql>
+  </changeSet>
+
+  <changeSet author="VanillaBP" id="vanillabp-task-delivery-2.0.0" labels="2.0.0">
+    <comment>
+      The log of processed task deliveries: what a BPMS repeating a delivery is answered from. The
+      delivery key is the BPMS' identity of the delivery, 512 characters for the same index reason.
+    </comment>
+    <createTable tableName="${vanillabp.delivery.table}">
+      <column name="DELIVERY_KEY" type="VARCHAR(512)">
+        <constraints primaryKey="true" nullable="false" />
+      </column>
+      <column name="WORKFLOW_MODULE_ID" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="BPMN_PROCESS_ID" type="VARCHAR(255)">
+        <constraints nullable="false" />
+      </column>
+      <column name="AGGREGATE_ID" type="VARCHAR(1024)" />
+      <column name="TASK_DEFINITION" type="VARCHAR(255)" />
+      <column name="OUTCOME" type="VARCHAR(32)">
+        <constraints nullable="false" />
+      </column>
+      <column name="BPMN_ERROR_CODE" type="VARCHAR(255)" />
+      <column name="BPMN_ERROR_NAME" type="VARCHAR(255)" />
+      <column name="RECORDED_AT" type="TIMESTAMP">
+        <constraints nullable="false" />
+      </column>
+    </createTable>
+    <!-- MySQL's TIMESTAMP ends in 2038 and auto-initializes, which is why the runtime creates
+         DATETIME(6) there as well - an application which starts with the runtime's tables and
+         later switches to this changelog has to end up with the same columns. -->
+    <modifySql dbms="mysql,mariadb">
+      <replace replace="timestamp" with="datetime(6)" />
+    </modifySql>
+  </changeSet>
+
+</databaseChangeLog>

--- a/schema/src/test/java/io/vanillabp/schema/ChangelogRulesTest.java
+++ b/schema/src/test/java/io/vanillabp/schema/ChangelogRulesTest.java
@@ -1,0 +1,152 @@
+package io.vanillabp.schema;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The rules which keep a released changeset unchangeable. Liquibase compares checksums of what it
+ * applied, so editing a changeset afterwards breaks the next installation of somebody else's
+ * database - and getting back from there costs a support case. This is an open-source project, so
+ * the rules are enforced here instead of being written down and hoped for:
+ * <ul>
+ * <li>the master changelog holds no changeset of its own, only properties and includes,</li>
+ * <li>every included file exists and declares the shared logical path, which is what lets the
+ * release rename a file without changing what Liquibase records,</li>
+ * <li>a file of a released version carries a checksum next to it and still matches it,</li>
+ * <li>every file except <code>latest.xml</code> is released, so a rename by hand without pinning is
+ * caught as well.</li>
+ * </ul>
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ChangelogRulesTest {
+
+  private static final Path SCHEMA = Path.of("src/main/resources/vanillabp/schema");
+
+  private static final String LOGICAL_FILE_PATH = "logicalFilePath=\"vanillabp/schema\"";
+
+  private static final Pattern INCLUDE = Pattern
+      .compile("<include\\s+file=\"vanillabp/schema/([^\"]+)\"");
+
+  private static String read(
+      final Path path) throws Exception {
+
+    return Files.readString(path);
+
+  }
+
+  private static List<Path> changelogFiles() throws Exception {
+
+    try (var files = Files.list(SCHEMA)) {
+      return files
+          .filter(path -> path.getFileName().toString().endsWith(".xml"))
+          .filter(path -> !path.getFileName().toString().equals("changelog.xml"))
+          .sorted()
+          .toList();
+    }
+
+  }
+
+  private static String sha256(
+      final Path path) throws Exception {
+
+    final var digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path));
+    final var hex = new StringBuilder();
+    for (final var b : digest) {
+      hex.append("%02x".formatted(b));
+    }
+    return hex.toString();
+
+  }
+
+  @Test
+  @DisplayName("The master changelog only includes - a changeset in it could never be pinned")
+  public void theMasterHoldsNoChangeset() throws Exception {
+
+    final var master = read(SCHEMA.resolve("changelog.xml"));
+
+    assertFalse(master.contains("<changeSet"), "changelog.xml must only define properties and includes");
+    // right after a release pinned it, latest.xml does not exist yet - the next one is opened by
+    // 'schema-version.sh open'. Wherever it exists, it has to be included, or its changesets would
+    // silently do nothing
+    if (Files.exists(SCHEMA.resolve("latest.xml"))) {
+      assertTrue(master.contains("<include file=\"vanillabp/schema/latest.xml\"/>"), master);
+    }
+
+  }
+
+  @Test
+  @DisplayName("Every included file exists, and every version file shares the logical path")
+  public void everyIncludeResolvesAndSharesTheLogicalPath() throws Exception {
+
+    final var master = read(SCHEMA.resolve("changelog.xml"));
+    final var included = INCLUDE.matcher(master).results().map(result -> result.group(1)).toList();
+
+    assertFalse(included.isEmpty(), "no include found in changelog.xml");
+    for (final var name : included) {
+      assertTrue(Files.exists(SCHEMA.resolve(name)), "included but missing: "
+          + name);
+    }
+    assertEquals(
+        included.stream().sorted().toList(),
+        changelogFiles().stream().map(path -> path.getFileName().toString()).sorted().toList(),
+        "every file next to the master has to be included, and nothing else");
+
+    for (final var file : changelogFiles()) {
+      assertTrue(
+          read(file).contains(LOGICAL_FILE_PATH),
+          "%s has to declare %s, otherwise renaming it on release changes what Liquibase recorded"
+              .formatted(file.getFileName(), LOGICAL_FILE_PATH));
+    }
+
+  }
+
+  @Test
+  @DisplayName("A released changelog still matches its checksum, and only latest.xml has none")
+  public void releasedChangelogsArePinned() throws Exception {
+
+    for (final var file : changelogFiles()) {
+      final var name = file.getFileName().toString();
+      final var checksumFile = SCHEMA.resolve(name
+          + ".sha256");
+
+      if (name.equals("latest.xml")) {
+        assertFalse(
+            Files.exists(checksumFile),
+            "latest.xml is the version under development and must not be pinned yet");
+        continue;
+      }
+
+      assertTrue(
+          Files.exists(checksumFile),
+          """
+              %s has no checksum next to it. A file of a released version is pinned by \
+              'schema/bin/schema-version.sh pin <version>', which the release workflow calls - a \
+              version file created by hand skips that and must not stay."""
+              .formatted(name));
+      assertEquals(
+          read(checksumFile).strip(),
+          sha256(file),
+          """
+              %s does not match its checksum any more! A changeset which was applied to a database \
+              must never change: Liquibase compares checksums and refuses to run, and every \
+              installation which already applied this file needs manual repair. Revert the file and \
+              put your change into latest.xml instead."""
+              .formatted(name));
+    }
+
+  }
+
+}


### PR DESCRIPTION
Addendum to story 75, on Stephan's request: programmers do edit Liquibase definitions after the fact, and the cost lands in somebody else's production database — Liquibase compares checksums and refuses to run. This is an open-source project, so the layout enforces the rule instead of documenting it.

## The layout

- `changelog.xml` holds **no changeset at all** any more: properties plus one `<include>` per VanillaBP version.
- A released version lives in `<version>.xml` with a `<version>.xml.sha256` next to it.
- Everything under development goes into `latest.xml`, the only file without a checksum.
- Every file declares the same `logicalFilePath`, which is why the release can rename `latest.xml`: Liquibase identifies a changeset by that logical path, its id and its author, so the physical name never reaches a database. Visible in the generated SQL, whose provenance line is now `vanillabp/schema::vanillabp-phase-two-outbox-2.0.0::VanillaBP`.

## The release

`schema/bin/schema-version.sh`, called by `release.yaml`:

```bash
schema/bin/schema-version.sh pin 2.0.0     # latest.xml -> 2.0.0.xml, include moved, checksum written
schema/bin/schema-version.sh open 2.1.0    # a new, empty latest.xml, included again
```

`pin` runs before build and deploy, so the published artifact carries the pinned file; `open` runs before the next snapshot version is set, so that build sees a complete changelog. Both were executed here and rolled back again.

## The enforcement

A test, not a build script — portable, and verifiable itself. `ChangelogRulesTest` fails when a changeset appears in the master, when a version file has no checksum (which catches a rename done by hand), and when a pinned file no longer matches. Verified by tampering with a probe file: the failure names the file and says the change belongs into `latest.xml`.

A side observation which confirms the identity model: two files carrying the same changeset ids were rejected by Liquibase itself as "duplicate identifiers".

## Verification

`./mvnw install verify` green, 257 test classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25