### PR TITLE
A workflow which ended releases its delivery records (story 76)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,31 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## A workflow which ended can release its delivery records (2026-08-19)
+
+Story 76. Additive and switched off, so nothing changes for an application which does not
+configure it.
+
+The records of processed task deliveries were cleaned up by age alone until now
+(`vanillabp.outbox.retention`, seven days). Where
+`vanillabp.delivery.release-on-workflow-end` is set to `true`, globally or per workflow
+module, the records of a workflow are deleted the moment it ends instead: nothing of an
+ended instance can be redelivered, so the clock does not have to decide it. The deletion
+runs in the transaction of the end notification and is bounded by workflow module, BPMN
+process, workflow aggregate and by the moment of that notification, which keeps the
+records of a second workflow on the same aggregate.
+
+Switching it on has a price in the model: VanillaBP asks a BPMS to report the end of a
+workflow only where that end is used, so from then on every deployed process of the module
+carries the listener respectively the worker doing it. That is why it is off by default,
+and the retention stays the backstop for workflows still running, for aggregates whose
+workflow never ends and for stores which cannot delete.
+
+**Only relevant for stores of your own:** `TaskDeliveryLog.releaseRecordsOf(...)` is a new
+`default` method deleting nothing, so an existing store stays valid and keeps its records
+until the retention passed. Where the release is switched on and the store cannot serve it,
+the startup names the store and the property.
+
 ## A redelivered task no longer runs the handler twice (2026-08-14)
 
 Story 51. This is a behaviour change of the inbound direction, and it is on by default.

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -402,6 +402,37 @@ remembers a processed delivery and answers a repeated one from the record:
   boot. Unlike the outbox, nothing is broken without a log - the behaviour is the one
   every VanillaBP had before, and the wiki's rule about idempotent handlers covers it.
 
