### PR TITLE
The supported Spring Boot and Quarkus versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ Currently, these platforms are supported:
 Developers who want to use VanillaBP should refer to the [Wiki](https://github.com/vanillabp/adapter-platform-integration/wiki).  
 It contains conceptual documentation as well as platform-specific details.
 
+The versions this release is built and tested against are Spring Boot **4.1.0**, Quarkus **3.37.1** and Java **21**.
+Applications on a newer patch or minor of either platform are expected to work and are not tested here; a new major
+is an upgrade of VanillaBP itself, and `UPGRADE.md` says what it took. There are no release lines per platform
+version, unlike the
+[Camunda 8 adapter](https://github.com/camunda-community-hub/vanillabp-camunda8-adapter#release-lines), whose
+artifacts carry the cluster minor: Camunda 8 forces that because the client a build was compiled against is the
+lowest cluster version it accepts, while Spring Boot and Quarkus are dependencies of the application, which picks
+them itself.
+
 ## Contribution
 
 Developers who want to contribute to VanillaBP should familiarize themselves with the implementation details by


### PR DESCRIPTION
Story 53. The README named no platform version at all, so a reader had to open a POM to learn
what this release is built against. It now says Spring Boot 4.1.0, Quarkus 3.37.1 and Java 21,
and why the platform has no release lines while the Camunda 8 adapter does: for Camunda 8 the
client a build was compiled against is the lowest cluster version it accepts, whereas Spring Boot
and Quarkus are dependencies the application picks itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
