### PR TITLE
Story 89: an open task has an age, and VanillaBP says when it grew past what is allowed

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -437,6 +437,44 @@ since nothing of an ended instance can be redelivered.
 - The retention stays for everything the end of a workflow does not cover: workflows
   still running, aggregates whose workflow never ends, stores without the release.
 
+#### How old an open task is (story 89)
+
+A `@TaskId` handler leaves its task open, and from there on nothing asks whether the
+completion is still coming: the BPMS keeps redelivering the task, the core answers every
+redelivery from the record it wrote when the handler ran, and a Camunda 8 adapter renews
+the job's lock on the way. A workflow waiting forever therefore looks exactly like one
+waiting legitimately.
+
+- `TaskDelivery` carries `recordedAt`, the moment the delivery was processed. Every store
+  persisted it from the beginning, because the retention deletes by it; what story 89 added
+  is the SPI component and the mapping in the four stores. The core sets the value when it
+  builds the record, so the timestamp is the processing moment and not whatever a store's
+  clock says.
+- `MigrationProcessService.stillOpen` measures the distance to now on every redelivery
+  answered with `COMPLETION_PENDING` and compares it to
+  `MigrationAdapterProperties.maxTaskAge(module, process, task)`
+  (`vanillabp.delivery.max-task-age`, default `P30D`, `0` switching it off). The property is
+  adapter-INDEPENDENT like the rest of `DeliveryProperties`, and it resolves globally, per
+  workflow module, per workflow and per task, most specific first - which is why
+  `WorkflowAdapterProperties` and `TaskAdapterProperties` gained a `delivery` section.
+- The report is one WARN per delivery key rather than per redelivery, remembered in a
+  bounded LRU map of the process service. Forgetting an entry costs one repeated message,
+  which is why nothing durable is involved.
+- What happens beyond the report belongs to the BPMS. `WorkflowTaskOutcome` therefore
+  carries `openFor` and `maxAgeExceeded`, and an adapter which has somewhere better to put
+  the finding reads them - Camunda 8 stops renewing the lock and fails the job into an
+  incident where `async-task-max-age-action` says so. An adapter without a lock to renew
+  ignores both and the report is all that happens.
+- Deliberately no callback into the application. An application which knows its task is
+  obsolete has `ProcessService#cancelTask`; one which lost track of it could not answer a
+  liveness question truthfully anyway.
+- Residual: the record itself still expires with `vanillabp.outbox.retention`, and its
+  timestamp is never refreshed (refreshing it would erase the very age this measures). A
+  task open longer than the retention therefore loses the record which answers its
+  redelivery, exactly as before this story - the story shrinks the exposure from the old
+  fourteen-day horizon to the retention, it does not remove it. Roadmap entry 97 carries
+  the decision about what to do with a pending record when the retention passes.
+
 #### Process versions (`version` attribute)
 
 The `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
@@ -1,5 +1,7 @@
 package io.vanillabp.integration.spi;
 
+import java.time.Instant;
+
 /**
  * What VanillaBP remembers about a task delivery it processed: the delivery's
  * identity plus the outcome reported to the BPMS. Written by the core through the
@@ -28,6 +30,14 @@ package io.vanillabp.integration.spi;
  *          <code>null</code>
  * @param bpmnErrorName The BPMN error name of an outcome carrying one, otherwise
  *          <code>null</code>
+ * @param recordedAt When the delivery was processed. Every store persisted this
+ *          value from the beginning, because the retention deletes by it; it is part
+ *          of the record so the core can answer the one question a retention cannot:
+ *          how long a task has been open. A task the BPMS keeps redelivering is
+ *          answered from the record it wrote when the handler ran, so the difference
+ *          between that moment and now IS the age of the open task, and a task nobody
+ *          will ever complete is the only thing that age ever grows into. See
+ *          <code>vanillabp.delivery.max-task-age</code>
  */
 public record TaskDelivery(
                            String deliveryKey,
@@ -37,6 +47,7 @@ public record TaskDelivery(
                            String taskDefinition,
                            String outcome,
                            String bpmnErrorCode,
-                           String bpmnErrorName) {
+                           String bpmnErrorName,
+                           Instant recordedAt) {
 
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/DeliveryProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/DeliveryProperties.java
@@ -1,5 +1,7 @@
 package io.vanillabp.integration.adapter.migration.config;
 
+import java.time.Duration;
+
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -12,8 +14,11 @@ import lombok.experimental.SuperBuilder;
  * records of every BPMS live in the store of the workflow aggregate, so the question is
  * one of the application's data, not one of a BPMS.
  * <p>
- * The only setting is whether a workflow which ended releases its records - see
- * {@link #releaseOnWorkflowEnd}.
+ * Two settings live here: whether a workflow which ended releases its records
+ * ({@link #releaseOnWorkflowEnd}), and how long a task may stay open before VanillaBP
+ * says so ({@link #maxTaskAge}). Both are overridable per workflow module, and the age
+ * additionally per workflow and per task, since how long a task may legitimately wait
+ * is a property of that task rather than of the application.
  */
 @Getter
 @Setter
@@ -36,5 +41,35 @@ public class DeliveryProperties {
    * means "whatever is configured globally".
    */
   private Boolean releaseOnWorkflowEnd;
+
+  /**
+   * How long a task may stay open before VanillaBP reports it, measured from the moment
+   * the handler ran (see {@link io.vanillabp.integration.spi.TaskDelivery#recordedAt()}).
+   * A task left open by a <code>&#64;TaskId</code> handler is a task the application
+   * promised to complete later, and nothing else in VanillaBP ever asks whether that
+   * promise was kept.
+   * <p>
+   * Defaults to {@value #DEFAULT_MAX_TASK_AGE_ISO} and to reporting only. An
+   * asynchronous task waiting for a person or for a partner may legitimately run for
+   * weeks, so a default which failed such a task would be worse than the leak it looks
+   * for, while a default which never fires would leave the leak invisible. Thirty days
+   * is long enough for the legitimate cases we know of and short enough to catch a task
+   * nobody will ever complete.
+   * <p>
+   * <code>null</code> at a level means "whatever the next less specific level says";
+   * {@link Duration#ZERO} switches the check off, which is how an application whose
+   * tasks have no upper bound says so deliberately.
+   */
+  private Duration maxTaskAge;
+
+  /**
+   * The default of {@link #maxTaskAge} in ISO-8601 notation, for javadoc and messages.
+   */
+  public static final String DEFAULT_MAX_TASK_AGE_ISO = "P30D";
+
+  /**
+   * The default of {@link #maxTaskAge}: thirty days, report only.
+   */
+  public static final Duration DEFAULT_MAX_TASK_AGE = Duration.parse(DEFAULT_MAX_TASK_AGE_ISO);
 
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -1,5 +1,6 @@
 package io.vanillabp.integration.adapter.migration.config;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -703,6 +704,121 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
   }
 
   /**
+   * How long a task of the given scope may stay open before VanillaBP reports it
+   * (<code>vanillabp.delivery.max-task-age</code>, overridable per workflow module, per
+   * workflow and per task). The most specific level which configured a value wins, the
+   * same way adapter-scoped properties resolve; nothing configured anywhere means
+   * {@link DeliveryProperties#DEFAULT_MAX_TASK_AGE}.
+   * <p>
+   * A result of {@link Duration#ZERO} means the check is switched off.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID or <code>null</code>
+   * @param taskDefinition The task definition or <code>null</code>
+   * @return The maximum age, never <code>null</code>
+   */
+  public Duration maxTaskAge(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinition) {
+
+    final var module = workflowModuleId != null
+        ? workflowModules.get(workflowModuleId)
+        : null;
+    final var workflow = (module != null) && (bpmnProcessId != null)
+        ? module.getWorkflows().get(bpmnProcessId)
+        : null;
+    final var task = (workflow != null) && (taskDefinition != null)
+        ? workflow.getTasks().get(taskDefinition)
+        : null;
+
+    final var configured = Stream
+        .of(
+            task != null ? task.getDelivery() : null,
+            workflow != null ? workflow.getDelivery() : null,
+            module != null ? module.getDelivery() : null,
+            delivery)
+        .filter(java.util.Objects::nonNull)
+        .map(DeliveryProperties::getMaxTaskAge)
+        .filter(java.util.Objects::nonNull)
+        .findFirst();
+    return configured.orElse(DeliveryProperties.DEFAULT_MAX_TASK_AGE);
+
+  }
+
+  /**
+   * The property naming the decision of {@link #maxTaskAge(String, String, String)},
+   * for the message which reports a task older than it.
+   *
+   * @return The property key of the global setting
+   */
+  public static String maxTaskAgeProperty() {
+
+    return "%s.delivery.max-task-age".formatted(PREFIX);
+
+  }
+
+  /**
+   * Refuses a negative maximum age at every level it may be configured at: a negative
+   * duration would report every task on its first redelivery, which is a typo rather
+   * than a decision. Zero is allowed and switches the check off.
+   */
+  private void validateMaxTaskAge() {
+
+    final var offenders = new LinkedList<String>();
+    checkMaxTaskAge(delivery, "%s.delivery".formatted(PREFIX), offenders);
+    workflowModules
+        .values()
+        .forEach(module -> {
+          final var modulePrefix = "%s.workflow-modules.%s".formatted(PREFIX, module.getWorkflowModuleId());
+          checkMaxTaskAge(module.getDelivery(), "%s.delivery".formatted(modulePrefix), offenders);
+          module
+              .getWorkflows()
+              .values()
+              .forEach(workflow -> {
+                final var workflowPrefix = "%s.workflows.%s".formatted(modulePrefix, workflow.getBpmnProcessId());
+                checkMaxTaskAge(workflow.getDelivery(), "%s.delivery".formatted(workflowPrefix), offenders);
+                workflow
+                    .getTasks()
+                    .forEach((
+                        taskDefinition,
+                        task) -> checkMaxTaskAge(
+                            task.getDelivery(),
+                            "%s.tasks.%s.delivery".formatted(workflowPrefix, taskDefinition),
+                            offenders));
+              });
+        });
+    if (offenders.isEmpty()) {
+      return;
+    }
+    throw new IllegalStateException(
+        """
+            A negative maximum age was configured for open tasks:
+              %s
+            The value says how long a task may wait for its asynchronous completion before VanillaBP \
+            reports it, so it has to be positive - the default is %s. Use '0' to switch the report off \
+            for that scope."""
+            .formatted(
+                String.join("\n  ", offenders),
+                DeliveryProperties.DEFAULT_MAX_TASK_AGE_ISO));
+
+  }
+
+  private static void checkMaxTaskAge(
+      final DeliveryProperties properties,
+      final String keyPrefix,
+      final List<String> offenders) {
+
+    if ((properties == null) || (properties.getMaxTaskAge() == null)) {
+      return;
+    }
+    if (properties.getMaxTaskAge().isNegative()) {
+      offenders.add("%s.max-task-age".formatted(keyPrefix));
+    }
+
+  }
+
+  /**
    * Provides the resources location according to the given properties, resolved in
    * this order (story 34):
    * <ol>
@@ -884,6 +1000,7 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
       workflowAdapterCache = new WorkflowAdapterCacheProperties();
     }
     workflowAdapterCache.validate();
+    validateMaxTaskAge();
 
     if (knownWorkflowModuleIds.isEmpty()) {
       throw new IllegalStateException("No workflow-modules where given!");

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/TaskAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/TaskAdapterProperties.java
@@ -31,4 +31,12 @@ public class TaskAdapterProperties {
   @Builder.Default
   private Map<String, AdapterProperties> adapters = Map.of();
 
+  /**
+   * Overrides <code>vanillabp.delivery</code> for this task - the most specific level
+   * the maximum age of an open task may be set at, which is where it belongs: the one
+   * task waiting for a signature is the reason the whole application does not get a
+   * longer age.
+   */
+  private DeliveryProperties delivery;
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/WorkflowAdapterProperties.java
@@ -35,4 +35,12 @@ public class WorkflowAdapterProperties extends AdaptersConfigurationProperties {
   @Builder.Default
   private Map<String, TaskAdapterProperties> tasks = Map.of();
 
+  /**
+   * Overrides <code>vanillabp.delivery</code> for this workflow. Only the settings which
+   * belong to a single workflow are read here - the maximum age of an open task, since
+   * one process may wait for a partner for weeks while every other one is done in
+   * minutes.
+   */
+  private DeliveryProperties delivery;
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -42,7 +42,7 @@ public class JdbcTaskDeliveryStore {
 
   private static final String SELECT_DELIVERY = """
       SELECT WORKFLOW_MODULE_ID, BPMN_PROCESS_ID, AGGREGATE_ID, TASK_DEFINITION, OUTCOME, \
-      BPMN_ERROR_CODE, BPMN_ERROR_NAME \
+      BPMN_ERROR_CODE, BPMN_ERROR_NAME, RECORDED_AT \
       FROM %s \
       WHERE DELIVERY_KEY = ?""";
 
@@ -112,11 +112,15 @@ public class JdbcTaskDeliveryStore {
           if (!resultSet.next()) {
             return Optional.empty();
           }
+          final var recordedAt = resultSet.getTimestamp(8);
           return Optional
               .of(
                   new TaskDelivery(
                       deliveryKey, resultSet.getString(1), resultSet.getString(2), resultSet.getString(3), resultSet
-                          .getString(4), resultSet.getString(5), resultSet.getString(6), resultSet.getString(7)));
+                          .getString(4), resultSet.getString(5), resultSet.getString(6), resultSet
+                              .getString(7), recordedAt == null
+                                  ? null
+                                  : recordedAt.toInstant()));
         }
       }
     } catch (final SQLException e) {
@@ -151,7 +155,11 @@ public class JdbcTaskDeliveryStore {
         statement.setString(6, delivery.outcome());
         statement.setString(7, delivery.bpmnErrorCode());
         statement.setString(8, delivery.bpmnErrorName());
-        statement.setTimestamp(9, Timestamp.from(Instant.now()));
+        statement.setTimestamp(
+            9,
+            Timestamp.from(delivery.recordedAt() == null
+                ? Instant.now()
+                : delivery.recordedAt()));
         statement.executeUpdate();
       }
       return true;

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -895,7 +895,8 @@ public class MigrationProcessService<A> {
     deliveryLog.record(
         new TaskDelivery(
             deliveryKey, workflowModuleId, bpmnProcessId, context.getWorkflowAggregateId(), context
-                .getTaskDefinition(), outcome.kind().name(), outcome.errorCode(), outcome.errorName()));
+                .getTaskDefinition(), outcome.kind().name(), outcome.errorCode(), outcome
+                    .errorName(), java.time.Instant.now()));
 
   }
 
@@ -914,7 +915,7 @@ public class MigrationProcessService<A> {
           .of(
               switch (WorkflowTaskOutcome.Kind.valueOf(delivery.outcome())) {
                 case COMPLETED -> WorkflowTaskOutcome.completed();
-                case COMPLETION_PENDING -> WorkflowTaskOutcome.completionPending();
+                case COMPLETION_PENDING -> stillOpen(delivery, context);
                 case BPMN_ERROR -> WorkflowTaskOutcome
                     .bpmnError(delivery.bpmnErrorCode(), delivery.bpmnErrorName());
               });
@@ -929,6 +930,98 @@ public class MigrationProcessService<A> {
           delivery.outcome());
       return java.util.Optional.empty();
     }
+
+  }
+
+  /**
+   * How long a task left open by a <code>&#64;TaskId</code> handler has been waiting,
+   * and whether that passed the maximum age configured for it
+   * (<code>vanillabp.delivery.max-task-age</code>, resolvable per workflow module,
+   * workflow and task).
+   * <p>
+   * This is the one place in VanillaBP which can answer the question at all. The record
+   * was written when the handler ran and it is what answers every redelivery of that
+   * task, so the distance between its timestamp and now IS the age of the open task -
+   * no clock, no scheduler and no second bookkeeping are involved, and the granularity
+   * follows whatever rhythm the BPMS redelivers in.
+   * <p>
+   * Reporting is one WARN per task, not one per redelivery: a task open for a year would
+   * otherwise fill the log with the same line every time its lock is renewed. The memory
+   * of what was already reported is bounded and lives in this process service - losing
+   * an entry costs one repeated WARN, which is why it needs nothing durable.
+   *
+   * @param delivery The record answering this delivery
+   * @param context The invocation context of the repeated delivery
+   * @return The outcome, carrying the age and whether it passed the maximum
+   */
+  private WorkflowTaskOutcome stillOpen(
+      final TaskDelivery delivery,
+      final TaskInvocationContext context) {
+
+    if (delivery.recordedAt() == null) {
+      // a store written before the timestamp was part of the record - the task is
+      // open, its age is simply not known
+      return WorkflowTaskOutcome.completionPending();
+    }
+    final var openFor = java.time.Duration.between(delivery.recordedAt(), java.time.Instant.now());
+    final var maxTaskAge = properties == null
+        ? io.vanillabp.integration.adapter.migration.config.DeliveryProperties.DEFAULT_MAX_TASK_AGE
+        : properties.maxTaskAge(workflowModuleId, bpmnProcessId, context.getTaskDefinition());
+    final var exceeded = !maxTaskAge.isZero() && (openFor.compareTo(maxTaskAge) > 0);
+    if (exceeded && reportTaskAgeOnce(delivery.deliveryKey())) {
+      log.warn(
+          """
+              Task '{}' of BPMN process '{}' of workflow module '{}' has been waiting for its \
+              asynchronous completion for {}, which is longer than the {} configured by '{}' for it. \
+              Workflow aggregate: '{}'. Either the application still owes this task a \
+              'ProcessService#completeTask' respectively 'cancelTask', or nobody will ever send it \
+              and the workflow waits forever. Raise the maximum age where such a wait is legitimate \
+              (it may be set per workflow module, workflow and task), or set it to '0' to switch \
+              this report off.""",
+          context.getTaskDefinition(),
+          bpmnProcessId,
+          workflowModuleId,
+          openFor,
+          maxTaskAge,
+          MigrationAdapterProperties.maxTaskAgeProperty(),
+          context.getWorkflowAggregateId());
+    }
+    return WorkflowTaskOutcome.completionPending(openFor, exceeded);
+
+  }
+
+  /**
+   * How many open tasks this process service remembers having reported. A bound rather
+   * than a growing set: the entry is a hint, and forgetting one costs one repeated WARN.
+   */
+  private static final int REPORTED_TASK_AGES = 1000;
+
+  private final java.util.Map<String, Boolean> reportedTaskAges = java.util.Collections
+      .synchronizedMap(new java.util.LinkedHashMap<String, Boolean>(16, 0.75f, true) {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        protected boolean removeEldestEntry(
+            final java.util.Map.Entry<String, Boolean> eldest) {
+
+          return size() > REPORTED_TASK_AGES;
+
+        }
+
+      });
+
+  /**
+   * Whether the given task's age is reported now - <code>true</code> exactly once per
+   * delivery key, which is once per task.
+   *
+   * @param deliveryKey The identity of the delivery answering this task
+   * @return Whether to log the report
+   */
+  private boolean reportTaskAgeOnce(
+      final String deliveryKey) {
+
+    return reportedTaskAges.putIfAbsent(deliveryKey, Boolean.TRUE) == null;
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/DeliveryRecordReleaseTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/DeliveryRecordReleaseTest.java
@@ -186,7 +186,7 @@ public class DeliveryRecordReleaseTest {
           .put(
               key,
               new TaskDelivery(
-                  key, workflowModuleId, bpmnProcessId, aggregateId, "task", "COMPLETED", null, null));
+                  key, workflowModuleId, bpmnProcessId, aggregateId, "task", "COMPLETED", null, null, when));
       recordedAt.put(key, when);
 
     }

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/InboundIdempotencyTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/InboundIdempotencyTest.java
@@ -509,7 +509,8 @@ public class InboundIdempotencyTest {
         key,
         new TaskDelivery(
             key, recorded.workflowModuleId(), recorded.bpmnProcessId(), recorded
-                .workflowAggregateId(), recorded.taskDefinition(), "WHATEVER", null, null));
+                .workflowAggregateId(), recorded.taskDefinition(), "WHATEVER", null, null, recorded
+                    .recordedAt()));
 
     final var messages = loggedBy(
         MigrationProcessService.class,

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskAgeTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskAgeTest.java
@@ -1,0 +1,515 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
+import io.vanillabp.integration.adapter.migration.config.DeliveryProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.TaskAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowAdapterProperties;
+import io.vanillabp.integration.adapter.migration.config.WorkflowModuleAdapterProperties;
+import io.vanillabp.integration.adapter.migration.processservice.MigrationProcessService;
+import io.vanillabp.integration.adapter.migration.processservice.TaskDeliveryLogResolver;
+import io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry;
+import io.vanillabp.integration.adapter.spi.MigratableProcessService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.spi.TaskDeliveryLog;
+import io.vanillabp.integration.spi.TransactionRunner;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.service.TaskId;
+import io.vanillabp.spi.service.WorkflowTask;
+
+/**
+ * Story 89: how old an open task is, and what VanillaBP does about it.
+ * <p>
+ * A task left open by a <code>&#64;TaskId</code> handler is answered from its delivery
+ * record on every redelivery, which is what keeps the handler from running twice. The
+ * record carries the moment the handler ran, so the core can measure how long the
+ * application has owed that task its completion - the generic half of the story, which
+ * holds for every BPMS. What is pinned here:
+ * <ul>
+ * <li>a redelivery of an open task reports COMPLETION_PENDING and does not touch the
+ * workflow aggregate;</li>
+ * <li>the outcome carries the age, which is the distance to the recorded moment;</li>
+ * <li>a task older than <code>vanillabp.delivery.max-task-age</code> is reported ONCE, by
+ * a message naming the workflow module, the process, the aggregate and the age, and the
+ * outcome says so - which is what a BPMS-specific reaction hangs on;</li>
+ * <li>the maximum age resolves per workflow module, workflow and task, most specific
+ * wins, and zero switches the report off.</li>
+ * </ul>
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OpenTaskAgeTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TestProcess";
+
+  private static final String ADAPTER = "test-adapter";
+
+  private static final String TASK = "asyncTask";
+
+  public static class Aggregate {
+
+    String id;
+
+    int invocations;
+
+    public String getId() {
+      return id;
+    }
+
+  }
+
+  static class InMemoryPersistence implements AggregatePersistenceAware<Aggregate> {
+
+    final Map<Object, Aggregate> aggregates = new HashMap<>();
+
+    @Override
+    public Class<Aggregate> getAggregateClass() {
+      return Aggregate.class;
+    }
+
+    @Override
+    public String getAggregateIdName() {
+      return "id";
+    }
+
+    @Override
+    public Class<?> getAggregateIdType() {
+      return String.class;
+    }
+
+    @Override
+    public Object getAggregateId(
+        final Aggregate aggregate) {
+      return aggregate.id;
+    }
+
+    @Override
+    public Aggregate save(
+        final Aggregate aggregate) {
+      aggregates.put(aggregate.id, aggregate);
+      return aggregate;
+    }
+
+    @Override
+    public Aggregate loadById(
+        final Object aggregateId) {
+      return aggregates.get(aggregateId);
+    }
+
+  }
+
+  static class TransactionRunnerStub implements TransactionRunner {
+
+    @Override
+    public <T> T requireNew(
+        final Supplier<T> work) {
+      return work.get();
+    }
+
+    @Override
+    public <T> T inCurrent(
+        final Supplier<T> work) {
+      return requireNew(work);
+    }
+
+    @Override
+    public boolean isRollbackOnly() {
+      return false;
+    }
+
+  }
+
+  /**
+   * A delivery log in memory whose records may be BACKDATED - which is how a task open
+   * for thirty days is tested without waiting for them.
+   */
+  static class InMemoryDeliveryLog implements TaskDeliveryLog {
+
+    final Map<String, TaskDelivery> records = new HashMap<>();
+
+    final List<String> recorded = new ArrayList<>();
+
+    @Override
+    public Optional<TaskDelivery> recordedDelivery(
+        final String deliveryKey) {
+      return Optional.ofNullable(records.get(deliveryKey));
+    }
+
+    @Override
+    public boolean record(
+        final TaskDelivery delivery) {
+      recorded.add(delivery.deliveryKey());
+      return records.putIfAbsent(delivery.deliveryKey(), delivery) == null;
+    }
+
+    void backdateBy(
+        final Duration age) {
+
+      records
+          .replaceAll(
+              (
+                  key,
+                  delivery) -> new TaskDelivery(
+                      delivery.deliveryKey(), delivery.workflowModuleId(), delivery.bpmnProcessId(), delivery
+                          .workflowAggregateId(), delivery.taskDefinition(), delivery.outcome(), delivery
+                              .bpmnErrorCode(), delivery.bpmnErrorName(), Instant.now().minus(age)));
+
+    }
+
+  }
+
+  public static class TestWorkflowService {
+
+    /**
+     * A task the application completes later - the only kind which can be left open.
+     */
+    @WorkflowTask(taskDefinition = TASK)
+    public void asyncTask(
+        final Aggregate aggregate,
+        @TaskId final String taskId) {
+
+      aggregate.invocations++;
+
+    }
+
+  }
+
+  private final InMemoryPersistence persistence = new InMemoryPersistence();
+
+  private final InMemoryDeliveryLog deliveryLog = new InMemoryDeliveryLog();
+
+  /**
+   * Properties configuring the maximum age at the given levels - <code>null</code> means
+   * "not configured there", so the most-specific-wins resolution can be exercised.
+   */
+  private MigrationAdapterProperties properties(
+      final Duration global,
+      final Duration moduleLevel,
+      final Duration workflowLevel,
+      final Duration taskLevel) {
+
+    final var task = TaskAdapterProperties
+        .builder()
+        .delivery(deliveryProperties(taskLevel))
+        .build();
+
+    final var workflow = WorkflowAdapterProperties
+        .builder()
+        .tasks(Map.of(TASK, task))
+        .delivery(deliveryProperties(workflowLevel))
+        .build();
+
+    final var workflowModule = WorkflowModuleAdapterProperties
+        .builder()
+        .workflows(Map.of(PROCESS, workflow))
+        .delivery(deliveryProperties(moduleLevel))
+        .build();
+
+    final var properties = MigrationAdapterProperties
+        .builder()
+        .adapters(Map.of(ADAPTER, AdapterConfigProperties.ofType("dummy")))
+        .prioritizedAdapters(List.of(ADAPTER))
+        .workflowModules(Map.of(MODULE, workflowModule))
+        .delivery(deliveryProperties(global))
+        .build();
+    properties.validateAndLink();
+    return properties;
+
+  }
+
+  private static DeliveryProperties deliveryProperties(
+      final Duration maxTaskAge) {
+
+    if (maxTaskAge == null) {
+      return null;
+    }
+    final var properties = new DeliveryProperties();
+    properties.setMaxTaskAge(maxTaskAge);
+    return properties;
+
+  }
+
+  private WorkflowTaskRegistry registry(
+      final MigrationAdapterProperties properties) {
+
+    @SuppressWarnings("unchecked")
+    final MigratableProcessService<Aggregate> adapter = mock(MigratableProcessService.class);
+    lenient().when(adapter.getAdapterId()).thenReturn(ADAPTER);
+    lenient().when(adapter.deliversTasksAtLeastOnce()).thenReturn(true);
+
+    final TaskDeliveryLogResolver resolver = new TaskDeliveryLogResolver() {
+
+      @Override
+      public TaskDeliveryLog resolveFor(
+          final Class<?> workflowAggregateClass) {
+        return deliveryLog;
+      }
+
+      @Override
+      public String remediesDescription() {
+        return "- add a store, or";
+      }
+
+    };
+
+    final var processService = new MigrationProcessService<>(
+        MODULE, PROCESS, Aggregate.class, properties, persistence, List.of(adapter), null, null, resolver);
+
+    final var registry = new WorkflowTaskRegistry(new TransactionRunnerStub());
+    registry.registerWorkflowService(
+        MODULE,
+        PROCESS,
+        TestWorkflowService.class,
+        TestWorkflowService::new,
+        type -> null,
+        processService);
+    return registry;
+
+  }
+
+  private Aggregate storeAggregate(
+      final String id) {
+
+    final var aggregate = new Aggregate();
+    aggregate.id = id;
+    persistence.aggregates.put(id, aggregate);
+    return aggregate;
+
+  }
+
+  private TaskInvocationContext delivery(
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return TASK;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getTaskId() {
+        return deliveryId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("A redelivery of an open task reports it as pending and leaves the aggregate alone")
+  public void aRedeliveryOfAnOpenTaskDoesNotTouchTheAggregate() {
+
+    final var testee = registry(properties(null, null, null, null));
+    storeAggregate("4711");
+
+    final var first = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4711", "job-1"));
+    final var second = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4711", "job-1"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, first.kind());
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, second.kind());
+    assertEquals(1, persistence.aggregates.get("4711").invocations, "the handler ran exactly once");
+    assertEquals(1, deliveryLog.recorded.size(), "the delivery was recorded once");
+    assertNotNull(second.openFor(), "the redelivery knows how long the task has been open");
+    assertFalse(second.maxAgeExceeded(), "a task open for milliseconds is not old");
+
+  }
+
+  @Test
+  @DisplayName("A task older than the maximum age is reported exactly once, naming the age")
+  public void anOverdueTaskIsReportedOnce() {
+
+    final var testee = registry(properties(Duration.ofHours(1), null, null, null));
+    storeAggregate("4712");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4712", "job-1"));
+    deliveryLog.backdateBy(Duration.ofHours(3));
+
+    final var messages = new ArrayList<String>();
+    final var second = loggedBy(
+        messages,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4712", "job-1")));
+
+    assertTrue(second.maxAgeExceeded(), "the outcome says the task is overdue");
+    assertTrue(second.openFor().toHours() >= 3, "the age is what the record says");
+    assertEquals(1, messages.size(), "exactly one message");
+    final var message = messages.getFirst();
+    assertTrue(message.contains(MODULE), "names the workflow module");
+    assertTrue(message.contains(PROCESS), "names the BPMN process");
+    assertTrue(message.contains("4712"), "names the workflow aggregate");
+    assertTrue(message.contains(TASK), "names the task");
+    assertTrue(message.contains("PT3H"), "names the age");
+    assertTrue(message.contains("vanillabp.delivery.max-task-age"), "names the property");
+
+    // the lock of an open task is renewed by every redelivery - the report is about the
+    // task, not about the renewal
+    final var repeated = new ArrayList<String>();
+    final var third = loggedBy(
+        repeated,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4712", "job-1")));
+    assertTrue(third.maxAgeExceeded(), "the task is still overdue");
+    assertTrue(repeated.isEmpty(), "and it is not reported a second time");
+
+  }
+
+  @Test
+  @DisplayName("The maximum age resolves per workflow module, workflow and task")
+  public void theMaximumAgeResolvesMostSpecificFirst() {
+
+    assertEquals(
+        DeliveryProperties.DEFAULT_MAX_TASK_AGE,
+        properties(null, null, null, null).maxTaskAge(MODULE, PROCESS, TASK),
+        "nothing configured anywhere is thirty days");
+    assertEquals(
+        Duration.ofDays(1),
+        properties(Duration.ofDays(1), null, null, null).maxTaskAge(MODULE, PROCESS, TASK));
+    assertEquals(
+        Duration.ofDays(2),
+        properties(Duration.ofDays(1), Duration.ofDays(2), null, null).maxTaskAge(MODULE, PROCESS, TASK));
+    assertEquals(
+        Duration.ofDays(3),
+        properties(Duration.ofDays(1), Duration.ofDays(2), Duration.ofDays(3), null)
+            .maxTaskAge(MODULE, PROCESS, TASK));
+    assertEquals(
+        Duration.ofDays(4),
+        properties(Duration.ofDays(1), Duration.ofDays(2), Duration.ofDays(3), Duration.ofDays(4))
+            .maxTaskAge(MODULE, PROCESS, TASK));
+    assertEquals(
+        Duration.ofDays(2),
+        properties(Duration.ofDays(1), Duration.ofDays(2), Duration.ofDays(3), Duration.ofDays(4))
+            .maxTaskAge(MODULE, "AnotherProcess", TASK),
+        "a workflow nobody configured falls back to its module");
+
+  }
+
+  @Test
+  @DisplayName("A maximum age of zero switches the report off")
+  public void zeroSwitchesTheReportOff() {
+
+    final var testee = registry(properties(Duration.ZERO, null, null, null));
+    storeAggregate("4713");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4713", "job-1"));
+    deliveryLog.backdateBy(Duration.ofDays(400));
+
+    final var messages = new ArrayList<String>();
+    final var second = loggedBy(
+        messages,
+        () -> testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4713", "job-1")));
+
+    assertFalse(second.maxAgeExceeded(), "nothing is overdue where no maximum applies");
+    assertTrue(messages.isEmpty(), "and nothing is reported");
+    assertNotNull(second.openFor(), "the age is still known - only the judgement is off");
+
+  }
+
+  @Test
+  @DisplayName("A record written before the timestamp existed reports no age")
+  public void aRecordWithoutATimestampReportsNoAge() {
+
+    final var testee = registry(properties(Duration.ofHours(1), null, null, null));
+    storeAggregate("4714");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4714", "job-1"));
+    deliveryLog.records
+        .replaceAll(
+            (
+                key,
+                delivery) -> new TaskDelivery(
+                    delivery.deliveryKey(), delivery.workflowModuleId(), delivery.bpmnProcessId(), delivery
+                        .workflowAggregateId(), delivery.taskDefinition(), delivery.outcome(), delivery
+                            .bpmnErrorCode(), delivery.bpmnErrorName(), null));
+
+    final var second = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4714", "job-1"));
+
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, second.kind());
+    assertEquals(null, second.openFor(), "an unknown age is not a zero age");
+    assertFalse(second.maxAgeExceeded());
+
+  }
+
+  @Test
+  @DisplayName("A negative maximum age fails the startup naming the property")
+  public void aNegativeMaximumAgeFailsTheStartup() {
+
+    final var properties = properties(Duration.ofDays(1), Duration.ofDays(-1), null, null);
+
+    final var exception = assertThrows(
+        IllegalStateException.class,
+        () -> properties.validateProperties(List.of("dummy"), List.of(MODULE)));
+
+    assertTrue(
+        exception.getMessage().contains("vanillabp.workflow-modules.test-module.delivery.max-task-age"),
+        "names the level which carries the value: "
+            + exception.getMessage());
+    assertTrue(exception.getMessage().contains("P30D"), "names the default");
+
+  }
+
+  /**
+   * Runs the given work and collects the warnings the core emitted while it ran.
+   */
+  private WorkflowTaskOutcome loggedBy(
+      final List<String> messages,
+      final Supplier<WorkflowTaskOutcome> work) {
+
+    final var logWatcher = new ch.qos.logback.core.read.ListAppender<ch.qos.logback.classic.spi.ILoggingEvent>();
+    logWatcher.start();
+    final var logger = (ch.qos.logback.classic.Logger) org.slf4j.LoggerFactory
+        .getLogger(MigrationProcessService.class);
+    logger.addAppender(logWatcher);
+    try {
+      return work.get();
+    } finally {
+      logger.detachAndStopAllAppenders();
+      logWatcher.list
+          .stream()
+          .filter(event -> event.getLevel().isGreaterOrEqual(ch.qos.logback.classic.Level.WARN))
+          .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
+          .forEach(messages::add);
+    }
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskOutcome.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskOutcome.java
@@ -1,5 +1,7 @@
 package io.vanillabp.integration.adapter.spi.workflowtask;
 
+import java.time.Duration;
+
 /**
  * The outcome of processing a BPMN task by a <code>&#64;WorkflowTask</code> method,
  * returned by
@@ -24,16 +26,44 @@ package io.vanillabp.integration.adapter.spi.workflowtask;
  * @param kind The outcome kind
  * @param errorCode The BPMN error code ({@link Kind#BPMN_ERROR} only)
  * @param errorName The BPMN error name ({@link Kind#BPMN_ERROR} only)
+ * @param openFor How long the task has been open ({@link Kind#COMPLETION_PENDING}
+ *          only, <code>null</code> otherwise and on the first delivery): the core
+ *          measures it from the record it wrote when the handler ran, so an adapter
+ *          learns the age of a task without keeping a clock of its own
+ * @param maxAgeExceeded Whether {@link #openFor()} passed the maximum age configured
+ *          for this task (<code>vanillabp.delivery.max-task-age</code>). The core
+ *          reports it once per task; an adapter whose BPMS has somewhere better to
+ *          put it than a log line reacts in addition, see
+ *          <code>async-task-max-age-action</code> of the Camunda 8 adapter
  */
 public record WorkflowTaskOutcome(
                                   Kind kind,
                                   String errorCode,
-                                  String errorName) {
+                                  String errorName,
+                                  Duration openFor,
+                                  boolean maxAgeExceeded) {
 
   public enum Kind {
     COMPLETED,
     COMPLETION_PENDING,
     BPMN_ERROR
+  }
+
+  /**
+   * An outcome which says nothing about the age of an open task - what every outcome
+   * besides a repeated {@link Kind#COMPLETION_PENDING} is.
+   *
+   * @param kind The outcome kind
+   * @param errorCode The BPMN error code ({@link Kind#BPMN_ERROR} only)
+   * @param errorName The BPMN error name ({@link Kind#BPMN_ERROR} only)
+   */
+  public WorkflowTaskOutcome(
+      final Kind kind,
+      final String errorCode,
+      final String errorName) {
+
+    this(kind, errorCode, errorName, null, false);
+
   }
 
   public static WorkflowTaskOutcome completed() {
@@ -45,6 +75,22 @@ public record WorkflowTaskOutcome(
   public static WorkflowTaskOutcome completionPending() {
 
     return new WorkflowTaskOutcome(Kind.COMPLETION_PENDING, null, null);
+
+  }
+
+  /**
+   * The outcome of a task which is still waiting for its asynchronous completion,
+   * carrying how long it has been waiting.
+   *
+   * @param openFor How long the task has been open
+   * @param maxAgeExceeded Whether that passed the configured maximum age
+   * @return The outcome
+   */
+  public static WorkflowTaskOutcome completionPending(
+      final Duration openFor,
+      final boolean maxAgeExceeded) {
+
+    return new WorkflowTaskOutcome(Kind.COMPLETION_PENDING, null, null, openFor, maxAgeExceeded);
 
   }
 

--- a/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
+++ b/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoTaskDeliveryLogTest.java
@@ -75,7 +75,8 @@ public class MongoTaskDeliveryLogTest {
       final String outcome) {
 
     return new TaskDelivery(
-        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed");
+        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed", java.time.Instant
+            .now());
 
   }
 
@@ -147,7 +148,8 @@ public class MongoTaskDeliveryLogTest {
       final String workflowAggregateId) {
 
     return new TaskDelivery(
-        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null);
+        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null, java.time.Instant
+            .now());
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -473,6 +473,16 @@ public interface QuarkusMigrationAdapterProperties {
      */
     Optional<Boolean> releaseOnWorkflowEnd();
 
+    /**
+     * How long a task may stay open before VanillaBP reports it. The default is thirty
+     * days and reporting only, see the core's
+     * {@link io.vanillabp.integration.adapter.migration.config.DeliveryProperties#getMaxTaskAge()}.
+     *
+     * @return The setting, an empty Optional meaning "whatever the next less specific
+     *         level says"
+     */
+    Optional<Duration> maxTaskAge();
+
   }
 
   /**
@@ -499,6 +509,13 @@ public interface QuarkusMigrationAdapterProperties {
      */
     Map<String, TaskProperties> tasks();
 
+    /**
+     * Overrides <code>vanillabp.delivery</code> for this workflow.
+     *
+     * @return The delivery configuration of this workflow
+     */
+    DeliveryProperties delivery();
+
   }
 
   /**
@@ -511,6 +528,14 @@ public interface QuarkusMigrationAdapterProperties {
      * The properties of adapters specific to this task.
      */
     Map<String, AdapterProperties> adapters();
+
+    /**
+     * Overrides <code>vanillabp.delivery</code> for this task - the most specific level
+     * the maximum age of an open task may be set at.
+     *
+     * @return The delivery configuration of this task
+     */
+    DeliveryProperties delivery();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
@@ -73,6 +73,7 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
       QuarkusMigrationAdapterProperties.TransactionsProperties transactionsProperties);
 
   @Mapping(target = "releaseOnWorkflowEnd", qualifiedByName = "unwrapBoolean")
+  @Mapping(target = "maxTaskAge", qualifiedByName = "unwrapDuration")
   DeliveryProperties toCore(
       QuarkusMigrationAdapterProperties.DeliveryProperties deliveryProperties);
 
@@ -153,6 +154,21 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
   @Named("unwrapBoolean")
   default Boolean unwrapBoolean(
       final Optional<Boolean> value) {
+
+    return value.orElse(null);
+
+  }
+
+  /**
+   * Unwraps an optional duration ({@code Optional.empty()} becomes {@code null}: a level
+   * which says nothing inherits what the next less specific one configured).
+   *
+   * @param value The optional duration
+   * @return The duration or {@code null}
+   */
+  @Named("unwrapDuration")
+  default java.time.Duration unwrapDuration(
+      final Optional<java.time.Duration> value) {
 
     return value.orElse(null);
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
@@ -172,7 +172,10 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
         .map(document -> new TaskDelivery(
             deliveryKey, document.getString("workflowModuleId"), document.getString("bpmnProcessId"), document
                 .getString("aggregateId"), document.getString("taskDefinition"), document
-                    .getString("outcome"), document.getString("bpmnErrorCode"), document.getString("bpmnErrorName")));
+                    .getString("outcome"), document.getString("bpmnErrorCode"), document
+                        .getString("bpmnErrorName"), document.getDate("recordedAt") == null
+                            ? null
+                            : document.getDate("recordedAt").toInstant()));
 
   }
 
@@ -195,7 +198,11 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
         .append("outcome", delivery.outcome())
         .append("bpmnErrorCode", delivery.bpmnErrorCode())
         .append("bpmnErrorName", delivery.bpmnErrorName())
-        .append("recordedAt", Date.from(java.time.Instant.now()));
+        .append(
+            "recordedAt",
+            Date.from(delivery.recordedAt() == null
+                ? java.time.Instant.now()
+                : delivery.recordedAt()));
     // a duplicate-key error inside a MongoDB transaction would abort it entirely, so the
     // common duplicate is read instead - the unique document ID stays the backstop
     if ((session != null) && (collection

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -54,13 +54,39 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
   }
 
   private record TaskProperties(
-                                Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters) implements QuarkusMigrationAdapterProperties.TaskProperties {
+                                Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
+                                QuarkusMigrationAdapterProperties.DeliveryProperties delivery) implements QuarkusMigrationAdapterProperties.TaskProperties {
+
+    /**
+     * Without a delivery section, which is what most of these fixtures need.
+     */
+    private TaskProperties(
+        final Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters) {
+
+      this(adapters, null);
+
+    }
+
   }
 
   private record WorkflowProperties(
                                     Optional<List<String>> prioritizedAdapters,
                                     Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
-                                    Map<String, QuarkusMigrationAdapterProperties.TaskProperties> tasks) implements QuarkusMigrationAdapterProperties.WorkflowProperties {
+                                    Map<String, QuarkusMigrationAdapterProperties.TaskProperties> tasks,
+                                    QuarkusMigrationAdapterProperties.DeliveryProperties delivery) implements QuarkusMigrationAdapterProperties.WorkflowProperties {
+
+    /**
+     * Without a delivery section, which is what most of these fixtures need.
+     */
+    private WorkflowProperties(
+        final Optional<List<String>> prioritizedAdapters,
+        final Map<String, QuarkusMigrationAdapterProperties.AdapterProperties> adapters,
+        final Map<String, QuarkusMigrationAdapterProperties.TaskProperties> tasks) {
+
+      this(prioritizedAdapters, adapters, tasks, null);
+
+    }
+
   }
 
   private record WorkflowModuleProperties(
@@ -103,7 +129,20 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
   }
 
   private record DeliveryProperties(
-                                    Optional<Boolean> releaseOnWorkflowEnd) implements QuarkusMigrationAdapterProperties.DeliveryProperties {
+                                    Optional<Boolean> releaseOnWorkflowEnd,
+                                    Optional<Duration> maxTaskAge) implements QuarkusMigrationAdapterProperties.DeliveryProperties {
+
+    /**
+     * Only the release setting, which is what the fixtures written before the maximum
+     * age existed need.
+     */
+    private DeliveryProperties(
+        final Optional<Boolean> releaseOnWorkflowEnd) {
+
+      this(releaseOnWorkflowEnd, Optional.empty());
+
+    }
+
   }
 
   private record JdbcOutboxProperties(
@@ -388,6 +427,32 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
     assertTrue(core.releasesDeliveryRecordsOnWorkflowEnd("loan-approval"));
     assertFalse(core.releasesDeliveryRecordsOnWorkflowEnd("payments"));
     assertFalse(core.releasesDeliveryRecordsOnWorkflowEnd("unconfigured-module"));
+
+  }
+
+  @Test
+  @DisplayName("Story 89: the maximum age of an open task travels through all four levels")
+  public void maxTaskAgeTravelsThroughEveryLevel() {
+
+    final var task = new TaskProperties(
+        Map.of(), new DeliveryProperties(Optional.empty(), Optional.of(Duration.ofDays(40))));
+    final var workflow = new WorkflowProperties(
+        Optional.empty(), Map.of(), Map.of("awaitSignature", task), new DeliveryProperties(
+            Optional.empty(), Optional.of(Duration.ofDays(30))));
+    final var module = new WorkflowModuleProperties(
+        Optional.empty(), Map.of(), Map.of("LoanApproval", workflow), null, new DeliveryProperties(
+            Optional.empty(), Optional.of(Duration.ofDays(20))));
+    final var properties = new Properties(
+        Optional.empty(), Optional.empty(), Map.of(), Map.of("loan-approval",
+            module), null, null, null, new DeliveryProperties(Optional.empty(), Optional.of(Duration.ofDays(10))));
+
+    final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
+    core.validateAndLink();
+
+    assertEquals(Duration.ofDays(10), core.maxTaskAge("payments", null, null));
+    assertEquals(Duration.ofDays(20), core.maxTaskAge("loan-approval", "OtherProcess", null));
+    assertEquals(Duration.ofDays(30), core.maxTaskAge("loan-approval", "LoanApproval", "otherTask"));
+    assertEquals(Duration.ofDays(40), core.maxTaskAge("loan-approval", "LoanApproval", "awaitSignature"));
 
   }
 

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoDeliveryLogCompensationTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoDeliveryLogCompensationTest.java
@@ -86,7 +86,8 @@ public class MongoDeliveryLogCompensationTest {
       final String key) {
 
     return new TaskDelivery(
-        key, "test-module", "SampleWorkflowService", "4711", "someTask", "COMPLETED", null, null);
+        key, "test-module", "SampleWorkflowService", "4711", "someTask", "COMPLETED", null, null, java.time.Instant
+            .now());
 
   }
 

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoOneTransactionTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoOneTransactionTest.java
@@ -129,7 +129,7 @@ public class MongoOneTransactionTest {
           .record(
               new TaskDelivery(
                   "test-module|SampleWorkflowService|one-transaction|job-1", "test-module", "SampleWorkflowService", started
-                      .getId(), "someTask", "COMPLETED", null, null));
+                      .getId(), "someTask", "COMPLETED", null, null, java.time.Instant.now()));
 
       // still inside the transaction: nothing of this is visible to anybody else
       assertEquals(0, visibleOutside("outbox-test-aggregate"), "the aggregate was written before the commit");
@@ -159,7 +159,7 @@ public class MongoOneTransactionTest {
               .record(
                   new TaskDelivery(
                       "test-module|SampleWorkflowService|rolled-back|job-1", "test-module", "SampleWorkflowService", started
-                          .getId(), "someTask", "COMPLETED", null, null));
+                          .getId(), "someTask", "COMPLETED", null, null, java.time.Instant.now()));
           throw new RuntimeException("no commit for this one");
         }));
 

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
@@ -90,7 +90,8 @@ public class MongoTaskDeliveryLogTest {
       final String outcome) {
 
     return new TaskDelivery(
-        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed");
+        deliveryKey, "test-module", "TestProcess", "4711", "processTask", outcome, "PAYMENT_FAILED", "PaymentFailed", java.time.Instant
+            .now());
 
   }
 
@@ -156,7 +157,8 @@ public class MongoTaskDeliveryLogTest {
       final String workflowAggregateId) {
 
     return new TaskDelivery(
-        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null);
+        deliveryKey, workflowModuleId, bpmnProcessId, workflowAggregateId, "processTask", "COMPLETED", null, null, java.time.Instant
+            .now());
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
@@ -89,7 +89,8 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
         .map(document -> new TaskDelivery(
             document.getId(), document.getWorkflowModuleId(), document.getBpmnProcessId(), document
                 .getAggregateId(), document.getTaskDefinition(), document
-                    .getOutcome(), document.getBpmnErrorCode(), document.getBpmnErrorName()));
+                    .getOutcome(), document.getBpmnErrorCode(), document
+                        .getBpmnErrorName(), document.getRecordedAt()));
 
   }
 
@@ -115,7 +116,9 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
           new TaskDeliveryDocument(
               delivery.deliveryKey(), delivery.workflowModuleId(), delivery.bpmnProcessId(), delivery
                   .workflowAggregateId(), delivery.taskDefinition(), delivery
-                      .outcome(), delivery.bpmnErrorCode(), delivery.bpmnErrorName(), Instant.now()),
+                      .outcome(), delivery.bpmnErrorCode(), delivery.bpmnErrorName(), delivery.recordedAt() == null
+                          ? Instant.now()
+                          : delivery.recordedAt()),
           collection);
       compensateUnlessCommitted(delivery);
       return true;

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/config/VanillaBpConfigurationBindingTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/config/VanillaBpConfigurationBindingTest.java
@@ -299,6 +299,33 @@ public class VanillaBpConfigurationBindingTest {
   }
 
   @Test
+  @DisplayName("Story 89: the maximum age of an open task binds at all four levels")
+  public void maxTaskAgeBindsAtEveryLevel() {
+
+    contextRunner
+        .withPropertyValues(
+            "vanillabp.resources-location=classpath*:vanillabp-processes",
+            "vanillabp.adapters.test.type=dummy",
+            "vanillabp.workflow-modules.test-module.prioritized-adapters=test",
+            "vanillabp.delivery.max-task-age=P10D",
+            "vanillabp.workflow-modules.test-module.delivery.max-task-age=P20D",
+            "vanillabp.workflow-modules.test-module.workflows.TestProcess.delivery.max-task-age=P30D",
+            "vanillabp.workflow-modules.test-module.workflows.TestProcess.tasks.awaitSignature.delivery.max-task-age=P40D")
+        .run(context -> {
+
+          final var properties = context.getBean(MigrationAdapterProperties.class);
+          assertEquals(Duration.ofDays(10), properties.maxTaskAge("other-module", null, null));
+          assertEquals(Duration.ofDays(20), properties.maxTaskAge("test-module", "OtherProcess", null));
+          assertEquals(Duration.ofDays(30), properties.maxTaskAge("test-module", "TestProcess", "otherTask"));
+          assertEquals(
+              Duration.ofDays(40),
+              properties.maxTaskAge("test-module", "TestProcess", "awaitSignature"));
+
+        });
+
+  }
+
+  @Test
   @DisplayName("An adapter-owned overlay of the same prefix coexists with the platform binding")
   public void adapterOverlayCoexistsWithPlatformBinding() {
 


### PR DESCRIPTION
Story 89, the generic half: a task left open by a `@TaskId` handler now has an age, and VanillaBP says when it grew past what the application allows.

## Why

A `@TaskId` handler leaves its task open, and from there on nothing asks whether the completion is still coming. The BPMS keeps redelivering the task, the core answers every redelivery from the record it wrote when the handler ran, and a Camunda 8 adapter renews the job's lock along the way. A workflow waiting forever therefore looks exactly like one waiting legitimately, and the only place which could tell them apart is the record itself.

## What is in here

`TaskDelivery` carries `recordedAt`, the moment the delivery was processed. Every store persisted that value from the beginning, because the retention deletes by it, so this is an SPI component and four mappings rather than new persistence. The core sets it when it builds the record, which makes the timestamp the processing moment instead of whatever a store's clock says.

`MigrationProcessService` measures the distance to now on every redelivery it answers with `COMPLETION_PENDING` and compares it to `vanillabp.delivery.max-task-age`. Thirty days by default, and reporting only: a task waiting for a person or for a partner may legitimately run for weeks, so a default which failed such a task would be worse than the leak it looks for, while a default which never fires would leave the leak invisible. The report is one WARNING per task naming the workflow module, the process, the workflow aggregate and the age, remembered in a bounded map so a renewal every hour does not become a log line every hour. A value of `0` switches it off, a negative one ends the boot.

The setting resolves globally, per workflow module, per workflow and per task, most specific first, which is why `WorkflowAdapterProperties` and `TaskAdapterProperties` gained a `delivery` section on both platforms.

What happens beyond the report belongs to the BPMS, so `WorkflowTaskOutcome` carries `openFor` and `maxAgeExceeded`. An adapter which has somewhere better to put the finding reads them; one without a lock to renew ignores both. There is deliberately no callback into the application: an application which knows its task is obsolete has `cancelTask`, and one which lost track of it could not answer a liveness question truthfully anyway.

## What this does not fix, and where it went

The record itself still expires with `vanillabp.outbox.retention`, and its timestamp is never refreshed, because refreshing it would erase the very age this measures. A task open longer than the retention therefore loses the record which answers its redelivery. The exposure shrinks from the Camunda 8 adapter's old fourteen day horizon to the retention, it does not disappear. That is written down in the wiki, in `migration-adapter/README.md`, and as story 97 with the three ways out to choose between.

## Tests

`OpenTaskAgeTest` (migration-adapter, six tests): a redelivery of an open task leaves the aggregate alone and reports the age, an overdue task is reported exactly once with every fact in the message, the resolution walks all four levels, zero switches the report off, a record without a timestamp reports no age, and a negative value ends the boot naming the level which carries it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
