### PR TITLE
Name the properties the schema's tables really follow

### DIFF
--- a/schema/src/main/resources/vanillabp/schema/changelog.xml
+++ b/schema/src/main/resources/vanillabp/schema/changelog.xml
@@ -18,9 +18,11 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
 
   <!-- override in your own changelog which includes this one, to match
-       'vanillabp.outbox.jdbc.table-name' -->
+       'vanillabp.outbox.jdbc.table' -->
   <property name="vanillabp.outbox.table" value="VANILLABP_PHASE_TWO_OUTBOX"/>
-  <!-- matches 'vanillabp.delivery.jdbc.table-name' -->
+  <!-- NOT configurable: VanillaBP creates and reads exactly this table
+       (JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME), so overriding this property would
+       build a table nobody uses -->
   <property name="vanillabp.delivery.table" value="VANILLABP_TASK_DELIVERY"/>
 
   <!-- released versions, oldest first; the release adds a line here and never touches an existing


### PR DESCRIPTION
Comments only, no changeset touched, no generated SQL changed.

The master changelog documented two property names, and neither is real:

- the outbox table follows `vanillabp.outbox.jdbc.table`, the comment said `...table-name`;
- the delivery table follows no property at all - its name is `JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME`, a constant. An application overriding the Liquibase property `vanillabp.delivery.table` builds a table VanillaBP never reads, which is the worst kind of wrong: the schema looks applied and the first delivery fails.

Found while writing the Camunda 8 wiki for story 76, where a draft recommended `vanillabp.delivery.jdbc.table-name` as the way out of a job-key collision after a cluster was replaced. The wiki now names the DELETE statement instead.

`mvn install -pl schema` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jss55UjjvxYcLQPVFUFe25