+#### The end of a workflow releases its records (story 76)
+
+Age alone is a poor answer to "how long does a record have to be kept": seven days are
+too long for a busy application and too short for a task genuinely open longer than
+that. The end of a workflow is the exact statement the retention only approximates,
+since nothing of an ended instance can be redelivered.
+
+- The switch is `vanillabp.delivery.release-on-workflow-end` (`DeliveryProperties`,
+  resolved by `MigrationAdapterProperties.releasesDeliveryRecordsOnWorkflowEnd`), global
+  and per workflow module, default `false`. It is adapter-INDEPENDENT: the records of
+  every BPMS live in the store of the aggregate, so this is a question about the
+  application's data.
+- Off by default because the end of a workflow is reported only where it is used:
+  adapters ask `WorkflowTaskRegistry.workflowEndedHandlerExists` while wiring, and that
+  method answers `true` where the release is switched on, even without a
+  `@WorkflowEnded` method. That is the whole reason no adapter had to change for this.
+- The deletion runs in `WorkflowEndedHandlers.workflowEnded`, inside the transaction that
+  notification opens anyway, bounded by workflow module, BPMN process, aggregate and by
+  an `Instant` taken BEFORE the notification is processed. The time bound is what keeps
+  the records of a SECOND workflow on the same aggregate, which is possible since
+  aggregates outlive their workflows.
+- `TaskDeliveryLog.releaseRecordsOf(...)` has a default deleting nothing, so every store
+  written before this stays valid. Whether a store implements it is answered by
+  reflection over the class the platform integration hands out
+  (`TaskDeliveryLogResolver.storeClassOf`, which unwraps CDI client proxies respectively
+  Spring AOP proxies - a proxy overrides the default method and would claim a release
+  which does not exist). A store which cannot release plus the option switched on is one
+  WARN at startup; with the option off nothing is logged.
+- The retention stays for everything the end of a workflow does not cover: workflows
+  still running, aggregates whose workflow never ends, stores without the release.
+
 #### Process versions (`version` attribute)
 
 The `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
@@ -1,5 +1,6 @@
 package io.vanillabp.integration.spi;
 
+import java.time.Instant;
 import java.util.Optional;
 
 /**
@@ -33,6 +34,14 @@ import java.util.Optional;
  * longer than the retention is a workflow waiting for something, not a delivery in
  * flight.
  * <p>
+ * <strong>Release at the end of a workflow:</strong> where
+ * <code>vanillabp.delivery.release-on-workflow-end</code> is switched on, the records of
+ * a workflow are deleted the moment it ends - nothing of an ended instance can be
+ * redelivered, so the clock does not have to decide it any more (see
+ * {@link #releaseRecordsOf(String, String, String, Instant)}). A store which does not
+ * implement the release keeps its records until the retention passed, and the startup
+ * says so where the release was asked for.
+ * <p>
  * Implementations are provided by the platform integrations (JDBC/JPA and MongoDB) or
  * by the application itself, since the platform-neutral core must not depend on any
  * particular persistence technology. Which log serves a workflow aggregate is decided
@@ -64,5 +73,36 @@ public interface TaskDeliveryLog {
    */
   boolean record(
       TaskDelivery delivery);
+
+  /**
+   * Deletes the records of ONE workflow, called when it ended and nothing of it can be
+   * redelivered any more. Invoked within the transaction of that notification, so the
+   * deletion commits with whatever else that transaction does.
+   * <p>
+   * The four arguments are the bound of the deletion, and each part of it matters: an
+   * aggregate may carry more than one BPMN process, and it may outlive its workflow and
+   * carry a SECOND one afterwards - whose records were written AFTER the notification
+   * and must survive it.
+   * <p>
+   * The default implementation deletes nothing, which keeps every store written before
+   * this existed valid: its records are cleaned up by the retention as they always
+   * were. VanillaBP reports at startup that the release was asked for and cannot be
+   * served, naming the store and the property.
+   *
+   * @param workflowModuleId The workflow module of the ended workflow
+   * @param bpmnProcessId The BPMN process of the ended workflow
+   * @param workflowAggregateId The ID of its workflow aggregate
+   * @param recordedBefore Only records written before this moment are deleted
+   * @return The number of records deleted
+   */
+  default int releaseRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final Instant recordedBefore) {
+
+    return 0;
+
+  }
 
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/DeliveryProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/DeliveryProperties.java
@@ -1,0 +1,40 @@
+package io.vanillabp.integration.adapter.migration.config;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Configuration of what VanillaBP does with the records of processed task deliveries
+ * (properties section <code>vanillabp.delivery</code>, overridable per workflow module as
+ * <code>vanillabp.workflow-modules.&lt;id&gt;.delivery</code>). Adapter-INDEPENDENT: the
+ * records of every BPMS live in the store of the workflow aggregate, so the question is
+ * one of the application's data, not one of a BPMS.
+ * <p>
+ * The only setting is whether a workflow which ended releases its records - see
+ * {@link #releaseOnWorkflowEnd}.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class DeliveryProperties {
+
+  /**
+   * Whether the records of a workflow are deleted the moment it ends, instead of waiting
+   * for <code>vanillabp.outbox.retention</code> to pass (see
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLog#releaseRecordsOf}). The end of an
+   * instance is the one statement after which nothing of it can be redelivered, so the
+   * deletion is safe - and it is bound to the moment of the notification, which keeps the
+   * records of a SECOND workflow on the same aggregate.
+   * <p>
+   * Defaults to <code>false</code>, and for two reasons: the end of a workflow is
+   * reported only where the application asked for it, so switching this on makes every
+   * deployed model pay for a listener respectively a worker; and an application may want
+   * to keep the records for support. <code>null</code> in a workflow module's section
+   * means "whatever is configured globally".
+   */
+  private Boolean releaseOnWorkflowEnd;
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -87,6 +87,13 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
   private TransactionsProperties transactions = new TransactionsProperties();
 
   /**
+   * What VanillaBP does with the records of processed task deliveries (properties
+   * section <code>vanillabp.delivery</code>, overridable per workflow module).
+   */
+  @Builder.Default
+  private DeliveryProperties delivery = new DeliveryProperties();
+
+  /**
    * Derived view of {@link #getAdapters()}: adapter ID mapped to the adapter's type.
    * An adapter entry without an explicit {@link AdapterConfigProperties#getType()
    * type} defaults to its ID being the type.
@@ -646,6 +653,51 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
       final String workflowModuleId) {
 
     return "%s.workflow-modules.%s.transactions.unguarded-aggregate-writes"
+        .formatted(PREFIX, workflowModuleId);
+
+  }
+
+  /**
+   * Whether the workflows of the given workflow module release the records of their
+   * processed task deliveries when they end
+   * (<code>vanillabp.delivery.release-on-workflow-end</code>, overridable as
+   * <code>vanillabp.workflow-modules.&lt;id&gt;.delivery.release-on-workflow-end</code>).
+   * The module's setting wins where it is defined, the global one applies otherwise, and
+   * the default is to keep the records until the retention passed.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @return Whether an ended workflow releases its delivery records
+   */
+  public boolean releasesDeliveryRecordsOnWorkflowEnd(
+      final String workflowModuleId) {
+
+    final var module = workflowModules.get(workflowModuleId);
+    final var moduleSetting = (module != null) && (module.getDelivery() != null)
+        ? module
+            .getDelivery()
+            .getReleaseOnWorkflowEnd()
+        : null;
+    final var effective = moduleSetting != null
+        ? moduleSetting
+        : delivery != null
+            ? delivery.getReleaseOnWorkflowEnd()
+            : null;
+    return (effective != null) && effective;
+
+  }
+
+  /**
+   * The property naming the decision of
+   * {@link #releasesDeliveryRecordsOnWorkflowEnd(String)}, for the messages which have to
+   * tell where the behaviour they describe comes from.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @return The property key of the module-scoped override
+   */
+  public static String releaseOnWorkflowEndProperty(
+      final String workflowModuleId) {
+
+    return "%s.workflow-modules.%s.delivery.release-on-workflow-end"
         .formatted(PREFIX, workflowModuleId);
 
   }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowModuleAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowModuleAdapterProperties.java
@@ -35,4 +35,11 @@ public class WorkflowModuleAdapterProperties extends AdaptersConfigurationProper
    */
   private TransactionsProperties transactions;
 
+  /**
+   * Overrides <code>vanillabp.delivery</code> for this workflow module. A setting left
+   * undefined here means the global one applies, so one module can release the records of
+   * its ended workflows while another keeps them for support.
+   */
+  private DeliveryProperties delivery;
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -56,6 +56,10 @@ public class JdbcTaskDeliveryStore {
       DELETE FROM %s \
       WHERE RECORDED_AT < ?""";
 
+  private static final String DELETE_DELIVERIES_OF_WORKFLOW = """
+      DELETE FROM %s \
+      WHERE WORKFLOW_MODULE_ID = ? AND BPMN_PROCESS_ID = ? AND AGGREGATE_ID = ? AND RECORDED_AT < ?""";
+
   private final JdbcConnectionAccess connectionAccess;
 
   private final String tableName;
@@ -66,6 +70,8 @@ public class JdbcTaskDeliveryStore {
 
   private final String deleteExpiredDeliveries;
 
+  private final String deleteDeliveriesOfWorkflow;
+
   public JdbcTaskDeliveryStore(
       final JdbcConnectionAccess connectionAccess,
       final String tableName) {
@@ -75,6 +81,7 @@ public class JdbcTaskDeliveryStore {
     this.selectDelivery = SELECT_DELIVERY.formatted(tableName);
     this.insertDelivery = INSERT_DELIVERY.formatted(tableName);
     this.deleteExpiredDeliveries = DELETE_EXPIRED_DELIVERIES.formatted(tableName);
+    this.deleteDeliveriesOfWorkflow = DELETE_DELIVERIES_OF_WORKFLOW.formatted(tableName);
 
   }
 
@@ -193,6 +200,54 @@ public class JdbcTaskDeliveryStore {
     } catch (final SQLException e) {
       log.warn("Could not clean up expired task-delivery records of table '{}'", tableName, e);
       return 0;
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Deletes the records of ONE ended workflow (see
+   * {@link io.vanillabp.integration.spi.TaskDeliveryLog#releaseRecordsOf}). Runs in the
+   * transaction of the end notification, so it commits with it.
+   * <p>
+   * Unlike {@link #deleteExpired(Duration)} a failure is NOT swallowed: the retention
+   * cleanup runs again in an hour, this deletion has exactly one chance and belongs to a
+   * transaction which has to know whether its work went through.
+   *
+   * @param workflowModuleId The workflow module of the ended workflow
+   * @param bpmnProcessId The BPMN process of the ended workflow
+   * @param workflowAggregateId The ID of its workflow aggregate
+   * @param recordedBefore Only records written before this moment are deleted - what
+   *          keeps the records of a second workflow on the same aggregate
+   * @return The number of records deleted
+   */
+  // No index ships for these columns: AGGREGATE_ID holds up to 1024 characters, and an
+  // index over the three of them exceeds the key-length limit of MySQL (3072 bytes with
+  // utf8mb4) and of a DB2 database using 4K pages. An application whose table grows large
+  // adds one itself, prefixed the way its database needs it - the wiki says so.
+  public int deleteRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final Instant recordedBefore) {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      try (var statement = connection.prepareStatement(deleteDeliveriesOfWorkflow)) {
+        statement.setString(1, workflowModuleId);
+        statement.setString(2, bpmnProcessId);
+        statement.setString(3, workflowAggregateId);
+        statement.setTimestamp(4, Timestamp.from(recordedBefore));
+        return statement.executeUpdate();
+      }
+    } catch (final SQLException e) {
+      throw new RuntimeException(
+          """
+              Could not release the task-delivery records of workflow '%s' (BPMN process '%s' of \
+              workflow module '%s') in table '%s'!"""
+              .formatted(workflowAggregateId, bpmnProcessId, workflowModuleId, tableName), e);
     } finally {
       release(connection);
     }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -682,6 +682,128 @@ public class MigrationProcessService<A> {
   }
 
   /**
+   * Whether an ended workflow of this BPMN process releases the records of its processed
+   * task deliveries (<code>vanillabp.delivery.release-on-workflow-end</code>, overridable
+   * per workflow module). Asked by the end-of-workflow path, and by the adapters through
+   * {@link io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedInvoker#workflowEndedHandlerExists}
+   * - where it is on, the end has to be reported even without an application handler.
+   *
+   * @return Whether the records are released when a workflow ends
+   */
+  public boolean releasesDeliveryRecordsOnWorkflowEnd() {
+
+    return (properties != null) && properties.releasesDeliveryRecordsOnWorkflowEnd(workflowModuleId);
+
+  }
+
+  /**
+   * Deletes the records of the processed task deliveries of ONE ended workflow. Invoked
+   * within the transaction of the end notification (see
+   * {@link io.vanillabp.integration.adapter.migration.workflowend.WorkflowEndedHandlers}),
+   * so the deletion commits with it - and a notification whose transaction is rolled back
+   * leaves the records where they were, to be released by the redelivered notification or
+   * by the retention.
+   *
+   * @param workflowAggregateId The ID of the ended workflow's aggregate
+   * @param recordedBefore Only records written before this moment are deleted - the bound
+   *          which keeps the records of a SECOND workflow on the same aggregate
+   * @return The number of records deleted
+   */
+  public int releaseDeliveryRecords(
+      final String workflowAggregateId,
+      final java.time.Instant recordedBefore) {
+
+    final var deliveryLog = resolveTaskDeliveryLog();
+    if (deliveryLog == null) {
+      return 0;
+    }
+    final var released = deliveryLog
+        .releaseRecordsOf(workflowModuleId, bpmnProcessId, workflowAggregateId, recordedBefore);
+    log.debug(
+        "Released {} task-delivery record(s) of the ended workflow '{}' (BPMN process '{}' of "
+            + "workflow module '{}')",
+        released,
+        workflowAggregateId,
+        bpmnProcessId,
+        workflowModuleId);
+    return released;
+
+  }
+
+  /**
+   * Validates AT STARTUP that the store resolved for this aggregate can do what
+   * <code>release-on-workflow-end</code> promises. A store which does not implement
+   * {@link TaskDeliveryLog#releaseRecordsOf(String, String, String, java.time.Instant)}
+   * keeps its records until the retention passed - which is not wrong, but it is not what
+   * the application configured, so it is said once at startup naming the store and the
+   * property.
+   * <p>
+   * Nothing happens where the release is switched off: an application which did not ask
+   * for it must not be told about a method its store does not have.
+   */
+  private void validateDeliveryRecordReleaseAtStartup() {
+
+    if (!releasesDeliveryRecordsOnWorkflowEnd()) {
+      return;
+    }
+    final var deliveryLog = resolveTaskDeliveryLog();
+    if (deliveryLog == null) {
+      // no store at all means no records at all - there is nothing to release, and the
+      // missing store is reported by the check for deduplication itself
+      return;
+    }
+    final var storeClass = taskDeliveryLogResolver != null
+        ? taskDeliveryLogResolver.storeClassOf(deliveryLog)
+        : deliveryLog.getClass();
+    if (implementsRelease(storeClass)) {
+      return;
+    }
+    log.warn(
+        """
+            The TaskDeliveryLog '{}' does not implement 'releaseRecordsOf', but '{}' is switched on \
+            for BPMN process '{}' of workflow module '{}' - the records of an ended workflow are \
+            NOT deleted when it ends but once 'vanillabp.outbox.retention' passed. To solve this \
+            either
+            - implement io.vanillabp.integration.spi.TaskDeliveryLog#releaseRecordsOf in '{}', or
+            - set '{}' to 'false' to state that the retention is what cleans up the records.""",
+        storeClass.getName(),
+        MigrationAdapterProperties.releaseOnWorkflowEndProperty(workflowModuleId),
+        bpmnProcessId,
+        workflowModuleId,
+        storeClass.getName(),
+        MigrationAdapterProperties.releaseOnWorkflowEndProperty(workflowModuleId));
+
+  }
+
+  /**
+   * Whether the given store implements the release itself instead of inheriting the
+   * default of {@link TaskDeliveryLog} which does nothing.
+   *
+   * @param storeClass The store's class, unwrapped by the platform integration
+   * @return Whether the store releases records
+   */
+  private static boolean implementsRelease(
+      final Class<?> storeClass) {
+
+    try {
+      // resolves to the override where there is one, and to the interface's default
+      // method otherwise - which is exactly the question asked here
+      final var method = storeClass
+          .getMethod(
+              "releaseRecordsOf",
+              String.class,
+              String.class,
+              String.class,
+              java.time.Instant.class);
+      return method.getDeclaringClass() != TaskDeliveryLog.class;
+    } catch (final NoSuchMethodException e) {
+      // a store compiled against an older SPI: it cannot release either
+      return false;
+    }
+
+  }
+
+  /**
    * Validates AT STARTUP that a delivery log is available if any prioritized adapter
    * may repeat a delivery
    * ({@link MigratableProcessService#deliversTasksAtLeastOnce()}) and deduplication is
@@ -695,6 +817,8 @@ public class MigrationProcessService<A> {
    * an embedded BPMS only must not be pushed towards a store it does not need.
    */
   public void validateTaskDeliveryLogAtStartup() {
+
+    validateDeliveryRecordReleaseAtStartup();
 
     final var atLeastOnceAdapters = adapterProcessServices
         .stream()

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/TaskDeliveryLogResolver.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/TaskDeliveryLogResolver.java
@@ -42,4 +42,23 @@ public interface TaskDeliveryLogResolver {
    */
   String remediesDescription();
 
+  /**
+   * The class of the given log AS THE APPLICATION WROTE IT - what the core reflects on to
+   * find out whether a store implements
+   * {@link TaskDeliveryLog#releaseRecordsOf(String, String, String, java.time.Instant)}
+   * or inherits the default doing nothing. A platform which hands out proxies (CDI client
+   * proxies, Spring AOP) has to unwrap them here: a proxy overrides every method of its
+   * target, the default implementation included, so reflecting on the proxy would report
+   * a release which does not exist.
+   *
+   * @param deliveryLog The resolved log
+   * @return The class the store is written in
+   */
+  default Class<?> storeClassOf(
+      final TaskDeliveryLog deliveryLog) {
+
+    return deliveryLog.getClass();
+
+  }
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowend/WorkflowEndedHandlers.java
@@ -1,5 +1,6 @@
 package io.vanillabp.integration.adapter.migration.workflowend;
 
+import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -207,7 +208,11 @@ public class WorkflowEndedHandlers {
 
   /**
    * Tells the application that a workflow ended: loads the aggregate, calls the
-   * method and saves the aggregate, in one transaction.
+   * method and saves the aggregate, in one transaction. Where the workflow module
+   * releases the records of its processed task deliveries (story 76), that deletion runs
+   * in the same transaction - and then this runs even without a
+   * <code>&#64;WorkflowEnded</code> method, which is why the adapters attach their
+   * listener in that case as well.
    *
    * @param <A> The workflow-aggregate type
    * @param processService The process service of the BPMN process
@@ -222,12 +227,87 @@ public class WorkflowEndedHandlers {
     // the notification proves which BPMS held this workflow
     processService.rememberWorkflowAdapter(context.getWorkflowAggregateId(), context.getAdapterId());
 
+    final var releaseRecords = processService.releasesDeliveryRecordsOnWorkflowEnd();
+    // the bound of the release, taken BEFORE anything is done: an aggregate may outlive
+    // its workflow and carry a second one, whose records are written after this moment
+    // and have to survive
+    final var recordedBefore = Instant.now();
+
+    final var handler = handlerOf(processService, context);
+    if ((handler == null) && !releaseRecords) {
+      return;
+    }
+
+    final Supplier<Void> transactionalWork = () -> {
+      if (handler != null) {
+        invokeHandler(processService, context, handler);
+      }
+      if (releaseRecords) {
+        processService.releaseDeliveryRecords(context.getWorkflowAggregateId(), recordedBefore);
+      }
+      return null;
+    };
+
+    io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
+        .inTransaction(
+            transactionRunner,
+            context.runInCurrentTransaction(),
+            processService.getWorkflowModuleId(),
+            processService.getBpmnProcessId(),
+            context.getWorkflowAggregateId(),
+            handler != null
+                ? "reporting the end of the workflow"
+                : "releasing the task-delivery records of the ended workflow",
+            transactionalWork);
+
+  }
+
+  /**
+   * Loads the aggregate, calls the method and saves the aggregate - the part of the end
+   * notification which belongs to the application.
+   */
+  private static <A> void invokeHandler(
+      final MigrationProcessService<A> processService,
+      final WorkflowEndedContext context,
+      final WorkflowEndedHandler handler) {
+
+    final var workflowAggregate = processService
+        .loadWorkflowAggregate(context.getWorkflowAggregateId());
+    if (workflowAggregate == null) {
+      // NOT an error: an application may delete the aggregate of a workflow which
+      // ended, and a redelivered notification would find nothing either
+      log
+          .info(
+              "The workflow aggregate '{}' of BPMN process '{}' (workflow module '{}') does not "
+                  + "exist (any more) - the end of that workflow is not reported to '{}'",
+              context.getWorkflowAggregateId(),
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              handler.describe());
+      return;
+    }
+    handler.invoke(workflowAggregate, context);
+    processService.saveWorkflowAggregate(workflowAggregate);
+
+  }
+
+  /**
+   * The <code>&#64;WorkflowEnded</code> method serving this notification, or
+   * <code>null</code> if the application has none - which is said in the log, since a
+   * method wired to the event but excluded by its version is a defect the developer has
+   * to see.
+   */
+  private <A> WorkflowEndedHandler handlerOf(
+      final MigrationProcessService<A> processService,
+      final WorkflowEndedContext context) {
+
     final var registered = handlers
         .get(
             new RegistryKey(processService.getWorkflowModuleId(), processService.getBpmnProcessId()));
     if (registered == null) {
       // the adapter attached a listener although nothing is registered - possible
-      // when a deployed model outlives the workflow service which asked for it
+      // when a deployed model outlives the workflow service which asked for it, and
+      // the normal case where the listener exists to release the delivery records
       log
           .debug(
               "No @WorkflowEnded method for BPMN process '{}' of workflow module '{}' - the end of "
@@ -235,7 +315,7 @@ public class WorkflowEndedHandlers {
               processService.getBpmnProcessId(),
               processService.getWorkflowModuleId(),
               context.getWorkflowAggregateId());
-      return;
+      return null;
     }
 
     final var wired = registered
@@ -251,68 +331,39 @@ public class WorkflowEndedHandlers {
                 processService.getBpmnProcessId())))
         .findFirst()
         .orElse(null);
-    if (handler == null) {
-      // a method wired to the event but excluded by its version is worth a warning: the
-      // application asked to be notified and is not, which no log level should hide
-      final var message = "No @WorkflowEnded method of BPMN process '{}' (workflow module '{}') "
-          + "serves end event '{}' of process version '{}' - the end of workflow '{}' is not "
-          + "reported.{}";
-      final var hint = io.vanillabp.integration.adapter.migration.workflowtask.VersionRange
-          .noVersionReportedHint(context.getProcessVersion());
-      if (wired.isEmpty()) {
-        log
-            .debug(
-                message,
-                processService.getBpmnProcessId(),
-                processService.getWorkflowModuleId(),
-                context.getEndEventId(),
-                context.getProcessVersion(),
-                context.getWorkflowAggregateId(),
-                hint);
-      } else {
-        log
-            .warn(
-                message,
-                processService.getBpmnProcessId(),
-                processService.getWorkflowModuleId(),
-                context.getEndEventId(),
-                context.getProcessVersion(),
-                context.getWorkflowAggregateId(),
-                hint);
-      }
-      return;
+    if (handler != null) {
+      return handler;
     }
 
-    final Supplier<Void> transactionalWork = () -> {
-      final var workflowAggregate = processService
-          .loadWorkflowAggregate(context.getWorkflowAggregateId());
-      if (workflowAggregate == null) {
-        // NOT an error: an application may delete the aggregate of a workflow which
-        // ended, and a redelivered notification would find nothing either
-        log
-            .info(
-                "The workflow aggregate '{}' of BPMN process '{}' (workflow module '{}') does not "
-                    + "exist (any more) - the end of that workflow is not reported to '{}'",
-                context.getWorkflowAggregateId(),
-                processService.getBpmnProcessId(),
-                processService.getWorkflowModuleId(),
-                handler.describe());
-        return null;
-      }
-      handler.invoke(workflowAggregate, context);
-      processService.saveWorkflowAggregate(workflowAggregate);
-      return null;
-    };
-
-    io.vanillabp.integration.adapter.migration.transaction.AggregateWrite
-        .inTransaction(
-            transactionRunner,
-            context.runInCurrentTransaction(),
-            processService.getWorkflowModuleId(),
-            processService.getBpmnProcessId(),
-            context.getWorkflowAggregateId(),
-            "reporting the end of the workflow",
-            transactionalWork);
+    // a method wired to the event but excluded by its version is worth a warning: the
+    // application asked to be notified and is not, which no log level should hide
+    final var message = "No @WorkflowEnded method of BPMN process '{}' (workflow module '{}') "
+        + "serves end event '{}' of process version '{}' - the end of workflow '{}' is not "
+        + "reported.{}";
+    final var hint = io.vanillabp.integration.adapter.migration.workflowtask.VersionRange
+        .noVersionReportedHint(context.getProcessVersion());
+    if (wired.isEmpty()) {
+      log
+          .debug(
+              message,
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              context.getEndEventId(),
+              context.getProcessVersion(),
+              context.getWorkflowAggregateId(),
+              hint);
+    } else {
+      log
+          .warn(
+              message,
+              processService.getBpmnProcessId(),
+              processService.getWorkflowModuleId(),
+              context.getEndEventId(),
+              context.getProcessVersion(),
+              context.getWorkflowAggregateId(),
+              hint);
+    }
+    return null;
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -126,6 +126,13 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
   private final io.vanillabp.integration.adapter.migration.transaction.ConcurrentTokenCheck concurrentTokenCheck = new io.vanillabp.integration.adapter.migration.transaction.ConcurrentTokenCheck();
 
   /**
+   * The bound <code>vanillabp.*</code> tree - needed to answer whether a workflow module
+   * releases the records of its processed task deliveries when a workflow ends (story
+   * 76). May be <code>null</code> (tests): nothing is released then.
+   */
+  private final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties;
+
+  /**
    * The process versions this application declares obsolete (story 57).
    */
   private final OutfadedProcessVersions outfadedVersions;
@@ -168,6 +175,7 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
     this.transactionRunner = transactionRunner;
     this.aggregateSync = aggregateSync;
     this.transactionAnnotations = transactionAnnotations;
+    this.properties = properties;
     this.outfadedVersions = new OutfadedProcessVersions(properties);
     this.deployedVersionsCheck = new DeployedProcessVersionsCheck(
         processVersions, outfadedVersions, this::tasksNotServedInVersion, this::handlersNotServingAnyVersion);
@@ -715,12 +723,23 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
 
   }
 
+  /**
+   * Whether the end of a workflow of that BPMN process has to be reported at all - asked
+   * by the adapters while wiring, so a model pays for a listener respectively a worker
+   * only where the end is used.
+   * <p>
+   * Beside an application's <code>&#64;WorkflowEnded</code> method there is a second
+   * reason to want it: a workflow module which releases the records of its processed task
+   * deliveries when a workflow ends (story 76) needs the notification to do so. That is
+   * why no adapter had to be touched for the release.
+   */
   @Override
   public boolean workflowEndedHandlerExists(
       final String workflowModuleId,
       final String bpmnProcessId) {
 
-    return workflowEndedHandlers.handlerExists(workflowModuleId, bpmnProcessId);
+    return workflowEndedHandlers.handlerExists(workflowModuleId, bpmnProcessId) || ((properties != null) && properties
+        .releasesDeliveryRecordsOnWorkflowEnd(workflowModuleId));
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/DeliveryRecordReleaseTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/DeliveryRecordReleaseTest.java
@@ -1,0 +1,542 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.DeliveryProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TransactionRunner;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.WorkflowEnd;
+import io.vanillabp.spi.service.WorkflowEnded;
+
+/**
+ * Story 76: a workflow which ended releases the records of its processed task deliveries,
+ * so the deduplication window is closed by the workflow instead of by the clock. What is
+ * pinned here is the CORE's part of it:
+ * <ul>
+ * <li>the deletion runs when a workflow ends, bounded by workflow module, BPMN process,
+ * aggregate and by the moment of the notification - the records of another workflow, of
+ * another process, of another module and of a SECOND workflow on the same aggregate are
+ * untouched;</li>
+ * <li>it runs without a <code>&#64;WorkflowEnded</code> method as well, which is why the
+ * core asks the adapters to attach their listener where the release is switched on;</li>
+ * <li>with the option off nothing is released and no listener is wanted;</li>
+ * <li>a store which does not implement the release plus the option on is reported at
+ * startup, naming the store and the property.</li>
+ * </ul>
+ * The stores themselves (JDBC, MongoDB) are covered by the platform integrations' tests -
+ * per platform, as the coverage rules require.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class DeliveryRecordReleaseTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String ADAPTER = "test-adapter";
+
+  public static class Aggregate {
+
+    String id;
+
+    String status;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  /**
+   * A delivery log in memory which really filters: the release has to be bounded the way
+   * a store would bound its DELETE, otherwise this test would pin nothing.
+   */
+  static class InMemoryDeliveryLog implements TaskDeliveryLog {
+
+    final Map<String, TaskDelivery> records = new LinkedHashMap<>();
+
+    final Map<String, Instant> recordedAt = new HashMap<>();
+
+    @Override
+    public Optional<TaskDelivery> recordedDelivery(
+        final String deliveryKey) {
+      return Optional.ofNullable(records.get(deliveryKey));
+    }
+
+    @Override
+    public boolean record(
+        final TaskDelivery delivery) {
+      recordedAt.put(delivery.deliveryKey(), Instant.now());
+      return records.putIfAbsent(delivery.deliveryKey(), delivery) == null;
+    }
+
+    @Override
+    public int releaseRecordsOf(
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String workflowAggregateId,
+        final Instant recordedBefore) {
+
+      final var released = new LinkedList<String>();
+      records
+          .forEach((
+              key,
+              delivery) -> {
+            if (!delivery.workflowModuleId().equals(workflowModuleId)) {
+              return;
+            }
+            if (!delivery.bpmnProcessId().equals(bpmnProcessId)) {
+              return;
+            }
+            if (!delivery.workflowAggregateId().equals(workflowAggregateId)) {
+              return;
+            }
+            if (!recordedAt.get(key).isBefore(recordedBefore)) {
+              return;
+            }
+            released.add(key);
+          });
+      released.forEach(records::remove);
+      released.forEach(recordedAt::remove);
+      return released.size();
+
+    }
+
+    /**
+     * Writes a record as a processed delivery would have, at a moment this test decides -
+     * the bound of the release is a timestamp, so it has to be one the test controls.
+     */
+    void given(
+        final String key,
+        final String workflowModuleId,
+        final String bpmnProcessId,
+        final String aggregateId,
+        final Instant when) {
+
+      records
+          .put(
+              key,
+              new TaskDelivery(
+                  key, workflowModuleId, bpmnProcessId, aggregateId, "task", "COMPLETED", null, null));
+      recordedAt.put(key, when);
+
+    }
+
+  }
+
+  /**
+   * A store written before the release existed: it inherits the SPI's default doing
+   * nothing.
+   */
+  static class LegacyDeliveryLog implements TaskDeliveryLog {
+
+    @Override
+    public Optional<TaskDelivery> recordedDelivery(
+        final String deliveryKey) {
+      return Optional.empty();
+    }
+
+    @Override
+    public boolean record(
+        final TaskDelivery delivery) {
+      return true;
+    }
+
+  }
+
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  /**
+   * A workflow service which does NOT want to know about the end of its workflows - the
+   * case the release has to work in, since it is what makes the listener necessary.
+   */
+  public static class SilentService {
+
+  }
+
+  public static class NoticingService {
+
+    static int calls;
+
+    @WorkflowEnded
+    public void ended(
+        final Aggregate aggregate) {
+
+      calls++;
+      aggregate.status = "ended";
+
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  private final InMemoryDeliveryLog deliveryLog = new InMemoryDeliveryLog();
+
+  /**
+   * The properties of an application which configures the release globally, per workflow
+   * module, or not at all (<code>null</code> = nothing configured at that level).
+   */
+  private MigrationAdapterProperties properties(
+      final Boolean global,
+      final Boolean module) {
+
+    final var moduleProperties = WorkflowModuleAdapterProperties.builder();
+    if (module != null) {
+      final var moduleDelivery = new DeliveryProperties();
+      moduleDelivery.setReleaseOnWorkflowEnd(module);
+      moduleProperties.delivery(moduleDelivery);
+    }
+
+    final var globalDelivery = new DeliveryProperties();
+    globalDelivery.setReleaseOnWorkflowEnd(global);
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of(ADAPTER))
+        .workflowModules(Map.of(MODULE, moduleProperties.build()))
+        .delivery(globalDelivery)
+        .build();
+    properties.validateAndLink();
+    return properties;
+
+  }
+
+  private MigrationProcessService<Aggregate> processService(
+      final MigrationAdapterProperties properties,
+      final TaskDeliveryLog log) {
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn(ADAPTER);
+    lenient().when(adapter.deliversTasksAtLeastOnce()).thenReturn(true);
+
+    final TaskDeliveryLogResolver resolver = new TaskDeliveryLogResolver() {
+
+      @Override
+      public TaskDeliveryLog resolveFor(
+          final Class<?> workflowAggregateClass) {
+        return log;
+      }
+
+      @Override
+      public String remediesDescription() {
+        return "- add a store, or";
+      }
+
+    };
+
+    return new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null, null, resolver);
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final MigrationAdapterProperties properties,
+      final Class<?> workflowServiceClass,
+      final Supplier<Object> bean) {
+
+    final var registry = new WorkflowTaskRegistry(
+        new TransactionRunnerStub(), null, List.of(), properties);
+    registry
+        .registerWorkflowService(
+            MODULE,
+            PROCESS,
+            workflowServiceClass,
+            bean,
+            type -> null,
+            processService(properties, deliveryLog));
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    aggregate.status = "running";
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  private WorkflowEndedContext context(
+      final String aggregateId) {
+
+    return new WorkflowEndedContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public WorkflowEnd.Kind getKind() {
+        return WorkflowEnd.Kind.COMPLETED;
+      }
+
+      @Override
+      public Instant getEndTime() {
+        return Instant.now();
+      }
+
+      @Override
+      public String getEndEventId() {
+        return "Event_Done";
+      }
+
+      @Override
+      public boolean runInCurrentTransaction() {
+        return false;
+      }
+
+    };
+
+  }
+
+  /**
+   * The messages the given class logged at WARN or above while the work ran.
+   */
+  private List<String> warningsOf(
+      final Class<?> loggingClass,
+      final Runnable work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory.getLogger(loggingClass);
+    logger.addAppender(logWatcher);
+    try {
+      work.run();
+    } finally {
+      logger.detachAppender(logWatcher);
+      logWatcher.stop();
+    }
+    return logWatcher.list
+        .stream()
+        .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+        .map(event -> event.getFormattedMessage())
+        .toList();
+
+  }
+
+  @Test
+  @DisplayName("An ended workflow releases its records - and only its own")
+  public void theEndOfAWorkflowReleasesItsRecords() {
+
+    final var testee = registry(properties(true, null), SilentService.class, SilentService::new);
+    storeAggregate("4711");
+
+    final var past = Instant.now().minus(1, ChronoUnit.MINUTES);
+    deliveryLog.given("of-the-workflow-1", MODULE, PROCESS, "4711", past);
+    deliveryLog.given("of-the-workflow-2", MODULE, PROCESS, "4711", past);
+    deliveryLog.given("of-another-aggregate", MODULE, PROCESS, "4712", past);
+    deliveryLog.given("of-another-process", MODULE, "OtherProcess", "4711", past);
+    deliveryLog.given("of-another-module", "other-module", PROCESS, "4711", past);
+    // the second workflow on the same aggregate: its record is written AFTER the end of
+    // the first one, which is exactly what the time bound protects
+    deliveryLog
+        .given("of-the-second-workflow", MODULE, PROCESS, "4711", Instant.now().plus(1, ChronoUnit.MINUTES));
+
+    testee.workflowEnded(MODULE, PROCESS, context("4711"));
+
+    assertEquals(
+        List.of("of-another-aggregate", "of-another-process", "of-another-module", "of-the-second-workflow"),
+        List.copyOf(deliveryLog.records.keySet()),
+        "only the records of the ended workflow, written before its end, may be released");
+
+  }
+
+  @Test
+  @DisplayName("Where the release is switched on the end has to be reported, even without a @WorkflowEnded method")
+  public void theListenerIsWantedWhereTheReleaseIsSwitchedOn() {
+
+    final var withRelease = registry(properties(true, null), SilentService.class, SilentService::new);
+
+    assertTrue(
+        withRelease.workflowEndedHandlerExists(MODULE, PROCESS),
+        "the release needs the end notification, so the adapter has to attach its listener");
+
+  }
+
+  @Test
+  @DisplayName("With the option off nothing is released and no listener is wanted")
+  public void withoutTheOptionTheRecordsStay() {
+
+    final var testee = registry(properties(false, null), SilentService.class, SilentService::new);
+    storeAggregate("4711");
+    deliveryLog.given("of-the-workflow", MODULE, PROCESS, "4711", Instant.now().minus(1, ChronoUnit.MINUTES));
+
+    assertFalse(
+        testee.workflowEndedHandlerExists(MODULE, PROCESS),
+        "a model must not pay for a listener nobody uses");
+
+    testee.workflowEnded(MODULE, PROCESS, context("4711"));
+
+    assertEquals(
+        List.of("of-the-workflow"),
+        List.copyOf(deliveryLog.records.keySet()),
+        "without the option the retention is what cleans up");
+
+  }
+
+  @Test
+  @DisplayName("The workflow module's setting wins over the global one")
+  public void theModulesSettingWins() {
+
+    final var testee = registry(properties(false, true), SilentService.class, SilentService::new);
+    storeAggregate("4711");
+    deliveryLog.given("of-the-workflow", MODULE, PROCESS, "4711", Instant.now().minus(1, ChronoUnit.MINUTES));
+
+    testee.workflowEnded(MODULE, PROCESS, context("4711"));
+
+    assertTrue(deliveryLog.records.isEmpty(), "the module releases although the application does not");
+
+  }
+
+  @Test
+  @DisplayName("The application's @WorkflowEnded method runs and the records are released in the same notification")
+  public void theHandlerRunsAndTheRecordsAreReleased() {
+
+    NoticingService.calls = 0;
+    final var testee = registry(properties(true, null), NoticingService.class, NoticingService::new);
+    final var aggregate = storeAggregate("4711");
+    deliveryLog.given("of-the-workflow", MODULE, PROCESS, "4711", Instant.now().minus(1, ChronoUnit.MINUTES));
+
+    testee.workflowEnded(MODULE, PROCESS, context("4711"));
+
+    assertEquals(1, NoticingService.calls);
+    assertEquals("ended", persistence.aggregates.get(aggregate.id).status);
+    assertTrue(deliveryLog.records.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("A store which cannot release plus the option on is reported at startup")
+  public void aStoreWithoutTheReleaseIsReported() {
+
+    final var properties = properties(true, null);
+    final var processService = processService(properties, new LegacyDeliveryLog());
+
+    final var messages = warningsOf(
+        MigrationProcessService.class,
+        processService::validateTaskDeliveryLogAtStartup);
+
+    final var message = messages
+        .stream()
+        .filter(candidate -> candidate.contains("releaseRecordsOf"))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("no warning about the missing release, logged: "
+            + messages));
+    assertTrue(message.contains(LegacyDeliveryLog.class.getName()), message);
+    assertTrue(message.contains("vanillabp.workflow-modules.test-module.delivery.release-on-workflow-end"), message);
+
+  }
+
+  @Test
+  @DisplayName("With the option off a store which cannot release is not reported")
+  public void aStoreWithoutTheReleaseIsSilentWhereNobodyAskedForIt() {
+
+    final var processService = processService(properties(false, null), new LegacyDeliveryLog());
+
+    final var messages = warningsOf(
+        MigrationProcessService.class,
+        processService::validateTaskDeliveryLogAtStartup);
+
+    assertTrue(
+        messages.stream().noneMatch(message -> message.contains("releaseRecordsOf")),
+        "an application which did not ask for the release must not be told about it, logged: "
+            + messages);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/DeliveryRecordReleaseTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/DeliveryRecordReleaseTest.java
@@ -1,9 +1,9 @@
 package io.vanillabp.integration.it;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.sql.SQLException;
+import java.time.Instant;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -17,6 +17,7 @@ import io.quarkus.test.QuarkusExtensionTest;
 import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
 import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
 import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
 import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
 import io.vanillabp.integration.test.delivery.DeliveryAggregate;
@@ -24,21 +25,26 @@ import io.vanillabp.integration.test.delivery.DeliveryAggregatePersistence;
 import io.vanillabp.integration.test.delivery.DeliveryProcessWiringSource;
 import io.vanillabp.integration.test.delivery.DeliveryWorkflowService;
 import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.WorkflowEnd;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Inject;
 
 /**
- * Acceptance test of the inbound idempotency (story 51) on Quarkus, with the default
- * JDBC-based delivery log doing the remembering: the dummy adapter delivers a task TWICE
- * under the same delivery identity - as a BPMS which never learned the result does - and
- * the <code>&#64;WorkflowTask</code> method has to run once while both deliveries are
- * answered with the same outcome. Also pinned: a delivery whose handler threw leaves no
- * record (its retry runs the handler again) and the task-level switch turns the feature
- * off.
+ * Acceptance test of the release of delivery records (story 76) on Quarkus, with the
+ * default JDBC-based delivery log: a workflow which ended deletes the records of its
+ * processed deliveries instead of leaving them to the retention. The workflow service of
+ * this test has NO <code>&#64;WorkflowEnded</code> method on purpose - the end
+ * notification is asked for by the release alone, which is what makes the feature work
+ * without touching any adapter.
+ * <p>
+ * Pinned as well: the record of a SECOND workflow on the same aggregate, written after the
+ * end of the first one, survives, and the records of another workflow stay untouched. The
+ * case with the option switched off is pinned by {@link InboundIdempotencyTest}, whose
+ * application does not configure the release.
  */
 @ExtendWith(SuppressOutputExtension.class)
-public class InboundIdempotencyTest {
+public class DeliveryRecordReleaseTest {
 
   private static final String MODULE = "test-module";
 
@@ -49,7 +55,7 @@ public class InboundIdempotencyTest {
   @RegisterExtension
   static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
       .withApplicationRoot(jar -> jar
-          .addAsResource("inbound-idempotency/application.yaml", "application.yaml")
+          .addAsResource("delivery-release/application.yaml", "application.yaml")
           .addClass(DeliveryAggregate.class)
           .addClass(DeliveryAggregatePersistence.class)
           .addClass(DeliveryWorkflowService.class)
@@ -82,10 +88,6 @@ public class InboundIdempotencyTest {
 
   }
 
-  /**
-   * One delivery of a task, as an adapter of a remote BPMS builds it: the delivery ID is
-   * what stays the same when the BPMS repeats it.
-   */
   private TaskInvocationContext delivery(
       final String taskDefinition,
       final String aggregateId,
@@ -117,6 +119,38 @@ public class InboundIdempotencyTest {
 
   }
 
+  /**
+   * The end of a workflow, as an adapter's process-end listener reports it.
+   */
+  private WorkflowEndedContext workflowEnded(
+      final String aggregateId) {
+
+    return new WorkflowEndedContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public WorkflowEnd.Kind getKind() {
+        return WorkflowEnd.Kind.COMPLETED;
+      }
+
+      @Override
+      public Instant getEndTime() {
+        return Instant.now();
+      }
+
+      @Override
+      public String getEndEventId() {
+        return "Event_Done";
+      }
+
+    };
+
+  }
+
   private int recordCount(
       final String aggregateId) throws SQLException {
 
@@ -132,87 +166,39 @@ public class InboundIdempotencyTest {
   }
 
   @Test
-  @DisplayName("A repeated delivery runs the handler once and reports the recorded outcome")
-  public void repeatedDeliveriesRunTheHandlerOnce() throws SQLException {
+  @DisplayName("An ended workflow releases its records, and a second workflow on the same aggregate keeps its own")
+  public void anEndedWorkflowReleasesItsRecords() throws SQLException {
 
     final var dummyAdapter = dummyAdapter();
+    assertEquals(
+        List.of(PROCESS),
+        dummyAdapter.getProcessesWithEndListener(),
+        "the release needs the end of a workflow, so the listener is attached without a @WorkflowEnded method");
 
     persistence.store("4711");
-    final var first = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
-    final var second = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+    persistence.store("4712");
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-2"));
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4712", "job-3"));
+    assertEquals(2, recordCount("4711"));
+    assertEquals(1, recordCount("4712"));
 
-    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, first.kind());
-    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, second.kind());
-    assertEquals(1, persistence.get("4711").getInvocations());
+    dummyAdapter.notifyWorkflowEnded(MODULE, PROCESS, workflowEnded("4711"));
+
+    assertEquals(0, recordCount("4711"), "the ended workflow releases its records");
+    assertEquals(1, recordCount("4712"), "another workflow keeps its own");
+
+    // a SECOND workflow on the same aggregate: its delivery is processed after the end of
+    // the first one, so its record was written after the notification and stays
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-4"));
     assertEquals(1, recordCount("4711"));
 
-    // the next task instance of the same workflow is another delivery
-    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-2"));
-    assertEquals(2, persistence.get("4711").getInvocations());
-    assertEquals(2, recordCount("4711"));
-
-  }
-
-  @Test
-  @DisplayName("A repeated delivery of a BPMN error reports code and name again")
-  public void repeatedDeliveryReportsTheRecordedBpmnError() {
-
-    final var dummyAdapter = dummyAdapter();
-
-    persistence.store("4712");
-    final var error = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
-    final var errorAgain = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("raiseBpmnError", "4712", "job-3"));
-
-    assertEquals(WorkflowTaskOutcome.Kind.BPMN_ERROR, errorAgain.kind());
-    assertEquals(error.errorCode(), errorAgain.errorCode());
-    assertEquals("PAYMENT_FAILED", errorAgain.errorCode());
-    assertEquals("PaymentFailed", errorAgain.errorName());
-    assertEquals(1, persistence.get("4712").getInvocations());
-
-  }
-
-  @Test
-  @DisplayName("A rolled-back delivery leaves no record, so its retry runs the handler")
-  public void aRolledBackDeliveryLeavesNoRecord() throws SQLException {
-
-    final var dummyAdapter = dummyAdapter();
-
-    persistence.store("4713");
-    assertThrows(
-        IllegalStateException.class,
-        () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
-    assertEquals(0, recordCount("4713"));
-
-    assertThrows(
-        IllegalStateException.class,
-        () -> dummyAdapter.invokeTask(MODULE, PROCESS, delivery("failTask", "4713", "job-4")));
-    assertEquals(0, recordCount("4713"));
-
-  }
-
-  @Test
-  @DisplayName("Story 76: without the release nobody asks for the end of a workflow")
-  public void noEndListenerWithoutTheRelease() {
-
+    final var repeated = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-4"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETED, repeated.kind());
     assertEquals(
-        List.of(),
-        dummyAdapter().getProcessesWithEndListener(),
-        "a model must not pay for a listener nobody uses");
-
-  }
-
-  @Test
-  @DisplayName("Switched off for a task, nothing is remembered")
-  public void aTaskMayOptOut() throws SQLException {
-
-    final var dummyAdapter = dummyAdapter();
-
-    persistence.store("4714");
-    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
-    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
-
-    assertEquals(2, persistence.get("4714").getInvocations());
-    assertEquals(0, recordCount("4714"));
+        3,
+        persistence.get("4711").getInvocations(),
+        "the released records must not make a repeated delivery run the handler again");
 
   }
 

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/delivery-release/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/delivery-release/application.yaml
@@ -1,0 +1,17 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:delivery-release;DB_CLOSE_DELAY=-1
+vanillabp:
+  delivery:
+    release-on-workflow-end: true
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
+++ b/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
@@ -136,6 +136,71 @@ public class MongoTaskDeliveryLogTest {
 
   }
 
+  /**
+   * A record of the given workflow, for the release which is bounded by exactly these
+   * three values plus the moment it runs at.
+   */
+  private TaskDelivery deliveryOf(
+      final String deliveryKey,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    return new TaskDelivery(
+        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null);
+
+  }
+
+  @Test
+  @DisplayName("Story 76: an ended workflow releases its records - and only its own")
+  public void theRecordsOfAnEndedWorkflowAreReleased() throws Exception {
+
+    userTransaction.begin();
+    deliveryLog.record(deliveryOf("job-5", "test-module", "TestProcess", "4711"));
+    deliveryLog.record(deliveryOf("job-6", "test-module", "TestProcess", "4711"));
+    deliveryLog.record(deliveryOf("job-7", "test-module", "TestProcess", "4712"));
+    deliveryLog.record(deliveryOf("job-8", "test-module", "OtherProcess", "4711"));
+    deliveryLog.record(deliveryOf("job-9", "other-module", "TestProcess", "4711"));
+    userTransaction.commit();
+
+    userTransaction.begin();
+    final var released = deliveryLog
+        // a moment safely after the records were written: a store's timestamp has
+        // millisecond resolution, and the bound is strict
+        .releaseRecordsOf("test-module", "TestProcess", "4711", java.time.Instant.now().plusSeconds(1));
+    userTransaction.commit();
+
+    assertEquals(2, released);
+    assertTrue(deliveryLog.recordedDelivery("job-5").isEmpty());
+    assertTrue(deliveryLog.recordedDelivery("job-6").isEmpty());
+    assertTrue(deliveryLog.recordedDelivery("job-7").isPresent(), "another aggregate keeps its records");
+    assertTrue(deliveryLog.recordedDelivery("job-8").isPresent(), "another process keeps its records");
+    assertTrue(deliveryLog.recordedDelivery("job-9").isPresent(), "another workflow module keeps its records");
+
+  }
+
+  @Test
+  @DisplayName("Story 76: a record written after the end of the workflow survives the release")
+  public void aRecordWrittenAfterTheNotificationSurvives() throws Exception {
+
+    // a moment safely before the record is written - see above on the resolution
+    final var endOfTheWorkflow = java.time.Instant.now().minusSeconds(1);
+
+    userTransaction.begin();
+    deliveryLog.record(deliveryOf("job-10", "test-module", "TestProcess", "4711"));
+    userTransaction.commit();
+
+    // the delivery of a SECOND workflow on the same aggregate, processed after the first
+    // one ended - the time bound is what keeps its record
+    userTransaction.begin();
+    final var released = deliveryLog.releaseRecordsOf("test-module", "TestProcess", "4711", endOfTheWorkflow);
+    userTransaction.commit();
+
+    assertEquals(0, released);
+    assertTrue(deliveryLog.recordedDelivery("job-10").isPresent());
+
+  }
+
   @Test
   @DisplayName("Records are deleted once the retention period passed")
   public void expiredRecordsAreDeleted() throws Exception {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -85,6 +85,13 @@ public interface QuarkusMigrationAdapterProperties {
   TransactionsProperties transactions();
 
   /**
+   * What VanillaBP does with the records of processed task deliveries (story 76).
+   *
+   * @return The delivery configuration
+   */
+  DeliveryProperties delivery();
+
+  /**
    * The adapter configuration. The properties in detail are defined by the
    * respective VanillaBP adapter Quarkus extension.
    */
@@ -425,6 +432,13 @@ public interface QuarkusMigrationAdapterProperties {
      */
     TransactionsProperties transactions();
 
+    /**
+     * Overrides <code>vanillabp.delivery</code> for this workflow module.
+     *
+     * @return The delivery configuration of this workflow module
+     */
+    DeliveryProperties delivery();
+
   }
 
   /**
@@ -441,6 +455,23 @@ public interface QuarkusMigrationAdapterProperties {
      * @return The setting, an empty Optional meaning "whatever applies globally"
      */
     Optional<io.vanillabp.integration.adapter.migration.config.TransactionsProperties.UnguardedAggregateWrites> unguardedAggregateWrites();
+
+  }
+
+  /**
+   * What VanillaBP does with the records of processed task deliveries: keep them until the
+   * retention passed, or delete them the moment their workflow ends (story 76).
+   */
+  interface DeliveryProperties {
+
+    /**
+     * Whether the records of a workflow are deleted when it ends. The default is
+     * <code>false</code>: switching it on makes every deployed model pay for the
+     * notification about the end of a workflow.
+     *
+     * @return The setting, an empty Optional meaning "whatever applies globally"
+     */
+    Optional<Boolean> releaseOnWorkflowEnd();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
@@ -11,6 +11,7 @@ import org.mapstruct.factory.Mappers;
 
 import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
 import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.DeliveryProperties;
 import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
 import io.vanillabp.integration.adapter.migration.config.TaskAdapterProperties;
@@ -70,6 +71,10 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
   @Mapping(target = "unguardedAggregateWrites", qualifiedByName = "unwrapUnguardedAggregateWrites")
   TransactionsProperties toCore(
       QuarkusMigrationAdapterProperties.TransactionsProperties transactionsProperties);
+
+  @Mapping(target = "releaseOnWorkflowEnd", qualifiedByName = "unwrapBoolean")
+  DeliveryProperties toCore(
+      QuarkusMigrationAdapterProperties.DeliveryProperties deliveryProperties);
 
   @Mapping(target = "outfadedVersions", qualifiedByName = "unwrapOutfadedVersions")
   AdapterConfigProperties toCore(
@@ -133,6 +138,21 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
   @Named("unwrapUnguardedAggregateWrites")
   default TransactionsProperties.UnguardedAggregateWrites unwrapUnguardedAggregateWrites(
       final Optional<TransactionsProperties.UnguardedAggregateWrites> value) {
+
+    return value.orElse(null);
+
+  }
+
+  /**
+   * Unwraps an optional flag ({@code Optional.empty()} becomes {@code null}: a workflow
+   * module which says nothing inherits what the application configured globally).
+   *
+   * @param value The optional flag
+   * @return The flag or {@code null}
+   */
+  @Named("unwrapBoolean")
+  default Boolean unwrapBoolean(
+      final Optional<Boolean> value) {
 
     return value.orElse(null);
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
@@ -172,6 +172,18 @@ public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAcces
   }
 
   @Override
+  public int releaseRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final java.time.Instant recordedBefore) {
+
+    return getStore()
+        .deleteRecordsOf(workflowModuleId, bpmnProcessId, workflowAggregateId, recordedBefore);
+
+  }
+
+  @Override
   public Connection acquire() throws SQLException {
 
     if (!dataSource.isResolvable()) {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
@@ -262,6 +262,31 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
 
   }
 
+  @Override
+  public int releaseRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final java.time.Instant recordedBefore) {
+
+    final var collection = deliveryCollection();
+    // through the session of the running transaction where MongoDB Panache provides one:
+    // the deletion then commits with the end notification instead of being written
+    // immediately (story 70)
+    final var session = io.vanillabp.integration.runtime.mongo.MongoSessions
+        .activeSession(txRegistry);
+    final var filter = new Document()
+        .append("workflowModuleId", workflowModuleId)
+        .append("bpmnProcessId", bpmnProcessId)
+        .append("aggregateId", workflowAggregateId)
+        .append("recordedAt", new Document("$lt", Date.from(recordedBefore)));
+    final var result = session != null
+        ? collection.deleteMany(session, filter)
+        : collection.deleteMany(filter);
+    return (int) result.getDeletedCount();
+
+  }
+
   private MongoCollection<Document> deliveryCollection() {
 
     final var database = ConfigProvider

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/QuarkusTaskDeliveryLogResolver.java
@@ -153,6 +153,21 @@ public class QuarkusTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
 
   }
 
+  /**
+   * Unwraps the CDI client proxy of a store: the proxy overrides every method of the bean
+   * class, the SPI's default doing nothing included, so reflecting on it would report a
+   * release which does not exist.
+   */
+  @Override
+  public Class<?> storeClassOf(
+      final TaskDeliveryLog deliveryLog) {
+
+    return io.quarkus.arc.ClientProxy
+        .unwrap(deliveryLog)
+        .getClass();
+
+  }
+
   @Override
   public String remediesDescription() {
 

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -67,17 +67,32 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                           Optional<List<String>> prioritizedAdapters,
                                           Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
                                           Map<String, QuarkusMigrationAdapterProperties.WorkflowProperties> workflows,
-                                          QuarkusMigrationAdapterProperties.TransactionsProperties transactions) implements QuarkusMigrationAdapterProperties.WorkflowModuleProperties {
+                                          QuarkusMigrationAdapterProperties.TransactionsProperties transactions,
+                                          QuarkusMigrationAdapterProperties.DeliveryProperties delivery) implements QuarkusMigrationAdapterProperties.WorkflowModuleProperties {
 
     /**
-     * Without a transaction section, which is what most of these fixtures need.
+     * Without a transaction and without a delivery section, which is what most of these
+     * fixtures need.
      */
     private WorkflowModuleProperties(
         final Optional<List<String>> prioritizedAdapters,
         final Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
         final Map<String, QuarkusMigrationAdapterProperties.WorkflowProperties> workflows) {
 
-      this(prioritizedAdapters, adapters, workflows, null);
+      this(prioritizedAdapters, adapters, workflows, null, null);
+
+    }
+
+    /**
+     * Without a delivery section.
+     */
+    private WorkflowModuleProperties(
+        final Optional<List<String>> prioritizedAdapters,
+        final Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
+        final Map<String, QuarkusMigrationAdapterProperties.WorkflowProperties> workflows,
+        final QuarkusMigrationAdapterProperties.TransactionsProperties transactions) {
+
+      this(prioritizedAdapters, adapters, workflows, transactions, null);
 
     }
 
@@ -85,6 +100,10 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
 
   private record TransactionsProperties(
                                         Optional<io.vanillabp.integration.adapter.migration.config.TransactionsProperties.UnguardedAggregateWrites> unguardedAggregateWrites) implements QuarkusMigrationAdapterProperties.TransactionsProperties {
+  }
+
+  private record DeliveryProperties(
+                                    Optional<Boolean> releaseOnWorkflowEnd) implements QuarkusMigrationAdapterProperties.DeliveryProperties {
   }
 
   private record JdbcOutboxProperties(
@@ -119,10 +138,11 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                             Map<String, QuarkusMigrationAdapterProperties.WorkflowModuleProperties> workflowModules,
                             QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
                             QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache,
-                            QuarkusMigrationAdapterProperties.TransactionsProperties transactions) implements QuarkusMigrationAdapterProperties {
+                            QuarkusMigrationAdapterProperties.TransactionsProperties transactions,
+                            QuarkusMigrationAdapterProperties.DeliveryProperties delivery) implements QuarkusMigrationAdapterProperties {
 
     /**
-     * Without a transaction section.
+     * Without a transaction and without a delivery section.
      */
     private Properties(
         final Optional<List<String>> prioritizedAdapters,
@@ -132,7 +152,25 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
         final QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
         final QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache) {
 
-      this(prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, null);
+      this(
+          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, null, null);
+
+    }
+
+    /**
+     * Without a delivery section.
+     */
+    private Properties(
+        final Optional<List<String>> prioritizedAdapters,
+        final Optional<String> resourcesLocation,
+        final Map<String, QuarkusMigrationAdapterProperties.AdapterConfiguration> adapters,
+        final Map<String, QuarkusMigrationAdapterProperties.WorkflowModuleProperties> workflowModules,
+        final QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
+        final QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache,
+        final QuarkusMigrationAdapterProperties.TransactionsProperties transactions) {
+
+      this(
+          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, transactions, null);
 
     }
 
@@ -324,6 +362,32 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
     assertTrue(core.acceptsUnguardedAggregateWrites("loan-approval"));
     assertFalse(core.acceptsUnguardedAggregateWrites("payments"));
     assertFalse(core.acceptsUnguardedAggregateWrites("unconfigured-module"));
+
+  }
+
+  @Test
+  @DisplayName("Story 76: the release-on-workflow-end setting travels globally and per workflow module")
+  public void deliverySettingTravelsGloballyAndPerModule() {
+
+    final var properties = new Properties(
+        Optional.empty(), Optional.empty(), Map.of(), Map
+            .of(
+                "loan-approval",
+                new WorkflowModuleProperties(
+                    Optional.empty(), Map.of(), Map.of(), null, new DeliveryProperties(Optional.of(true))),
+                "payments",
+                new WorkflowModuleProperties(
+                    Optional.empty(), Map.of(), Map.of(), null, new DeliveryProperties(Optional
+                        .empty()))), null, null, null, new DeliveryProperties(Optional.of(false)));
+
+    final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
+
+    assertEquals(Boolean.FALSE, core.getDelivery().getReleaseOnWorkflowEnd());
+    // the module's own value wins; a module saying nothing, and a module without any
+    // section at all, inherit what the application configured globally
+    assertTrue(core.releasesDeliveryRecordsOnWorkflowEnd("loan-approval"));
+    assertFalse(core.releasesDeliveryRecordsOnWorkflowEnd("payments"));
+    assertFalse(core.releasesDeliveryRecordsOnWorkflowEnd("unconfigured-module"));
 
   }
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/TaskDeliveryLogStartupValidationTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/adapter/TaskDeliveryLogStartupValidationTest.java
@@ -74,6 +74,36 @@ public class TaskDeliveryLogStartupValidationTest {
 
   }
 
+  /**
+   * An application's own store, written before the release of story 76 existed: it
+   * inherits the SPI's default which deletes nothing.
+   */
+  @org.springframework.context.annotation.Configuration
+  static class LegacyDeliveryLogConfiguration {
+
+    @org.springframework.context.annotation.Bean
+    io.vanillabp.integration.spi.TaskDeliveryLog legacyDeliveryLog() {
+
+      return new io.vanillabp.integration.spi.TaskDeliveryLog() {
+
+        @Override
+        public java.util.Optional<io.vanillabp.integration.spi.TaskDelivery> recordedDelivery(
+            final String deliveryKey) {
+          return java.util.Optional.empty();
+        }
+
+        @Override
+        public boolean record(
+            final io.vanillabp.integration.spi.TaskDelivery delivery) {
+          return true;
+        }
+
+      };
+
+    }
+
+  }
+
   private final ApplicationContextRunner contextRunner = new ApplicationContextRunner();
 
   /**
@@ -105,16 +135,28 @@ public class TaskDeliveryLogStartupValidationTest {
       final Runnable assertions,
       final String... properties) {
 
+    bootWith(assertions, new Class<?>[0], properties);
+
+  }
+
+  private void bootWith(
+      final Runnable assertions,
+      final Class<?>[] userConfigurations,
+      final String... properties) {
+
     final var propertyValues = new java.util.LinkedList<String>(
         List.of("spring.config.location=classpath:application.yaml"));
     propertyValues.addAll(List.of(properties));
+    final var configurations = new java.util.LinkedList<Class<?>>(
+        List.of(
+            WorkflowModuleConfiguration.class,
+            TestPersistenceConfiguration.class,
+            OwnOutboxConfiguration.class));
+    configurations.addAll(List.of(userConfigurations));
     this.contextRunner
         .withPropertyValues(propertyValues.toArray(String[]::new))
         .withInitializer(new ConfigDataApplicationContextInitializer())
-        .withUserConfiguration(
-            WorkflowModuleConfiguration.class,
-            TestPersistenceConfiguration.class,
-            OwnOutboxConfiguration.class)
+        .withUserConfiguration(configurations.toArray(Class<?>[]::new))
         .withConfiguration(
             AutoConfigurations.of(
                 DummyAdapterConfiguration.class, DummyAdapterProcessServiceConfiguration.class,
@@ -155,6 +197,55 @@ public class TaskDeliveryLogStartupValidationTest {
     Assertions.assertTrue(message.contains("TaskDeliveryLog"));
     Assertions.assertTrue(message.contains("TaskDeliveryLogAware"));
     Assertions.assertTrue(message.contains("vanillabp.adapters.test.deduplicate-deliveries"));
+
+  }
+
+  @Test
+  public void aStoreWithoutTheReleaseIsReportedWhereTheReleaseIsSwitchedOn() {
+
+    // story 76: the application asked for records to disappear when a workflow ends, and
+    // its own store cannot do it - which is a misconfiguration, not a missing feature
+    final var messages = loggedByCore(
+        () -> bootWith(
+            () -> {
+            },
+            new Class<?>[]{
+                LegacyDeliveryLogConfiguration.class
+            },
+            "dummy-adapter.two-phase-commit=true",
+            "vanillabp.delivery.release-on-workflow-end=true"));
+
+    final var message = messages
+        .stream()
+        .filter(candidate -> candidate.contains("releaseRecordsOf"))
+        .findFirst()
+        .orElseThrow(
+            () -> new AssertionError("no warning about the missing release, logged: "
+                + messages));
+    Assertions.assertTrue(message.contains("TaskDeliveryLog"), message);
+    Assertions
+        .assertTrue(
+            message.contains("delivery.release-on-workflow-end"),
+            message);
+
+  }
+
+  @Test
+  public void aStoreWithoutTheReleaseIsSilentWhereNobodyAskedForIt() {
+
+    final var messages = loggedByCore(
+        () -> bootWith(
+            () -> {
+            },
+            new Class<?>[]{
+                LegacyDeliveryLogConfiguration.class
+            },
+            "dummy-adapter.two-phase-commit=true"));
+
+    Assertions.assertTrue(
+        messages.stream().noneMatch(message -> message.contains("releaseRecordsOf")),
+        "an application which did not ask for the release must not be told about it, logged: "
+            + messages);
 
   }
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryRecordReleaseTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryRecordReleaseTest.java
@@ -1,0 +1,370 @@
+package io.vanillabp.integration.test.delivery;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.spi.workflowend.WorkflowEndedContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.delivery.JdbcTaskDeliveryLogAutoConfiguration;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+import io.vanillabp.spi.service.WorkflowEnd;
+
+/**
+ * Acceptance test of the release of delivery records (story 76) on Spring Boot, with the
+ * default JDBC-based delivery log: a workflow which ended deletes the records of its
+ * processed deliveries instead of leaving them to the retention. The workflow service of
+ * this test has NO <code>&#64;WorkflowEnded</code> method on purpose - the notification is
+ * asked for by the release alone, which is what makes the feature work without touching
+ * any adapter.
+ * <p>
+ * Pinned as well: the record of a SECOND workflow on the same aggregate, written after the
+ * end of the first one, survives; records of another aggregate stay; and with the option
+ * off nothing is released and no end listener is attached at all.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class DeliveryRecordReleaseTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "DeliveryProcess";
+
+  private static final String ADAPTER = "test";
+
+  /**
+   * The same in-memory persistence plus H2 the inbound-idempotency test uses - the records
+   * are really written, read and deleted through JDBC.
+   */
+  @Configuration
+  static class ReleaseConfiguration {
+
+    static final Map<String, DeliveryAggregate> AGGREGATES = new ConcurrentHashMap<>();
+
+    @Bean
+    AggregatePersistenceAware<DeliveryAggregate> deliveryPersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<DeliveryAggregate> getAggregateClass() {
+          return DeliveryAggregate.class;
+        }
+
+        @Override
+        public DeliveryAggregate save(
+            final DeliveryAggregate aggregate) {
+          AGGREGATES.put(aggregate.getId(), copyOf(aggregate));
+          return aggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final DeliveryAggregate aggregate) {
+          return aggregate.getId();
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public DeliveryAggregate loadById(
+            final Object aggregateId) {
+          final var stored = AGGREGATES.get(aggregateId);
+          return stored != null
+              ? copyOf(stored)
+              : null;
+        }
+
+      };
+
+    }
+
+    private static DeliveryAggregate copyOf(
+        final DeliveryAggregate aggregate) {
+
+      final var copy = new DeliveryAggregate();
+      copy.setId(aggregate.getId());
+      copy.setStatus(aggregate.getStatus());
+      copy.setInvocations(aggregate.getInvocations());
+      return copy;
+
+    }
+
+    @Bean
+    DataSource deliveryDataSource() {
+
+      return new EmbeddedDatabaseBuilder()
+          .setType(EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager(
+        final DataSource deliveryDataSource) {
+
+      return new DataSourceTransactionManager(deliveryDataSource);
+
+    }
+
+    /**
+     * Stands in for the BPMN model, so the wiring validation passes.
+     */
+    @Bean
+    DummyTaskWiringSource deliveryTaskWiringSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> PROCESS.equals(bpmnProcessId)
+              ? List.of(
+                  new BpmnTaskSpec("Activity_Process", "processTask"),
+                  new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
+                  new BpmnTaskSpec("Activity_Fail", "failTask"),
+                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+              : List.of();
+
+    }
+
+  }
+
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        adapters:
+          test:
+            type: dummy
+            test: 1
+        delivery:
+          release-on-workflow-end: %s
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/delivery
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            DeliveryWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            ReleaseConfiguration.class,
+            // after the data source it is conditional on: the auto-configuration is
+            // listed as a plain source here, so its conditions see the bean definitions
+            // registered before it
+            JdbcTaskDeliveryLogAutoConfiguration.class,
+            DeploymentTest.TestConfig.class)
+        .run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp(
+      final boolean releaseOnWorkflowEnd) throws IOException {
+
+    return SpringBootTestApplication.builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML.formatted(releaseOnWorkflowEnd))
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  /**
+   * The end of a workflow, as an adapter's process-end listener reports it.
+   */
+  private WorkflowEndedContext workflowEnded(
+      final String aggregateId) {
+
+    return new WorkflowEndedContext() {
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public WorkflowEnd.Kind getKind() {
+        return WorkflowEnd.Kind.COMPLETED;
+      }
+
+      @Override
+      public java.time.Instant getEndTime() {
+        return java.time.Instant.now();
+      }
+
+      @Override
+      public String getEndEventId() {
+        return "Event_Done";
+      }
+
+    };
+
+  }
+
+  private void storeAggregate(
+      final String id) {
+
+    final var aggregate = new DeliveryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("new");
+    ReleaseConfiguration.AGGREGATES.put(id, aggregate);
+
+  }
+
+  private int recordCount(
+      final ConfigurableApplicationContext context,
+      final String aggregateId) {
+
+    return new JdbcTemplate(context.getBean(DataSource.class))
+        .queryForObject(
+            "SELECT COUNT(*) FROM %s WHERE AGGREGATE_ID = ?".formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME),
+            Integer.class,
+            aggregateId);
+
+  }
+
+  @Test
+  public void anEndedWorkflowReleasesItsRecords() throws IOException {
+
+    ReleaseConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(true); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+      Assertions.assertEquals(
+          List.of(PROCESS),
+          dummyAdapter.getProcessesWithEndListener(),
+          "the release needs the end of a workflow, so the listener is attached without a @WorkflowEnded method");
+
+      storeAggregate("4711");
+      storeAggregate("4712");
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-2"));
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4712", "job-3"));
+      Assertions.assertEquals(2, recordCount(context, "4711"));
+      Assertions.assertEquals(1, recordCount(context, "4712"));
+
+      dummyAdapter.notifyWorkflowEnded(MODULE, PROCESS, workflowEnded("4711"));
+
+      Assertions.assertEquals(0, recordCount(context, "4711"), "the ended workflow releases its records");
+      Assertions.assertEquals(1, recordCount(context, "4712"), "another workflow keeps its own");
+
+      // a SECOND workflow on the same aggregate: its delivery is processed after the end
+      // of the first one, so its record was written after the notification and stays
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-4"));
+      Assertions.assertEquals(1, recordCount(context, "4711"));
+
+      // a repeated delivery of the second workflow is still answered from that record
+      final var repeated = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-4"));
+      Assertions.assertEquals(
+          io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome.Kind.COMPLETED,
+          repeated.kind());
+      Assertions.assertEquals(
+          3,
+          ReleaseConfiguration.AGGREGATES.get("4711").getInvocations(),
+          "the released records must not make a repeated delivery run the handler again");
+
+    }
+
+  }
+
+  @Test
+  public void withoutTheOptionTheRecordsStayAndNoListenerIsAttached() throws IOException {
+
+    ReleaseConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(false); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+      Assertions.assertEquals(
+          List.of(),
+          dummyAdapter.getProcessesWithEndListener(),
+          "a model must not pay for a listener nobody uses");
+
+      storeAggregate("4713");
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4713", "job-5"));
+      Assertions.assertEquals(1, recordCount(context, "4713"));
+
+      // a BPMS reporting the end anyway (a listener of another feature) changes nothing
+      dummyAdapter.notifyWorkflowEnded(MODULE, PROCESS, workflowEnded("4713"));
+
+      Assertions.assertEquals(
+          1,
+          recordCount(context, "4713"),
+          "with the option off the retention is what cleans up");
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
@@ -145,6 +145,66 @@ public class MongoTaskDeliveryLogTest {
 
   }
 
+  /**
+   * A record of the given workflow, for the release which is bounded by exactly these
+   * three values plus the moment it runs at.
+   */
+  private TaskDelivery deliveryOf(
+      final String deliveryKey,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    return new TaskDelivery(
+        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null);
+
+  }
+
+  @Test
+  @DisplayName("Story 76: an ended workflow releases its records - and only its own")
+  public void theRecordsOfAnEndedWorkflowAreReleased() {
+
+    transactionTemplate.executeWithoutResult(status -> {
+      deliveryLog.record(deliveryOf("job-5", "test-module", "TestProcess", "4711"));
+      deliveryLog.record(deliveryOf("job-6", "test-module", "TestProcess", "4711"));
+      deliveryLog.record(deliveryOf("job-7", "test-module", "TestProcess", "4712"));
+      deliveryLog.record(deliveryOf("job-8", "test-module", "OtherProcess", "4711"));
+      deliveryLog.record(deliveryOf("job-9", "other-module", "TestProcess", "4711"));
+    });
+
+    final var released = deliveryLog
+        // a moment safely after the records were written: a store's timestamp has
+        // millisecond resolution, and the bound is strict
+        .releaseRecordsOf("test-module", "TestProcess", "4711", java.time.Instant.now().plusSeconds(1));
+
+    assertEquals(2, released);
+    assertTrue(deliveryLog.recordedDelivery("job-5").isEmpty());
+    assertTrue(deliveryLog.recordedDelivery("job-6").isEmpty());
+    assertTrue(deliveryLog.recordedDelivery("job-7").isPresent(), "another aggregate keeps its records");
+    assertTrue(deliveryLog.recordedDelivery("job-8").isPresent(), "another process keeps its records");
+    assertTrue(deliveryLog.recordedDelivery("job-9").isPresent(), "another workflow module keeps its records");
+
+  }
+
+  @Test
+  @DisplayName("Story 76: a record written after the end of the workflow survives the release")
+  public void aRecordWrittenAfterTheNotificationSurvives() {
+
+    // a moment safely before the record is written - see above on the resolution
+    final var endOfTheWorkflow = java.time.Instant.now().minusSeconds(1);
+    transactionTemplate
+        .executeWithoutResult(
+            status -> deliveryLog.record(deliveryOf("job-10", "test-module", "TestProcess", "4711")));
+
+    // the delivery of a SECOND workflow on the same aggregate, processed after the first
+    // one ended - the time bound is what keeps its record
+    final var released = deliveryLog.releaseRecordsOf("test-module", "TestProcess", "4711", endOfTheWorkflow);
+
+    assertEquals(0, released);
+    assertTrue(deliveryLog.recordedDelivery("job-10").isPresent());
+
+  }
+
   @Test
   @DisplayName("Records are deleted once the retention period passed")
   public void expiredRecordsAreDeleted() {

--- a/spring-boot-integration/runtime/pom.xml
+++ b/spring-boot-integration/runtime/pom.xml
@@ -75,6 +75,10 @@
       <artifactId>spring-tx</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.data</groupId>
       <artifactId>spring-data-commons</artifactId>
     </dependency>

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
@@ -115,6 +115,18 @@ public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAcces
   }
 
   @Override
+  public int releaseRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final java.time.Instant recordedBefore) {
+
+    return store
+        .deleteRecordsOf(workflowModuleId, bpmnProcessId, workflowAggregateId, recordedBefore);
+
+  }
+
+  @Override
   public Connection acquire() throws SQLException {
 
     // bound to the Spring-managed transaction if one is running (which the recording

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
@@ -127,6 +127,32 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
 
   }
 
+  @Override
+  public int releaseRecordsOf(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final Instant recordedBefore) {
+
+    return (int) mongoTemplate
+        .remove(
+            Query
+                .query(
+                    Criteria
+                        .where("workflowModuleId")
+                        .is(workflowModuleId)
+                        .and("bpmnProcessId")
+                        .is(bpmnProcessId)
+                        .and("aggregateId")
+                        .is(workflowAggregateId)
+                        .and("recordedAt")
+                        .lt(recordedBefore)),
+            TaskDeliveryDocument.class,
+            collection)
+        .getDeletedCount();
+
+  }
+
   /**
    * Removes the record again where the transaction it was written in did not commit
    * (story 70). Without a MongoDB transaction covering it - no

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringTaskDeliveryLogResolver.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringTaskDeliveryLogResolver.java
@@ -107,6 +107,20 @@ public class SpringTaskDeliveryLogResolver implements TaskDeliveryLogResolver {
 
   }
 
+  /**
+   * Unwraps a proxied store: an application may put <code>&#64;Transactional</code> on
+   * its own {@link TaskDeliveryLog}, and the proxy Spring creates for it overrides every
+   * method of the target - the SPI's default doing nothing included. Reflecting on the
+   * proxy would therefore report a release which does not exist.
+   */
+  @Override
+  public Class<?> storeClassOf(
+      final TaskDeliveryLog deliveryLog) {
+
+    return org.springframework.aop.framework.AopProxyUtils.ultimateTargetClass(deliveryLog);
+
+  }
+
   @Override
   public String remediesDescription() {
 


### PR DESCRIPTION
Story 76. Opt-in, so an application which configures nothing behaves exactly as before.

## What this builds

The records of processed task deliveries were cleaned up by age alone (`vanillabp.outbox.retention`, seven days). Seven days are a guess: too long for a busy application, too short for a task genuinely open longer than that. The end of a workflow is what the clock only approximates, since nothing of an ended instance can be redelivered.

- `vanillabp.delivery.release-on-workflow-end` (default `false`), global and per workflow module, the module's value winning.
- The deletion runs in the transaction of the workflow-ended notification, bounded by workflow module, BPMN process, aggregate and by an `Instant` taken before the notification is processed. That time bound is what keeps the records of a SECOND workflow on the same aggregate.
- Opt-in because the end of a workflow is reported only where it is used: adapters ask `WorkflowTaskRegistry.workflowEndedHandlerExists` while wiring, and that answers `true` where the release is on, even without a `@WorkflowEnded` method. **No adapter had to change.**
- `TaskDeliveryLog.releaseRecordsOf(...)` has a default deleting nothing, so every existing store stays valid. Whether a store implements it is decided by reflection over the class the platform hands out (new `TaskDeliveryLogResolver.storeClassOf`, unwrapping CDI client proxies respectively Spring AOP proxies - a proxy overrides the default and would claim a release which does not exist). Store without the release plus option on = one guiding WARN at startup; option off = silence.
- Both built-in stores implement it. No index ships for the three columns: `AGGREGATE_ID` holds up to 1024 characters, and an index over the three exceeds MySQL's key-length limit and DB2's with 4K pages. The wiki says an application whose table grows large adds one itself.
- The retention stays the backstop for workflows still running, for aggregates whose workflow never ends and for stores without the release.

## Deliberately not built

"B follows A" (analysis decision 2): a record carries no process instance id, an aggregate may carry several processes, a multi-instance task has several live deliveries of one definition, and parallel branches say nothing about each other. The cheap variant would be wrong rather than approximate, the safe one needs model reachability per BPMS with a silent failure mode.

## Tests

- Core: `DeliveryRecordReleaseTest` (7) - the four bounds, both switch levels, handler plus release in one notification, the startup line and its silence.
- Spring Boot: acceptance test against the dummy adapter (release, second workflow on the same aggregate keeps its record, no listener without the option), plus the startup line for an application-provided store in `TaskDeliveryLogStartupValidationTest`.
- Quarkus: the same acceptance test, plus "no listener without the release" in `InboundIdempotencyTest`.
- MongoDB: the release pinned in both stores (bounds and the record written after the notification).
- Full build green, 26:25 min.

## Docs

Wiki `Workflow-tasks` (new section "How long a delivery is remembered"), both platform integration pages, `UPGRADE.md`, `migration-adapter/README.md`, skill `vanillabp-configuration-model`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25