### PR TITLE
The Spring Boot outbox table is checked at startup (story 95)

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -389,7 +389,11 @@ remembers a processed delivery and answers a repeated one from the record:
   aggregate's own transaction. `JdbcTaskDeliveryStore` and
   `TaskDeliveryRetentionCleanup` (package `delivery`) hold the SQL respectively the
   cleanup schedule both platforms share; the connection comes from
-  `JdbcConnectionAccess`, the one piece which cannot be platform-neutral.
+  `JdbcConnectionAccess`, the one piece which cannot be platform-neutral. Whether a
+  table is there is asked of the JDBC metadata by `jdbc.JdbcSchema#tableExists`, used
+  by every store which either creates its table or verifies that the application
+  created it - including the gruelbox outbox of the Spring Boot integration, whose
+  table is gruelbox's and therefore not shipped by `vanillabp-schema` (story 95).
 - The switch is the adapter-scoped `deduplicate-deliveries` (default `true`),
   resolvable per workflow module, workflow and task like every adapter-scoped key.
 - An adapter says whether it needs this at all:

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/PhaseTwoOutboxProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/PhaseTwoOutboxProperties.java
@@ -98,7 +98,8 @@ public class PhaseTwoOutboxProperties {
      * (Spring Boot/gruelbox: <code>TXNO_OUTBOX</code>; Quarkus:
      * <code>VANILLABP_PHASE_TWO_OUTBOX</code>). NOTE: on Spring Boot the gruelbox
      * schema migration always targets the default table - a custom name requires
-     * the table (structured like <code>TXNO_OUTBOX</code>) to be created manually.
+     * the table (structured like <code>TXNO_OUTBOX</code>) to be created manually,
+     * which is verified at startup.
      */
     @Builder.Default
     private String table = null;

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -6,9 +6,9 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Optional;
 
+import io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema;
 import io.vanillabp.integration.spi.TaskDelivery;
 import lombok.extern.slf4j.Slf4j;
 
@@ -265,7 +265,7 @@ public class JdbcTaskDeliveryStore {
     Connection connection = null;
     try {
       connection = connectionAccess.acquire();
-      if (tableExists(connection, tableName)) {
+      if (JdbcSchema.tableExists(connection, tableName)) {
         return;
       }
       try (var statement = connection.createStatement()) {
@@ -301,7 +301,7 @@ public class JdbcTaskDeliveryStore {
     Connection connection = null;
     try {
       connection = connectionAccess.acquire();
-      if (tableExists(connection, tableName)) {
+      if (JdbcSchema.tableExists(connection, tableName)) {
         return;
       }
       throw new IllegalStateException(
@@ -354,28 +354,6 @@ public class JdbcTaskDeliveryStore {
     return (e instanceof SQLIntegrityConstraintViolationException) || ((e.getSQLState() != null) && e
         .getSQLState()
         .startsWith("23"));
-
-  }
-
-  private static boolean tableExists(
-      final Connection connection,
-      final String tableName) throws SQLException {
-
-    final var metaData = connection.getMetaData();
-    // unquoted identifiers are folded to upper case by some databases (Oracle, H2)
-    // and to lower case by others (PostgreSQL) - check both spellings
-    for (final var name : List.of(
-        tableName,
-        tableName.toLowerCase())) {
-      try (var tables = metaData.getTables(null, null, name, new String[]{
-          "TABLE"
-      })) {
-        if (tables.next()) {
-          return true;
-        }
-      }
-    }
-    return false;
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
@@ -1,0 +1,50 @@
+package io.vanillabp.integration.adapter.migration.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.List;
+
+/**
+ * Reading the database's own catalog, used by every store which either creates its table
+ * or verifies that the application created it (see
+ * {@link io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore} and the
+ * phase-two outboxes of both platform integrations).
+ */
+public final class JdbcSchema {
+
+  private JdbcSchema() {
+  }
+
+  /**
+   * Whether a table of that name exists, asked of the JDBC metadata rather than by a
+   * <code>CREATE TABLE IF NOT EXISTS</code>, which not every database supports (e.g. Oracle,
+   * SQL Server).
+   *
+   * @param connection The connection to the database holding the table
+   * @param tableName The table to look for, spelled as the application configured it
+   * @return Whether the table exists
+   * @throws SQLException If the metadata cannot be read
+   */
+  public static boolean tableExists(
+      final Connection connection,
+      final String tableName) throws SQLException {
+
+    final var metaData = connection.getMetaData();
+    // unquoted identifiers are folded to upper case by some databases (Oracle, H2)
+    // and to lower case by others (PostgreSQL) - check both spellings
+    for (final var name : List.of(
+        tableName,
+        tableName.toLowerCase())) {
+      try (var tables = metaData.getTables(null, null, name, new String[]{
+          "TABLE"
+      })) {
+        if (tables.next()) {
+          return true;
+        }
+      }
+    }
+    return false;
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
@@ -17,6 +17,7 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.config.SmallRyeConfig;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
+import io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
@@ -249,7 +250,7 @@ public class JdbcPhaseTwoOutboxDispatcher {
     try (var connection = dataSource.get().getConnection()) {
       // existence is checked via JDBC metadata since 'CREATE TABLE IF NOT EXISTS'
       // is not supported by all databases (e.g. Oracle, SQL Server)
-      if (tableExists(connection, tableName)) {
+      if (JdbcSchema.tableExists(connection, tableName)) {
         return;
       }
       try (var statement = connection.createStatement()) {
@@ -275,7 +276,7 @@ public class JdbcPhaseTwoOutboxDispatcher {
   private void validateTableExists() {
 
     try (var connection = dataSource.get().getConnection()) {
-      if (tableExists(connection, tableName)) {
+      if (JdbcSchema.tableExists(connection, tableName)) {
         return;
       }
       throw new IllegalStateException(
@@ -293,28 +294,6 @@ public class JdbcPhaseTwoOutboxDispatcher {
       throw new IllegalStateException(
           "Could not check whether the phase-two outbox table '%s' exists!".formatted(tableName), e);
     }
-
-  }
-
-  private static boolean tableExists(
-      final Connection connection,
-      final String tableName) throws SQLException {
-
-    final var metaData = connection.getMetaData();
-    // unquoted identifiers are folded to upper case by some databases (Oracle, H2)
-    // and to lower case by others (PostgreSQL) - check both spellings
-    for (final var name : List.of(
-        tableName,
-        tableName.toLowerCase())) {
-      try (var tables = metaData.getTables(null, null, name, new String[]{
-          "TABLE"
-      })) {
-        if (tables.next()) {
-          return true;
-        }
-      }
-    }
-    return false;
 
   }
 

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/GruelboxOutboxSchemaHandoverTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/GruelboxOutboxSchemaHandoverTest.java
@@ -1,0 +1,129 @@
+package io.vanillabp.integration.test.outbox;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration;
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import com.gruelbox.transactionoutbox.TransactionOutbox;
+
+import io.vanillabp.integration.outbox.gruelbox.GruelboxPhaseTwoOutboxAutoConfiguration;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 95: on Spring Boot the phase-two outbox is gruelbox, and its table
+ * <code>TXNO_OUTBOX</code> is the one table a schema handover does NOT get from
+ * <code>io.vanillabp:vanillabp-schema</code> - the schema belongs to gruelbox. Switching
+ * VanillaBP's table creation off switches gruelbox's migrator off with it, and a custom table
+ * name does the same silently, so the table's existence is verified at startup exactly like
+ * VanillaBP's own two. Without that check an application which forgot the table boots cleanly
+ * and fails at the first workflow it starts.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class GruelboxOutboxSchemaHandoverTest {
+
+  private static ApplicationContextRunner applicationOn(
+      final String database,
+      final String... properties) {
+
+    final var configuration = new String[properties.length + 2];
+    configuration[0] = "spring.datasource.url=jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1".formatted(database);
+    configuration[1] = "spring.jpa.hibernate.ddl-auto=none";
+    System.arraycopy(properties, 0, configuration, 2, properties.length);
+
+    return new ApplicationContextRunner()
+        .withPropertyValues(configuration)
+        .withConfiguration(
+            AutoConfigurations.of(
+                DataSourceAutoConfiguration.class, DataSourceTransactionManagerAutoConfiguration.class,
+                HibernateJpaAutoConfiguration.class, GruelboxPhaseTwoOutboxAutoConfiguration.class));
+
+  }
+
+  private static String bootFailureOf(
+      final AssertableApplicationContext context) {
+
+    final var failure = context.getStartupFailure();
+    assertNotNull(failure, "the boot has to end with a guiding message");
+    var cause = (Throwable) failure;
+    while (cause.getCause() != null) {
+      cause = cause.getCause();
+    }
+    return String.valueOf(cause.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("A handed-over schema without the outbox table ends the boot naming table, property and source")
+  public void aMissingOutboxTableEndsTheBoot() {
+
+    applicationOn("schema-handover-missing", "vanillabp.outbox.create-schema=false")
+        .run(context -> {
+
+          final var message = bootFailureOf(context);
+
+          assertTrue(message.contains("TXNO_OUTBOX"), message);
+          assertTrue(message.contains("vanillabp.outbox.create-schema"), message);
+          // the statements are gruelbox's, so the message must not send anybody to
+          // VanillaBP's schema artifact for them
+          assertTrue(message.contains("gruelbox"), message);
+          assertTrue(
+              message.contains("Creating the tables with Liquibase or Flyway"),
+              message);
+          // the remedy has to name what actually produces those statements
+          assertTrue(message.contains("DefaultPersistor.writeSchema"), message);
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("The table gruelbox's own migrator creates satisfies the check")
+  public void aTableCreatedByGruelboxPasses() {
+
+    // first boot creates the table the way an application which never handed the schema
+    // over gets it ...
+    applicationOn("schema-handover-created")
+        .run(context -> assertNull(context.getStartupFailure(), "the migrating boot has to work"));
+
+    // ... and that is what the check accepts on the next boot of the same database
+    applicationOn("schema-handover-created", "vanillabp.outbox.create-schema=false")
+        .run(context -> {
+
+          assertNull(context.getStartupFailure(), "the table exists, so nothing changes");
+          assertNotNull(context.getBean(TransactionOutbox.class));
+
+        });
+
+  }
+
+  @Test
+  @DisplayName("A custom table name is checked as well - it switches the migration off silently")
+  public void aMissingCustomOutboxTableEndsTheBoot() {
+
+    applicationOn(
+        "schema-handover-custom",
+        "vanillabp.outbox.create-schema=true",
+        "vanillabp.outbox.jdbc.table=MY_OUTBOX")
+        .run(context -> {
+
+          final var message = bootFailureOf(context);
+
+          assertTrue(message.contains("MY_OUTBOX"), message);
+          assertTrue(message.contains("vanillabp.outbox.jdbc.table"), message);
+          assertTrue(message.contains("gruelbox"), message);
+
+        });
+
+  }
+
+}

--- a/spring-boot-integration/runtime/README.md
+++ b/spring-boot-integration/runtime/README.md
@@ -162,10 +162,18 @@ disable an unwanted default via its `enabled` flag:
    application's `@EnableScheduling` setup stays unaffected. The outbox table
    `TXNO_OUTBOX` is created by gruelbox's auto-DDL — set
    `vanillabp.outbox.create-schema: false` to manage the schema manually (use
-   gruelbox's `DefaultPersistor.writeSchema(Writer)` or the DDL from the gruelbox
-   documentation for your database). NOTE: gruelbox's migrations always target the
+   gruelbox's `DefaultPersistor.writeSchema(Writer)`, which emits its migrations as
+   SQL for the configured dialect). NOTE: gruelbox's migrations always target the
    DEFAULT table, so a custom `vanillabp.outbox.jdbc.table` requires that table
-   (structured like `TXNO_OUTBOX`) to be created manually. The default's beans
+   (structured like `TXNO_OUTBOX`) to be created manually. Wherever the migration is
+   off, the auto-configuration verifies AT STARTUP that the table exists
+   (`validateOutboxTableExists`) and ends the boot naming table and property. This
+   table is the one piece of a schema handover `io.vanillabp:vanillabp-schema` does
+   not cover, because the schema belongs to gruelbox (story 95, decided against
+   shipping foreign DDL and against replacing gruelbox for now); VanillaBP's own two
+   tables are checked by `JdbcTaskDeliveryStore#validateSchemaExists` respectively the
+   Quarkus dispatcher, all three through
+   `io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema#tableExists`. The default's beans
    reference each other BY NAME (`vanillaBpTransactionOutbox`), so additional
    user-defined gruelbox instances (e.g. a dedicated hot-process outbox) do not
    suppress the default; with several transaction managers (mixed persistence)

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
@@ -26,6 +26,7 @@ import com.gruelbox.transactionoutbox.TransactionOutbox;
 import com.gruelbox.transactionoutbox.spring.SpringInstantiator;
 import com.gruelbox.transactionoutbox.spring.SpringTransactionManager;
 
+import io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema;
 import io.vanillabp.integration.adapter.migration.processservice.PhaseTwoRouter;
 import io.vanillabp.integration.config.VanillaBpConfigurationProperties;
 import io.vanillabp.integration.spi.PhaseTwoCall;
@@ -50,7 +51,10 @@ import jakarta.persistence.EntityManagerFactory;
  * <code>vanillabp.outbox.jdbc.table</code>) is created automatically via gruelbox's
  * schema migration unless <code>vanillabp.outbox.create-schema</code> is set to
  * <code>false</code> (see the module's <code>README.md</code> for managing the schema
- * manually).
+ * manually). Wherever that migration is off - which a custom table name does as well -
+ * the table's existence is verified AT STARTUP (see
+ * {@link #validateOutboxTableExists(DataSource, String)}), because this one table is
+ * gruelbox's and therefore not covered by <code>io.vanillabp:vanillabp-schema</code>.
  * <p>
  * <strong>Contract mapping (deviations):</strong> the {@link PhaseTwoOutbox} contract
  * is mapped onto gruelbox's native capabilities: idempotency keys become
@@ -95,6 +99,13 @@ public class GruelboxPhaseTwoOutboxAutoConfiguration {
   public static final String DEFAULT_TRANSACTION_OUTBOX_BEAN_NAME = "vanillaBpTransactionOutbox";
 
   /**
+   * The table gruelbox stores outbox entries in unless
+   * <code>vanillabp.outbox.jdbc.table</code> names another one - and the only table
+   * gruelbox's own schema migration ever creates.
+   */
+  public static final String DEFAULT_OUTBOX_TABLE_NAME = "TXNO_OUTBOX";
+
+  /**
    * The gruelbox {@link TransactionOutbox} enlisting entries in Spring-managed JDBC
    * transactions and instantiating the scheduled {@link GruelboxPhaseTwoDispatch}
    * from the application context.
@@ -122,10 +133,14 @@ public class GruelboxPhaseTwoOutboxAutoConfiguration {
     // custom table name therefore requires the table to be created manually (see
     // 'vanillabp.outbox.jdbc.table')
     final var customTable = properties.getJdbc().getTable();
+    final var migrate = properties.isCreateSchema() && (customTable == null);
+    if (!migrate) {
+      validateOutboxTableExists(dataSource, customTable);
+    }
     final var persistorBuilder = DefaultPersistor
         .builder()
         .dialect(detectDialect(dataSource))
-        .migrate(properties.isCreateSchema() && (customTable == null));
+        .migrate(migrate);
     if (customTable != null) {
       persistorBuilder.tableName(customTable);
     }
@@ -240,6 +255,63 @@ public class GruelboxPhaseTwoOutboxAutoConfiguration {
             the JPA workflow aggregates - name that one 'transactionManager' (Spring Boot's \
             convention) or define your own gruelbox TransactionOutbox bean named '%s'."""
             .formatted(transactionManagers.keySet(), DEFAULT_TRANSACTION_OUTBOX_BEAN_NAME));
+
+  }
+
+  /**
+   * Verifies that the outbox table exists whenever gruelbox's schema migration is switched
+   * off - by <code>vanillabp.outbox.create-schema</code> for an application applying its
+   * schema itself (story 75), or by a custom table name, which switches the migration off
+   * as well since it only ever targets {@value #DEFAULT_OUTBOX_TABLE_NAME}.
+   * <p>
+   * Unlike VanillaBP's own tables this one belongs to gruelbox, so the message points to
+   * gruelbox for the statements instead of to
+   * <code>io.vanillabp:vanillabp-schema</code>. Without the check a missing table surfaces
+   * at the first workflow started on a remote BPMS, hours after a deployment which booted
+   * cleanly.
+   *
+   * @param dataSource The data source holding the outbox table
+   * @param customTable The configured table name, <code>null</code> for the default
+   * @throws IllegalStateException If the table is missing
+   */
+  private static void validateOutboxTableExists(
+      final DataSource dataSource,
+      final String customTable) {
+
+    final var tableName = customTable == null ? DEFAULT_OUTBOX_TABLE_NAME : customTable;
+    try (var connection = dataSource.getConnection()) {
+      if (JdbcSchema.tableExists(connection, tableName)) {
+        return;
+      }
+    } catch (final SQLException e) {
+      throw new IllegalStateException(
+          "Could not check whether the phase-two outbox table '%s' exists!".formatted(tableName), e);
+    }
+    final var remedies = customTable == null
+        ? """
+            - apply gruelbox's schema with your migration tool: \
+            'com.gruelbox.transactionoutbox.DefaultPersistor.writeSchema(Writer)' writes the \
+            statements for the database you configure, or
+            - let gruelbox create the table by setting 'vanillabp.outbox.create-schema' to \
+            'true' (the default)."""
+        : """
+            - create the table yourself, structured like gruelbox's default table '%s': \
+            'com.gruelbox.transactionoutbox.DefaultPersistor.writeSchema(Writer)' writes the \
+            statements for the database you configure, or
+            - remove 'vanillabp.outbox.jdbc.table' and let gruelbox create '%s' (which needs \
+            'vanillabp.outbox.create-schema' to be 'true', the default)."""
+            .formatted(DEFAULT_OUTBOX_TABLE_NAME, DEFAULT_OUTBOX_TABLE_NAME);
+    throw new IllegalStateException(
+        """
+            The phase-two outbox table '%s' does not exist! Starting a workflow on a remote BPMS \
+            writes an entry into it inside the caller's transaction, so without the table nothing \
+            can be started. This table is gruelbox's own, not VanillaBP's: it is NOT part of \
+            'io.vanillabp:vanillabp-schema' and gruelbox's schema migration is switched off here. \
+            Either
+            %s
+            The wiki page 'Spring Boot integration', section 'Creating the tables with Liquibase or \
+            Flyway', describes the whole procedure."""
+            .formatted(tableName, remedies));
 
   }
 


### PR DESCRIPTION
Found while building the blueprint `persistence-liquibase/springboot`, recorded as G23 in the blueprints repository.

## What was wrong

`vanillabp.outbox.create-schema` is one switch for two things. Turning it off so Liquibase or Flyway can own `VANILLABP_PHASE_TWO_OUTBOX` and `VANILLABP_TASK_DELIVERY` also turns off the migrator of gruelbox, which owns `TXNO_OUTBOX` on Spring Boot. A custom `vanillabp.outbox.jdbc.table` turns it off as well, silently, because that migration only ever targets the default name.

VanillaBP has verified its own two tables at startup since story 75. This one was verified by nobody, so an application which forgot it booted cleanly, served requests, and failed at the first workflow it started — the 3 a.m. failure story 75 set out to remove.

## What this changes

- `GruelboxPhaseTwoOutboxAutoConfiguration` verifies the outbox table wherever gruelbox's migration is off and ends the boot naming the table, the property and the remedy.
- The remedy names `DefaultPersistor.writeSchema(Writer)`, which emits gruelbox's migrations as SQL for the configured dialect. Verified against `transactionoutbox-core` 7.0.707: it produces `TXNO_OUTBOX` and `TXNO_SEQUENCE` and not `TXNO_VERSION`, which is the bookkeeping of the migrator just switched off.
- The JDBC metadata lookup existed twice (delivery store, Quarkus outbox dispatcher). It moved into the core as `JdbcSchema#tableExists` instead of being copied a third time.

## Decision

Option 3 of the story: gruelbox stays, its DDL stays the application's job, and the silence goes. An outbox of VanillaBP's own on Spring Boot remains story 26i's question.

## Tests

`GruelboxOutboxSchemaHandoverTest` (outbox-jpa-integration-test): a missing table ends the boot with that message, a table gruelbox migrated satisfies the check, a custom table name is checked the same way. Full build green on both platforms.

Docs: wiki page `Spring-Boot-integration` (new section), `spring-boot-integration/runtime/README.md`, `migration-adapter/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)