### PR TITLE
Metrics, health and a logging context around every delivery

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -28,11 +28,22 @@ BPMS' own delivery id. VanillaBP restores the previous values afterwards and tou
 other key, so an existing log configuration keeps working; a pattern to paste is in the
 wiki page.
 
+One property comes with this, and it exists to keep a promise rather than to offer a
+choice: `vanillabp.metrics.gauge-cache` (default `PT10S`) is how long the measurement of a
+gauge which has to ask somebody is reused. Counting the waiting outbox entries is a
+database query, a gauge is read on every collection, and every instance of your application
+answers every collector separately - so without holding, a dashboard would turn watching
+the outbox into load on it. Ten seconds is one collection interval, a little under
+Prometheus' default scrape. `PT0S` measures on every collection, which is what a test wants.
+
 **Only relevant for adapters and for stores of your own:**
 `AdapterDeploymentService.checkHealth()` and `PhaseTwoOutbox.pendingCalls()` are new
 `default` methods contributing nothing, so existing implementations stay valid. An adapter
 which contributes no health is absent from the endpoint rather than reported as healthy,
-and a store which cannot count its waiting entries publishes no gauge.
+and a store which cannot count its waiting entries publishes no gauge. An adapter
+registering a gauge whose value costs a query wraps it in
+`io.vanillabp.integration.adapter.spi.observability.CachedGaugeValue`, which is the class
+behind the property above; a gauge reading something already in memory needs none of it.
 
 ## A workflow which ended can release its delivery records (2026-08-19)
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,6 +4,36 @@ Documents changes that were necessary when upgrading major dependency versions,
 so the reasoning can be looked up later (e.g. when upgrading BPMS adapters or
 applications built on VanillaBP).
 
+## Metrics, health and a logging context around every delivery (2026-08-20)
+
+Story 92. Additive and without a single new property: nothing changes for an application
+which does nothing.
+
+Where Micrometer is on the classpath, VanillaBP now publishes what it does with your work
+under `vanillabp.*`: task deliveries by outcome, how long each took, redeliveries answered
+from the delivery record, and the phase-two outbox with its backlog, its retries and its
+failures. Without Micrometer nothing is registered and nothing fails, exactly as for the
+election cache's meters. The names, the tags and the question each one answers are in the
+wiki page [Observability](https://github.com/vanillabp/adapter-platform-integration/wiki/Observability).
+
+Where the platform has a health endpoint, the BPMS adapters contribute what they know about
+their BPMS under the name `vanillabp` (Spring Boot: a health component of
+`/actuator/health`, needs `spring-boot-health` on the classpath; Quarkus: a readiness check
+of `/q/health/ready`, needs the SmallRye Health extension). An adapter which is not
+configured yet reports UNKNOWN and does not make the application unhealthy.
+
+Every task delivery and every phase-two dispatch now runs inside six MDC keys naming the
+adapter, the workflow module, the BPMN process, the workflow aggregate, the task and the
+BPMS' own delivery id. VanillaBP restores the previous values afterwards and touches no
+other key, so an existing log configuration keeps working; a pattern to paste is in the
+wiki page.
+
+**Only relevant for adapters and for stores of your own:**
+`AdapterDeploymentService.checkHealth()` and `PhaseTwoOutbox.pendingCalls()` are new
+`default` methods contributing nothing, so existing implementations stay valid. An adapter
+which contributes no health is absent from the endpoint rather than reported as healthy,
+and a store which cannot count its waiting entries publishes no gauge.
+
 ## A workflow which ended can release its delivery records (2026-08-19)
 
 Story 76. Additive and switched off, so nothing changes for an application which does not

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -1020,6 +1020,45 @@ The core answers the part it owns, and only that part:
   warns once per BPMN process where there is none. An aggregate with a version attribute stays
   quiet, because then the collision is the exception above instead of a lost write.
 
+## What an operator gets to see (story 92)
+
+Three things about one delivery, built in the core because every BPMS passes through it:
+the delivery is counted and measured, the log lines written while it runs name the workflow,
+and the adapters answer a health question the platform publishes.
+
+`MigrationProcessService#executeWorkflowTask` is the single place all of it hangs on. It is
+where the transaction is opened, so a timer around it measures the handler plus the commit
+rather than the handler alone, and it is where a delivery which throws still produces an
+outcome to count. Everything the adapters do is upstream of it, everything the application
+does is inside it, and nothing had to be repeated per BPMS.
+
+- `VanillaBpMetrics` is plain Java with a no-op `NONE`, and `MicrometerVanillaBpMetrics`
+  implements it plus `MeterBinder`. That is the same optional-Micrometer wiring the election
+  cache uses (`WorkflowAdapterCacheMeters`), and reusing it is the point: both platforms apply
+  `MeterBinder` beans to their registries by themselves, so no code of ours ever asks for a
+  registry. Before the binding there is no registry and every record is dropped, which is the
+  normal state while beans are being built.
+  The meters are cached per tag combination, because a delivery must not pay for its own
+  measurement, and the tag values are what a deployment fixes: adapter id, workflow module,
+  BPMN process, task definition. Never an aggregate id or a job key - those would grow one
+  time series per workflow, and they belong in the log anyway.
+- `DeliveryMdc` is a `try`-with-resources remembering the previous values of its six keys and
+  putting them back, so a thread the application uses for other work is handed over unchanged.
+  It is used around the task delivery and around the phase-two dispatch in `PhaseTwoRouter`,
+  which is where a broken BPMS connection does its logging.
+- Health is `AdapterDeploymentService#checkHealth()`, defaulting to `null`. Absent is honest,
+  `UP` would be a claim nobody checked, and an adapter written before this existed keeps
+  working. `AdapterHealthReport` collects the answers, turns a thrown exception into `DOWN`
+  (a health endpoint has to answer even when an adapter misbehaves) and computes the overall
+  status, where `UNKNOWN` is not worse than `UP`: an adapter which is not configured yet is
+  not an outage.
+- The outbox backlog is `PhaseTwoOutbox#pendingCalls()`, an `OptionalLong` defaulting to empty.
+  A store which cannot count publishes no gauge, which is honest where a zero would not be.
+  All four stores VanillaBP ships implement it with one indexed count; gruelbox has no API for
+  it, so its store reads the table gruelbox created, along the index gruelbox created with it.
+  On Quarkus the gauges are registered by a `StartupEvent` observer running AFTER the outbox
+  dispatchers, because a store asked before its table exists cannot count.
+
 ## Modules
 
 1. **business-spi:** (artifact `io.vanillabp:vanillabp-integration-spi`)<br>

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -1059,6 +1059,37 @@ does is inside it, and nothing had to be repeated per BPMS.
   On Quarkus the gauges are registered by a `StartupEvent` observer running AFTER the outbox
   dispatchers, because a store asked before its table exists cannot count.
 
+### Reading a metric must not cost anything
+
+A counter is a number we already hold. A gauge is a question asked at the moment somebody
+collects, and `outbox.pending` asks a database. Prometheus collects every fifteen seconds by
+default, a dashboard collects alongside it, and every instance answers each of them - so a
+gauge which queries turns watching a system into load on it. Nobody expects looking to be
+expensive, which is exactly why it has to be designed in rather than remembered.
+
+`CachedGaugeValue` (adapter SPI, `io.vanillabp.integration.adapter.spi.observability`) is how
+it is kept: it holds one measurement for `vanillabp.metrics.gauge-cache` (`MetricsProperties`,
+default ten seconds, `PT0S` switches the holding off for a test which needs the real value).
+
+Three decisions inside it are worth knowing before changing it:
+
+- It sits in the adapter SPI, not in this module's runtime. A BPMS adapter registers gauges of
+  its own and owes the same promise, and the adapters depend on the SPI. What does NOT belong
+  in it is a value already in memory - a counter, the free permits of a semaphore - because
+  holding those would only make them stale. Camunda 8's execution slots are that case.
+- Concurrent collectors are serialized on a lock rather than allowed to race. The second
+  collector waits for the first one's answer and then finds it fresh, so eight collectors at
+  the same moment are one query and not eight. Handing the second one a stale value instead
+  would be cheaper and was rejected: on the first collection there is nothing stale to hand
+  out, and the wait is bounded by the query the first collector is already paying for.
+- A measurement which throws is answered as absent for the rest of the window and taken again
+  in the next one. Not caching the failure would hammer a database which is down; caching it
+  forever would poison the gauge. The exception never leaves the class, because a metric must
+  not be the reason an application fails.
+
+The wrapping happens in `MicrometerVanillaBpMetrics#registerPendingOutboxEntries`, not in the
+platform modules and not in the stores. One place, so a store cannot forget.
+
 ## Modules
 
 1. **business-spi:** (artifact `io.vanillabp:vanillabp-integration-spi`)<br>

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/PhaseTwoOutbox.java
@@ -359,4 +359,23 @@ public interface PhaseTwoOutbox {
 
   }
 
+  /**
+   * How many entries are waiting to be dispatched right now (story 92). It is the
+   * number an operator looks at first when a BPMS is unreachable: phase two is where
+   * a broken connection piles up, and a rising figure says the application is fine
+   * while the BPMS is not.
+   * <p>
+   * The default is {@link java.util.OptionalLong#empty()}, which means "this store
+   * cannot say" - no meter is published then, which is honest, whereas a zero would
+   * be a claim. A store implementing it answers with a cheap query; it is called
+   * whenever the metrics backend collects, so an expensive scan does not belong here.
+   *
+   * @return The number of entries waiting, or empty if the store cannot count them
+   */
+  default java.util.OptionalLong pendingCalls() {
+
+    return java.util.OptionalLong.empty();
+
+  }
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MetricsProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MetricsProperties.java
@@ -1,0 +1,101 @@
+package io.vanillabp.integration.adapter.migration.config;
+
+import java.time.Duration;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * Configuration of what VanillaBP publishes as metrics (properties section
+ * <code>vanillabp.metrics</code>). There is one setting, and it exists because of one
+ * rule: reading a metric must not cost anything worth noticing.
+ * <p>
+ * Most of what VanillaBP reports is a number it already has - a counter, a timer, the
+ * size of a map. A few gauges have to ask somebody: how many entries wait in the
+ * phase-two outbox is a query against the outbox store. A gauge is read on every
+ * collection, Prometheus collects every fifteen seconds by default, a dashboard asks in
+ * between and every instance of the application answers for itself, so a gauge which
+ * queries would turn watching the system into load on it. {@link #gaugeCache} is how
+ * long one such measurement is reused instead.
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@SuperBuilder
+public class MetricsProperties {
+
+  public static final String SECTION = MigrationAdapterProperties.PREFIX
+      + ".metrics";
+
+  public static final String GAUGE_CACHE_PROPERTY = SECTION
+      + ".gauge-cache";
+
+  /**
+   * The default of {@link #gaugeCache} in ISO-8601 notation, for javadoc and messages.
+   */
+  public static final String DEFAULT_GAUGE_CACHE_ISO = "PT10S";
+
+  /**
+   * The default of {@link #gaugeCache}: ten seconds.
+   */
+  public static final Duration DEFAULT_GAUGE_CACHE = Duration.parse(DEFAULT_GAUGE_CACHE_ISO);
+
+  /**
+   * How long the measurement of a gauge which has to ask somebody is reused before it
+   * is taken again. Default: {@value #DEFAULT_GAUGE_CACHE_ISO}.
+   * <p>
+   * <b>Why ten seconds.</b> It is one collection interval, a little under the fifteen
+   * seconds Prometheus scrapes with by default. Every scrape therefore gets a
+   * measurement of its own, while the dashboard somebody opens next to it, a second
+   * collector, and a liveness check asking at the same moment all read the number the
+   * scrape already paid for. Raise it where the query is heavier than a counting one,
+   * lower it where a backlog has to be visible faster than the scrape interval.
+   * <p>
+   * <code>PT0S</code> switches the holding off, so every collection measures. That is
+   * what a test wants when it has just changed something and needs to see it; in an
+   * application it means paying for the query as often as somebody looks.
+   */
+  @Builder.Default
+  private Duration gaugeCache = DEFAULT_GAUGE_CACHE;
+
+  /**
+   * The duration to hold a measurement for, with the default applied where nothing is
+   * configured.
+   *
+   * @return The duration, never <code>null</code>
+   */
+  public Duration resolvedGaugeCache() {
+
+    return gaugeCache == null
+        ? DEFAULT_GAUGE_CACHE
+        : gaugeCache;
+
+  }
+
+  /**
+   * Validates the duration at startup like every other property - an unconfigured
+   * application boots with the default.
+   *
+   * @throws IllegalStateException Naming the offending property, its value and the
+   *           default
+   */
+  public void validate() {
+
+    if ((gaugeCache == null) || !gaugeCache.isNegative()) {
+      return;
+    }
+    throw new IllegalStateException(
+        """
+            The property '%s' is '%s' but has to be a duration of zero or more! It is how long the \
+            measurement of a gauge which has to ask somebody - the number of waiting outbox entries, \
+            for instance - is reused before it is taken again, and a negative span is neither a \
+            duration nor a way to switch anything off. Remove the property to use the default of %s, \
+            or set 'PT0S' to measure on every collection."""
+            .formatted(GAUGE_CACHE_PROPERTY, gaugeCache, DEFAULT_GAUGE_CACHE_ISO));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/config/MigrationAdapterProperties.java
@@ -95,6 +95,14 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
   private DeliveryProperties delivery = new DeliveryProperties();
 
   /**
+   * What VanillaBP publishes as metrics (properties section
+   * <code>vanillabp.metrics</code>) - today only how long the measurement of a gauge
+   * which has to ask somebody is reused.
+   */
+  @Builder.Default
+  private MetricsProperties metrics = new MetricsProperties();
+
+  /**
    * Derived view of {@link #getAdapters()}: adapter ID mapped to the adapter's type.
    * An adapter entry without an explicit {@link AdapterConfigProperties#getType()
    * type} defaults to its ID being the type.
@@ -1000,6 +1008,11 @@ public class MigrationAdapterProperties extends AdaptersConfigurationProperties 
       workflowAdapterCache = new WorkflowAdapterCacheProperties();
     }
     workflowAdapterCache.validate();
+    if (metrics == null) {
+      // a binder mapping an absent section onto null must not cost the defaults
+      metrics = new MetricsProperties();
+    }
+    metrics.validate();
     validateMaxTaskAge();
 
     if (knownWorkflowModuleIds.isEmpty()) {

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/health/AdapterHealthReport.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/health/AdapterHealthReport.java
@@ -1,0 +1,115 @@
+package io.vanillabp.integration.adapter.migration.health;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Supplier;
+
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Asks every BPMS adapter of the application what it can say about its BPMS and
+ * collects the answers. One class for both platforms: Spring Boot turns the report
+ * into an Actuator health indicator, Quarkus into a readiness check, and neither
+ * knows anything about a BPMS.
+ * <p>
+ * What the report does beyond calling the adapters:
+ * <ul>
+ * <li>an adapter contributing <code>null</code> is left out entirely - it is not
+ * reported as healthy, because nobody checked it;</li>
+ * <li>an adapter throwing is reported as {@link AdapterHealth.Status#DOWN} naming the
+ * exception. A health endpoint has to answer even when an adapter misbehaves, and an
+ * adapter which cannot answer its own question is a defect worth seeing;</li>
+ * <li>the overall status is the worst one reported, where
+ * {@link AdapterHealth.Status#UNKNOWN} is NOT worse than
+ * {@link AdapterHealth.Status#UP}: an application whose second adapter is not
+ * configured yet is not an outage.</li>
+ * </ul>
+ */
+@Slf4j
+public class AdapterHealthReport {
+
+  private final Supplier<Collection<AdapterDeploymentService<?, ?>>> adapters;
+
+  /**
+   * @param adapters Reports the adapter deployment services of the application, one
+   *          per configured adapter id (resolved on every call - the platform's bean
+   *          provider does the collecting)
+   */
+  public AdapterHealthReport(
+      final Supplier<Collection<AdapterDeploymentService<?, ?>>> adapters) {
+
+    this.adapters = adapters;
+
+  }
+
+  /**
+   * Asks every adapter and returns what they answered, in the order the platform
+   * reports the adapters.
+   *
+   * @return One entry per adapter which contributed something
+   */
+  public List<AdapterHealth> collect() {
+
+    final var collected = new ArrayList<AdapterHealth>();
+    for (final var adapter : adapters.get()) {
+      final AdapterHealth health;
+      try {
+        health = adapter.checkHealth();
+      } catch (final RuntimeException e) {
+        log.debug("Adapter '{}' failed to report its health", adapter.getAdapterId(), e);
+        collected.add(
+            AdapterHealth.down(
+                adapter.getAdapterId(),
+                adapter.getAdapterType(),
+                "The adapter failed to report its health: %s: %s".formatted(
+                    e
+                        .getClass()
+                        .getSimpleName(),
+                    e.getMessage()),
+                AdapterHealth
+                    .detailsBuilder()
+                    .build()));
+        continue;
+      }
+      if (health != null) {
+        collected.add(health);
+      }
+    }
+    return List.copyOf(collected);
+
+  }
+
+  /**
+   * The status of the application as a whole: {@link AdapterHealth.Status#DOWN} if
+   * any adapter is down, {@link AdapterHealth.Status#UP} if at least one adapter
+   * answered and none is down, {@link AdapterHealth.Status#UNKNOWN} where nothing was
+   * checked at all.
+   *
+   * @param healths What the adapters answered
+   * @return The overall status
+   */
+  public static AdapterHealth.Status overallStatus(
+      final List<AdapterHealth> healths) {
+
+    if (healths
+        .stream()
+        .anyMatch(health -> health.status() == AdapterHealth.Status.DOWN)) {
+      return AdapterHealth.Status.DOWN;
+    }
+    return healths
+        .stream()
+        .anyMatch(health -> health.status() == AdapterHealth.Status.UP)
+            ? AdapterHealth.Status.UP
+            : AdapterHealth.Status.UNKNOWN;
+
+  }
+
+  /**
+   * The name a platform's health endpoint publishes this contribution under.
+   */
+  public static final String HEALTH_NAME = "vanillabp";
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/DeliveryMdc.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/DeliveryMdc.java
@@ -1,0 +1,172 @@
+package io.vanillabp.integration.adapter.migration.observability;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.MDC;
+
+/**
+ * The logging context VanillaBP puts around everything it delivers to application
+ * code: which BPMS, which workflow module, which BPMN process, which workflow, which
+ * task, and what the BPMS calls this delivery. Every log line an application writes
+ * inside a <code>&#64;WorkflowTask</code> method carries them, so a log search can
+ * follow one workflow through a system without the application passing anything
+ * around.
+ * <p>
+ * The keys are listed in the wiki together with a log pattern to paste. Camunda
+ * documents MDC keys around its own handler as well, but its 8.9 client does not set
+ * any; what VanillaBP puts here is more, and it is the same on every BPMS because it
+ * is set in the core rather than in an adapter.
+ * <p>
+ * <b>VanillaBP touches its own keys and nothing else.</b> The previous values of
+ * exactly these keys are remembered and restored on {@link #close()}, so a thread
+ * which the application uses for other things as well - a Camunda 7 job-executor
+ * thread, a request thread - looks afterwards the way it looked before. Use it as a
+ * resource:
+ *
+ * <pre>
+ * try (var mdc = DeliveryMdc.ofTaskDelivery(...)) {
+ *   ...
+ * }
+ * </pre>
+ */
+public final class DeliveryMdc implements AutoCloseable {
+
+  /**
+   * The id of the adapter (and therefore the BPMS instance) the work came from.
+   */
+  public static final String ADAPTER = "vanillabp.adapter";
+
+  /**
+   * The id of the workflow module owning the BPMN process.
+   */
+  public static final String WORKFLOW_MODULE = "vanillabp.workflow.module";
+
+  /**
+   * The BPMN process id, as the application wrote it (without any prefixing a
+   * name-clash-avoidance mode applies).
+   */
+  public static final String BPMN_PROCESS = "vanillabp.bpmn.process";
+
+  /**
+   * The id of the workflow aggregate, which is the id of the workflow itself - the
+   * value to search a log by.
+   */
+  public static final String WORKFLOW_AGGREGATE_ID = "vanillabp.workflow.aggregate.id";
+
+  /**
+   * The task definition delivered (the BPMN task's task definition or its activity
+   * id), absent outside a task delivery.
+   */
+  public static final String TASK_DEFINITION = "vanillabp.task.definition";
+
+  /**
+   * What the BPMS calls this delivery (the Camunda 8 job key, the task id of a
+   * remote engine), absent where the BPMS does not name its deliveries. Two log
+   * lines of one delivery share it, a redelivery repeats it.
+   */
+  public static final String DELIVERY_ID = "vanillabp.delivery.id";
+
+  /**
+   * Every key VanillaBP sets - the list to build a log pattern from, and the list
+   * restored when a scope ends.
+   */
+  public static final List<String> KEYS = List.of(
+      ADAPTER,
+      WORKFLOW_MODULE,
+      BPMN_PROCESS,
+      WORKFLOW_AGGREGATE_ID,
+      TASK_DEFINITION,
+      DELIVERY_ID);
+
+  private final Map<String, String> restore;
+
+  private DeliveryMdc(
+      final Map<String, String> values) {
+
+    this.restore = new HashMap<>(KEYS.size());
+    KEYS.forEach(key -> restore.put(key, MDC.get(key)));
+    values.forEach(DeliveryMdc::put);
+
+  }
+
+  /**
+   * The context of a task delivered to a <code>&#64;WorkflowTask</code> method.
+   *
+   * @param adapterId The id of the delivering adapter
+   * @param workflowModuleId The workflow module of the BPMN process
+   * @param bpmnProcessId The BPMN process
+   * @param workflowAggregateId The workflow aggregate's id in serialized form
+   * @param taskDefinition The task definition delivered
+   * @param deliveryId What the BPMS calls this delivery
+   * @return The scope, to be closed when the delivery is done
+   */
+  public static DeliveryMdc ofTaskDelivery(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId,
+      final String taskDefinition,
+      final String deliveryId) {
+
+    final var values = new HashMap<String, String>();
+    values.put(ADAPTER, adapterId);
+    values.put(WORKFLOW_MODULE, workflowModuleId);
+    values.put(BPMN_PROCESS, bpmnProcessId);
+    values.put(WORKFLOW_AGGREGATE_ID, workflowAggregateId);
+    values.put(TASK_DEFINITION, taskDefinition);
+    values.put(DELIVERY_ID, deliveryId);
+    return new DeliveryMdc(values);
+
+  }
+
+  /**
+   * The context of a phase-two call dispatched out of the transaction outbox. It
+   * knows no task and no delivery of a BPMS: the entry was written by this
+   * application, and what the BPMS answers to it is exactly what an operator is
+   * looking for when a connection is broken.
+   *
+   * @param adapterId The id of the adapter the call goes to, if the entry names one
+   * @param workflowModuleId The workflow module of the BPMN process
+   * @param bpmnProcessId The BPMN process
+   * @param workflowAggregateId The workflow aggregate's id in serialized form
+   * @return The scope, to be closed when the dispatch is done
+   */
+  public static DeliveryMdc ofPhaseTwoDispatch(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String workflowAggregateId) {
+
+    final var values = new HashMap<String, String>();
+    values.put(ADAPTER, adapterId);
+    values.put(WORKFLOW_MODULE, workflowModuleId);
+    values.put(BPMN_PROCESS, bpmnProcessId);
+    values.put(WORKFLOW_AGGREGATE_ID, workflowAggregateId);
+    values.put(TASK_DEFINITION, null);
+    values.put(DELIVERY_ID, null);
+    return new DeliveryMdc(values);
+
+  }
+
+  private static void put(
+      final String key,
+      final String value) {
+
+    if (value == null) {
+      MDC.remove(key);
+    } else {
+      MDC.put(key, value);
+    }
+
+  }
+
+  @Override
+  public void close() {
+
+    restore.forEach(DeliveryMdc::put);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/MicrometerVanillaBpMetrics.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/MicrometerVanillaBpMetrics.java
@@ -1,0 +1,262 @@
+package io.vanillabp.integration.adapter.migration.observability;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+/**
+ * Publishes what {@link VanillaBpMetrics} records as Micrometer meters. Both
+ * platforms apply {@link MeterBinder} beans to their registries themselves (Spring
+ * Boot through the Actuator's metrics auto-configuration, Quarkus through the
+ * Micrometer extension), so this one class serves both.
+ * <p>
+ * Micrometer is OPTIONAL: this class is loaded only where the platform integration
+ * found Micrometer, and everything the core records goes to {@link
+ * VanillaBpMetrics#NONE} otherwise.
+ * <p>
+ * <b>Why the meters are cached.</b> A delivery must not pay for its own measurement.
+ * Resolving a meter by name and tags costs a map lookup plus the tag list on every
+ * call, so each meter is looked up once per tag combination and kept - and the number
+ * of combinations is fixed by the deployment, see the cardinality note on
+ * {@link VanillaBpMetrics}.
+ * <p>
+ * Before {@link #bindTo(MeterRegistry)} was called there is no registry, and every
+ * record is dropped. That is the normal state during startup, where beans are built
+ * before the metrics infrastructure binds them.
+ */
+public class MicrometerVanillaBpMetrics implements VanillaBpMetrics, MeterBinder {
+
+  private volatile MeterRegistry registry;
+
+  private final Map<String, Counter> counters = new ConcurrentHashMap<>();
+
+  private final Map<String, Timer> timers = new ConcurrentHashMap<>();
+
+  /**
+   * The pending-entry suppliers of the outbox stores, kept because a store may
+   * register before the registry exists.
+   */
+  private final Map<String, LongSupplier> pendingOutboxEntries = new ConcurrentHashMap<>();
+
+  @Override
+  public void bindTo(
+      final MeterRegistry meterRegistry) {
+
+    this.registry = meterRegistry;
+    // the cached meters belong to the registry they were created in
+    counters.clear();
+    timers.clear();
+    pendingOutboxEntries.forEach((
+        store,
+        pending) -> registerPendingGauge(meterRegistry, store, pending));
+
+  }
+
+  @Override
+  public void taskDelivered(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinition,
+      final DeliveryOutcome outcome,
+      final long durationNanos) {
+
+    final var meterRegistry = registry;
+    if (meterRegistry == null) {
+      return;
+    }
+
+    final var adapter = tagValue(adapterId);
+    final var module = tagValue(workflowModuleId);
+    final var process = tagValue(bpmnProcessId);
+    final var task = tagValue(taskDefinition);
+
+    counter(
+        meterRegistry,
+        TASK_DELIVERIES,
+        "Task deliveries processed, by outcome",
+        Tags.of(
+            TAG_ADAPTER, adapter,
+            TAG_WORKFLOW_MODULE, module,
+            TAG_BPMN_PROCESS, process,
+            TAG_TASK_DEFINITION, task,
+            TAG_OUTCOME, outcome.getTagValue()))
+        .increment();
+
+    timer(
+        meterRegistry,
+        TASK_DELIVERY_DURATION,
+        "Duration of a task delivery, including the transaction VanillaBP opens for it",
+        Tags.of(
+            TAG_ADAPTER, adapter,
+            TAG_WORKFLOW_MODULE, module,
+            TAG_BPMN_PROCESS, process,
+            TAG_TASK_DEFINITION, task))
+        .record(durationNanos, TimeUnit.NANOSECONDS);
+
+  }
+
+  @Override
+  public void taskRedeliveryDeduplicated(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinition) {
+
+    final var meterRegistry = registry;
+    if (meterRegistry == null) {
+      return;
+    }
+
+    counter(
+        meterRegistry,
+        TASK_REDELIVERIES_DEDUPLICATED,
+        "Repeated deliveries answered from the delivery record instead of running the handler again",
+        Tags.of(
+            TAG_ADAPTER, tagValue(adapterId),
+            TAG_WORKFLOW_MODULE, tagValue(workflowModuleId),
+            TAG_BPMN_PROCESS, tagValue(bpmnProcessId),
+            TAG_TASK_DEFINITION, tagValue(taskDefinition)))
+        .increment();
+
+  }
+
+  @Override
+  public void outboxDispatchStarted(
+      final String operation,
+      final boolean previouslyAttempted) {
+
+    final var meterRegistry = registry;
+    if (meterRegistry == null) {
+      return;
+    }
+
+    final var tags = Tags.of(TAG_OPERATION, tagValue(operation));
+    counter(
+        meterRegistry,
+        OUTBOX_DISPATCHES,
+        "Phase-two calls dispatched out of the transaction outbox",
+        tags)
+        .increment();
+    if (previouslyAttempted) {
+      counter(
+          meterRegistry,
+          OUTBOX_RETRIES,
+          "Dispatches of an outbox entry which was attempted before",
+          tags)
+          .increment();
+    }
+
+  }
+
+  @Override
+  public void outboxDispatchFailed(
+      final String operation,
+      final boolean permanent) {
+
+    final var meterRegistry = registry;
+    if (meterRegistry == null) {
+      return;
+    }
+
+    counter(
+        meterRegistry,
+        OUTBOX_FAILURES,
+        "Outbox dispatches which ended in a failure",
+        Tags.of(
+            TAG_OPERATION, tagValue(operation),
+            TAG_PERMANENT, Boolean.toString(permanent)))
+        .increment();
+
+  }
+
+  @Override
+  public void registerPendingOutboxEntries(
+      final String store,
+      final LongSupplier pending) {
+
+    pendingOutboxEntries.put(store, pending);
+    final var meterRegistry = registry;
+    if (meterRegistry != null) {
+      registerPendingGauge(meterRegistry, store, pending);
+    }
+
+  }
+
+  private static void registerPendingGauge(
+      final MeterRegistry meterRegistry,
+      final String store,
+      final LongSupplier pending) {
+
+    Gauge
+        .builder(OUTBOX_PENDING, pending, supplier -> supplier.getAsLong())
+        .tags(Tags.of(TAG_STORE, store))
+        .description("Outbox entries waiting to be dispatched")
+        .register(meterRegistry);
+
+  }
+
+  private Counter counter(
+      final MeterRegistry meterRegistry,
+      final String name,
+      final String description,
+      final Tags tags) {
+
+    return counters.computeIfAbsent(
+        cacheKey(name, tags),
+        key -> Counter
+            .builder(name)
+            .tags(tags)
+            .description(description)
+            .register(meterRegistry));
+
+  }
+
+  private Timer timer(
+      final MeterRegistry meterRegistry,
+      final String name,
+      final String description,
+      final Tags tags) {
+
+    return timers.computeIfAbsent(
+        cacheKey(name, tags),
+        key -> Timer
+            .builder(name)
+            .tags(tags)
+            .description(description)
+            .register(meterRegistry));
+
+  }
+
+  private static String cacheKey(
+      final String name,
+      final Tags tags) {
+
+    final var key = new StringBuilder(name);
+    tags.forEach(tag -> key
+        .append('|')
+        .append(tag.getKey())
+        .append('=')
+        .append(tag.getValue()));
+    return key.toString();
+
+  }
+
+  private static String tagValue(
+      final String value) {
+
+    return ((value == null) || value.isBlank())
+        ? TAG_VALUE_UNKNOWN
+        : value;
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/MicrometerVanillaBpMetrics.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/MicrometerVanillaBpMetrics.java
@@ -1,9 +1,11 @@
 package io.vanillabp.integration.adapter.migration.observability;
 
+import java.time.Duration;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
-import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.Gauge;
@@ -11,6 +13,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.vanillabp.integration.adapter.migration.config.MetricsProperties;
+import io.vanillabp.integration.adapter.spi.observability.CachedGaugeValue;
 
 /**
  * Publishes what {@link VanillaBpMetrics} records as Micrometer meters. Both
@@ -31,10 +35,43 @@ import io.micrometer.core.instrument.binder.MeterBinder;
  * Before {@link #bindTo(MeterRegistry)} was called there is no registry, and every
  * record is dropped. That is the normal state during startup, where beans are built
  * before the metrics infrastructure binds them.
+ * <p>
+ * <b>Reading a metric costs nothing.</b> The counters and the timer are numbers this
+ * class already holds, but a gauge is different: it is read on every collection, and
+ * the only gauge here has to ask an outbox store how many entries wait. That query is
+ * wrapped in a {@link CachedGaugeValue} before it ever becomes a gauge, so a store
+ * cannot forget to do it - see {@link #registerPendingOutboxEntries(String, java.util.function.Supplier)}.
  */
 public class MicrometerVanillaBpMetrics implements VanillaBpMetrics, MeterBinder {
 
   private volatile MeterRegistry registry;
+
+  /**
+   * How long one measurement of an asking gauge is reused
+   * (<code>vanillabp.metrics.gauge-cache</code>). Zero measures on every collection.
+   */
+  private final Duration gaugeCache;
+
+  /**
+   * Creates the meters with the default holding period - kept for tests; the platform
+   * integrations always pass the configured one.
+   */
+  public MicrometerVanillaBpMetrics() {
+
+    this(MetricsProperties.DEFAULT_GAUGE_CACHE);
+
+  }
+
+  /**
+   * @param gaugeCache How long one measurement of a gauge which has to ask somebody is
+   *          reused before it is taken again
+   */
+  public MicrometerVanillaBpMetrics(
+      final Duration gaugeCache) {
+
+    this.gaugeCache = gaugeCache;
+
+  }
 
   private final Map<String, Counter> counters = new ConcurrentHashMap<>();
 
@@ -44,7 +81,7 @@ public class MicrometerVanillaBpMetrics implements VanillaBpMetrics, MeterBinder
    * The pending-entry suppliers of the outbox stores, kept because a store may
    * register before the registry exists.
    */
-  private final Map<String, LongSupplier> pendingOutboxEntries = new ConcurrentHashMap<>();
+  private final Map<String, Supplier<OptionalLong>> pendingOutboxEntries = new ConcurrentHashMap<>();
 
   @Override
   public void bindTo(
@@ -178,26 +215,48 @@ public class MicrometerVanillaBpMetrics implements VanillaBpMetrics, MeterBinder
 
   }
 
+  /**
+   * The supplier is NOT registered as the gauge reads it. Counting the waiting entries
+   * of an outbox is a query, a gauge is read on every collection, and every instance of
+   * the application answers for itself - so what becomes the gauge is a
+   * {@link CachedGaugeValue} around it, and the query runs at most once per
+   * <code>vanillabp.metrics.gauge-cache</code> however many collectors ask.
+   */
   @Override
   public void registerPendingOutboxEntries(
       final String store,
-      final LongSupplier pending) {
+      final Supplier<OptionalLong> pending) {
 
-    pendingOutboxEntries.put(store, pending);
+    final var held = CachedGaugeValue.holding(gaugeCache, pending);
+    pendingOutboxEntries.put(store, held);
     final var meterRegistry = registry;
     if (meterRegistry != null) {
-      registerPendingGauge(meterRegistry, store, pending);
+      registerPendingGauge(meterRegistry, store, held);
     }
 
   }
 
+  /**
+   * A measurement which could not be taken is reported as NaN, which Micrometer treats
+   * as "no measurement" and most backends skip - the same way the election cache's size
+   * gauge answers for a cache which does not know its size. A zero would be a claim
+   * nobody checked.
+   */
   private static void registerPendingGauge(
       final MeterRegistry meterRegistry,
       final String store,
-      final LongSupplier pending) {
+      final Supplier<OptionalLong> pending) {
 
     Gauge
-        .builder(OUTBOX_PENDING, pending, supplier -> supplier.getAsLong())
+        .builder(
+            OUTBOX_PENDING,
+            pending,
+            supplier -> supplier
+                .get()
+                .stream()
+                .mapToDouble(waiting -> waiting)
+                .findFirst()
+                .orElse(Double.NaN))
         .tags(Tags.of(TAG_STORE, store))
         .description("Outbox entries waiting to be dispatched")
         .register(meterRegistry);

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/VanillaBpMetrics.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/VanillaBpMetrics.java
@@ -1,6 +1,7 @@
 package io.vanillabp.integration.adapter.migration.observability;
 
-import java.util.function.LongSupplier;
+import java.util.OptionalLong;
+import java.util.function.Supplier;
 
 /**
  * What VanillaBP counts and measures while it delivers work, expressed without any
@@ -207,13 +208,22 @@ public interface VanillaBpMetrics {
    * Registers where the number of waiting outbox entries is read from. Called once
    * per outbox store by the platform integration, for the stores which can count
    * them.
+   * <p>
+   * Counting them is a QUERY, and a gauge is read on every collection, so the
+   * implementation is expected to hold one measurement for
+   * <code>vanillabp.metrics.gauge-cache</code> rather than to ask on every collection
+   * (see
+   * {@link io.vanillabp.integration.adapter.spi.observability.CachedGaugeValue}). A
+   * measurement which could not be taken stays {@link OptionalLong#empty()} all the way
+   * to the backend, where it is a gap rather than a zero.
    *
    * @param store The name of the outbox store, used as the <code>store</code> tag
-   * @param pending Reports the number of entries waiting to be dispatched
+   * @param pending Reports the number of entries waiting to be dispatched, empty where
+   *          the store cannot say right now
    */
   default void registerPendingOutboxEntries(
       final String store,
-      final LongSupplier pending) {
+      final Supplier<OptionalLong> pending) {
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/VanillaBpMetrics.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/observability/VanillaBpMetrics.java
@@ -1,0 +1,220 @@
+package io.vanillabp.integration.adapter.migration.observability;
+
+import java.util.function.LongSupplier;
+
+/**
+ * What VanillaBP counts and measures while it delivers work, expressed without any
+ * metrics library: the core records, and whoever wants the numbers implements this
+ * interface. {@link #NONE} is the implementation of an application which brings no
+ * metrics backend at all, and it is what every process service uses until a platform
+ * integration hands in a different one.
+ * <p>
+ * The Micrometer implementation is {@link MicrometerVanillaBpMetrics}, registered by
+ * both platform integrations where Micrometer is present. It is the same mechanism
+ * the election cache uses
+ * ({@link io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters}),
+ * and both follow one naming scheme: every meter starts with <code>vanillabp.</code>
+ * and names WHAT is measured, while WHERE it happened - the adapter, the workflow
+ * module, the BPMN process, the task - is a tag.
+ * <p>
+ * <b>Cardinality.</b> The tags are values a deployment fixes: the configured adapter
+ * ids, the workflow modules of the application, their BPMN processes and the task
+ * definitions of those processes. Nothing that grows with the number of workflows -
+ * no workflow-aggregate id, no job key, no delivery id - is ever a tag. Those belong
+ * to a log line, which is why they are in the MDC instead (see {@link DeliveryMdc}).
+ */
+public interface VanillaBpMetrics {
+
+  /**
+   * Counts nothing - the implementation of an application without a metrics backend.
+   */
+  VanillaBpMetrics NONE = new VanillaBpMetrics() {
+  };
+
+  /**
+   * Task deliveries this application processed, by outcome. The rate of this counter
+   * is what tells a quiet system from a stalled one.
+   */
+  String TASK_DELIVERIES = "vanillabp.task.deliveries";
+
+  /**
+   * How long a task delivery took, measured around the transaction VanillaBP opens
+   * for it - so a slow handler is visible as a slow handler.
+   */
+  String TASK_DELIVERY_DURATION = "vanillabp.task.delivery.duration";
+
+  /**
+   * Repeated deliveries answered from the record of story 51 instead of running the
+   * <code>&#64;WorkflowTask</code> method again. A rising rate means the BPMS hands
+   * work out a second time, usually because the lock is too short for the handler.
+   */
+  String TASK_REDELIVERIES_DEDUPLICATED = "vanillabp.task.redeliveries.deduplicated";
+
+  /**
+   * Phase-two calls dispatched out of the transaction outbox.
+   */
+  String OUTBOX_DISPATCHES = "vanillabp.outbox.dispatches";
+
+  /**
+   * Dispatches of an outbox entry which was attempted before.
+   */
+  String OUTBOX_RETRIES = "vanillabp.outbox.retries";
+
+  /**
+   * Dispatches which ended in a failure, separated by whether repeating them can
+   * help.
+   */
+  String OUTBOX_FAILURES = "vanillabp.outbox.failures";
+
+  /**
+   * Outbox entries waiting to be dispatched, reported by the stores which can count
+   * them ({@link io.vanillabp.integration.spi.PhaseTwoOutbox#pendingCalls()}).
+   */
+  String OUTBOX_PENDING = "vanillabp.outbox.pending";
+
+  String TAG_ADAPTER = "adapter";
+
+  String TAG_WORKFLOW_MODULE = "workflow.module";
+
+  String TAG_BPMN_PROCESS = "bpmn.process";
+
+  String TAG_TASK_DEFINITION = "task.definition";
+
+  String TAG_OUTCOME = "outcome";
+
+  String TAG_OPERATION = "operation";
+
+  String TAG_PERMANENT = "permanent";
+
+  String TAG_STORE = "store";
+
+  /**
+   * The value used where a tag has no value at all (an adapter reporting no id, a
+   * task delivered without a definition). An empty tag value is dropped by some
+   * backends and kept by others, so VanillaBP names the case instead.
+   */
+  String TAG_VALUE_UNKNOWN = "unknown";
+
+  /**
+   * How a task delivery ended, as the <code>outcome</code> tag of
+   * {@link #TASK_DELIVERIES} sees it.
+   */
+  enum DeliveryOutcome {
+
+    /**
+     * The handler returned and the task was completed.
+     */
+    COMPLETED("completed"),
+
+    /**
+     * The handler returned and the task stays open for an asynchronous completion
+     * (a <code>&#64;TaskId</code> parameter).
+     */
+    PENDING("pending"),
+
+    /**
+     * The handler threw a {@link io.vanillabp.spi.service.TaskException}, so the
+     * task ends in a BPMN error.
+     */
+    BPMN_ERROR("bpmn-error"),
+
+    /**
+     * The handler threw anything else: the transaction was rolled back and the BPMS
+     * gets the delivery back.
+     */
+    FAILED("failed");
+
+    private final String tagValue;
+
+    DeliveryOutcome(
+        final String tagValue) {
+
+      this.tagValue = tagValue;
+
+    }
+
+    public String getTagValue() {
+
+      return tagValue;
+
+    }
+
+  }
+
+  /**
+   * A task delivery was processed.
+   *
+   * @param adapterId The id of the adapter which delivered the task
+   * @param workflowModuleId The workflow module of the BPMN process
+   * @param bpmnProcessId The BPMN process the task belongs to
+   * @param taskDefinition The task definition delivered
+   * @param outcome How the delivery ended
+   * @param durationNanos How long it took, including the transaction
+   */
+  default void taskDelivered(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinition,
+      final DeliveryOutcome outcome,
+      final long durationNanos) {
+
+  }
+
+  /**
+   * A repeated delivery was answered from the delivery record instead of running the
+   * handler again.
+   *
+   * @param adapterId The id of the adapter which delivered the task
+   * @param workflowModuleId The workflow module of the BPMN process
+   * @param bpmnProcessId The BPMN process the task belongs to
+   * @param taskDefinition The task definition delivered
+   */
+  default void taskRedeliveryDeduplicated(
+      final String adapterId,
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinition) {
+
+  }
+
+  /**
+   * An outbox entry is about to be dispatched.
+   *
+   * @param operation The persisted name of the phase-two operation
+   * @param previouslyAttempted Whether the entry was dispatched before
+   */
+  default void outboxDispatchStarted(
+      final String operation,
+      final boolean previouslyAttempted) {
+
+  }
+
+  /**
+   * An outbox dispatch ended in a failure.
+   *
+   * @param operation The persisted name of the phase-two operation
+   * @param permanent Whether repeating the operation cannot help
+   *          ({@link io.vanillabp.integration.spi.PhaseTwoPermanentFailure})
+   */
+  default void outboxDispatchFailed(
+      final String operation,
+      final boolean permanent) {
+
+  }
+
+  /**
+   * Registers where the number of waiting outbox entries is read from. Called once
+   * per outbox store by the platform integration, for the stores which can count
+   * them.
+   *
+   * @param store The name of the outbox store, used as the <code>store</code> tag
+   * @param pending Reports the number of entries waiting to be dispatched
+   */
+  default void registerPendingOutboxEntries(
+      final String store,
+      final LongSupplier pending) {
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -133,6 +133,27 @@ public class MigrationProcessService<A> {
   private volatile TransactionRunner transactionRunner;
 
   /**
+   * What the application counts about its deliveries (story 92). Handed in by the
+   * platform integration after construction, because it exists once per application
+   * while process services exist per BPMN process;
+   * {@link io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics#NONE}
+   * until then and for an application without a metrics backend.
+   */
+  private volatile io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics metrics = io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE;
+
+  /**
+   * @param metrics What to count deliveries into, never <code>null</code>
+   */
+  public void setMetrics(
+      final io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics metrics) {
+
+    this.metrics = metrics == null
+        ? io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE
+        : metrics;
+
+  }
+
+  /**
    * Creates a process service without an adapter cache (elections probe every
    * time) - kept for tests; the platform integrations always pass the cache.
    */
@@ -550,6 +571,65 @@ public class MigrationProcessService<A> {
       final TransactionRunner platformTransactionRunner,
       final List<String> rollbackRuleRemedies) {
 
+    // story 92: everything the application logs while its handler runs carries the
+    // workflow it runs for, and the delivery is counted and measured - here, because
+    // this is the one place every BPMS passes through
+    final var startedAt = System.nanoTime();
+    WorkflowTaskOutcome outcome = null;
+    try (var ignored = io.vanillabp.integration.adapter.migration.observability.DeliveryMdc
+        .ofTaskDelivery(
+            context.getAdapterId(),
+            workflowModuleId,
+            bpmnProcessId,
+            context.getWorkflowAggregateId(),
+            context.getTaskDefinition(),
+            context.getDeliveryId())) {
+      outcome = deliverWorkflowTask(handler, context, platformTransactionRunner, rollbackRuleRemedies);
+      return outcome;
+    } finally {
+      metrics
+          .taskDelivered(
+              context.getAdapterId(),
+              workflowModuleId,
+              bpmnProcessId,
+              context.getTaskDefinition(),
+              deliveryOutcomeOf(outcome),
+              System.nanoTime() - startedAt);
+    }
+
+  }
+
+  /**
+   * How a delivery ended, as the metrics see it: a delivery which produced no outcome
+   * threw, which means the transaction was rolled back and the BPMS gets the work
+   * back.
+   *
+   * @param outcome The outcome or <code>null</code> if the delivery threw
+   * @return The outcome to count
+   */
+  private static io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.DeliveryOutcome deliveryOutcomeOf(
+      final WorkflowTaskOutcome outcome) {
+
+    if (outcome == null) {
+      return io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.DeliveryOutcome.FAILED;
+    }
+    return switch (outcome.kind()) {
+      case COMPLETED ->
+        io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.DeliveryOutcome.COMPLETED;
+      case COMPLETION_PENDING ->
+        io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.DeliveryOutcome.PENDING;
+      case BPMN_ERROR ->
+        io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.DeliveryOutcome.BPMN_ERROR;
+    };
+
+  }
+
+  private WorkflowTaskOutcome deliverWorkflowTask(
+      final WorkflowTaskHandler handler,
+      final TaskInvocationContext context,
+      final TransactionRunner platformTransactionRunner,
+      final List<String> rollbackRuleRemedies) {
+
     // the runner of the application where it contributed one for this aggregate, the
     // platform's otherwise (story 70) - resolved once and cached by the process service
     final var runner = getTransactionRunner(platformTransactionRunner);
@@ -600,6 +680,12 @@ public class MigrationProcessService<A> {
               workflowModuleId,
               context.getWorkflowAggregateId(),
               recorded.get().kind());
+          metrics
+              .taskRedeliveryDeduplicated(
+                  context.getAdapterId(),
+                  workflowModuleId,
+                  bpmnProcessId,
+                  context.getTaskDefinition());
           return recorded.get();
         }
       }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/PhaseTwoRouter.java
@@ -54,6 +54,26 @@ public final class PhaseTwoRouter {
    */
   private final TransactionRunner transactionRunner;
 
+  /**
+   * What the application counts about its outbox (story 92). Handed in by the
+   * platform integration;
+   * {@link io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics#NONE}
+   * for an application without a metrics backend.
+   */
+  private volatile io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics metrics = io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE;
+
+  /**
+   * @param metrics What to count dispatches into, never <code>null</code>
+   */
+  public void setMetrics(
+      final io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics metrics) {
+
+    this.metrics = metrics == null
+        ? io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE
+        : metrics;
+
+  }
+
   public PhaseTwoRouter() {
 
     this(new PhaseTwoOperationRegistry(), null);
@@ -187,14 +207,30 @@ public final class PhaseTwoRouter {
     // its own runner here as well, and an entry of an extension - which routes to no
     // process service - gets the platform's.
     final var runner = runnerFor(call);
-    if (runner == null) {
-      dispatch.dispatch(call, previouslyAttempted);
-      return;
+    metrics.outboxDispatchStarted(call.operation(), previouslyAttempted);
+    // story 92: whatever the dispatch logs - and a broken BPMS connection logs a lot -
+    // names the workflow it belongs to, exactly like a task delivery does
+    try (var ignored = io.vanillabp.integration.adapter.migration.observability.DeliveryMdc
+        .ofPhaseTwoDispatch(
+            call.adapterId(),
+            call.workflowModuleId(),
+            call.bpmnProcessId(),
+            call.workflowAggregateId())) {
+      if (runner == null) {
+        dispatch.dispatch(call, previouslyAttempted);
+        return;
+      }
+      runner.requireTransaction(() -> {
+        dispatch.dispatch(call, previouslyAttempted);
+        return null;
+      });
+    } catch (final RuntimeException e) {
+      metrics
+          .outboxDispatchFailed(
+              call.operation(),
+              io.vanillabp.integration.spi.PhaseTwoPermanentFailure.isPermanent(e));
+      throw e;
     }
-    runner.requireTransaction(() -> {
-      dispatch.dispatch(call, previouslyAttempted);
-      return null;
-    });
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MetricsPropertiesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/config/MetricsPropertiesTest.java
@@ -1,0 +1,80 @@
+package io.vanillabp.migration.test.config;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.config.MetricsProperties;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 92: how long the measurement of a gauge which has to ask somebody is reused.
+ * The default is one collection interval, zero is the way to switch the holding off,
+ * and a negative span is a typo the boot names.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MetricsPropertiesTest {
+
+  @Test
+  @DisplayName("Nothing configured means ten seconds")
+  public void theDefaultIsOneCollectionInterval() {
+
+    assertEquals(
+        Duration.ofSeconds(10),
+        new MetricsProperties().resolvedGaugeCache(),
+        "a little under Prometheus' default scrape of fifteen seconds");
+    assertEquals(
+        Duration.ofSeconds(10),
+        MetricsProperties.DEFAULT_GAUGE_CACHE,
+        "and the constant says the same as the ISO notation the messages use");
+
+    final var configured = new MetricsProperties();
+    configured.setGaugeCache(Duration.ofMinutes(1));
+    assertEquals(Duration.ofMinutes(1), configured.resolvedGaugeCache());
+
+    configured.setGaugeCache(null);
+    assertEquals(
+        Duration.ofSeconds(10),
+        configured.resolvedGaugeCache(),
+        "a binder mapping an absent section onto null must not cost the default");
+
+  }
+
+  @Test
+  @DisplayName("Zero is a legitimate value: measure on every collection")
+  public void zeroSwitchesTheHoldingOff() {
+
+    final var properties = new MetricsProperties();
+    properties.setGaugeCache(Duration.ZERO);
+
+    assertDoesNotThrow(properties::validate);
+    assertEquals(Duration.ZERO, properties.resolvedGaugeCache());
+
+  }
+
+  @Test
+  @DisplayName("A negative span fails the boot naming the property and the default")
+  public void aNegativeSpanFailsTheBoot() {
+
+    final var properties = new MetricsProperties();
+    properties.setGaugeCache(Duration.ofSeconds(-1));
+
+    final var failure = assertThrows(IllegalStateException.class, properties::validate);
+
+    final var message = failure.getMessage();
+    assertTrue(message.contains(MetricsProperties.GAUGE_CACHE_PROPERTY), message);
+    assertTrue(message.contains("PT10S"), "names the default: "
+        + message);
+    assertTrue(message.contains("PT0S"), "and the way to switch the holding off: "
+        + message);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/health/AdapterHealthReportTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/health/AdapterHealthReportTest.java
@@ -1,0 +1,209 @@
+package io.vanillabp.migration.test.health;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.health.AdapterHealthReport;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * What the platform-neutral half of the health contribution does with the adapters'
+ * answers (story 92): nothing is invented for an adapter which says nothing, an
+ * adapter which throws is a defect worth seeing, and an adapter which is not
+ * configured yet is not an outage.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class AdapterHealthReportTest {
+
+  /**
+   * An adapter which answers the health question and nothing else - the deployment
+   * pipeline is not what this test is about.
+   */
+  private static AdapterDeploymentService<?, ?> adapter(
+      final String adapterId,
+      final java.util.function.Supplier<AdapterHealth> health) {
+
+    return new AdapterDeploymentService<Object, Object>() {
+
+      @Override
+      public String getAdapterId() {
+        return adapterId;
+      }
+
+      @Override
+      public String getAdapterType() {
+        return "dummy";
+      }
+
+      @Override
+      public AdapterHealth checkHealth() {
+        return health.get();
+      }
+
+      @Override
+      public Class<Object> getModelType() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Class<Object> getProcessContextType() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public List<java.util.Map.Entry<String, Object>> readBpmn(
+          final String workflowModuleId,
+          final String filename,
+          final java.io.InputStream bpmn,
+          final boolean isVanillaBpBpmn) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public Object prepareBpmn(
+          final String workflowModuleId,
+          final Object existingContext,
+          final String filename,
+          final String bpmnProcessId,
+          final Object model) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void wireBpmn(
+          final String workflowModuleId,
+          final String filename,
+          final String bpmnProcessId,
+          final Object model,
+          final Object bpmsProcessingContext) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void deployResources(
+          final String workflowModuleId,
+          final Object bpmsProcessingContext) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void startWorkflowProcessing(
+          final String workflowModuleId,
+          final Object bpmsProcessingContext) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void stopWorkflowProcessing(
+          final String workflowModuleId,
+          final Object bpmsProcessingContext) {
+        throw new UnsupportedOperationException();
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("An adapter contributing nothing is absent from the report")
+  public void adapterWithoutCheckIsAbsent() {
+
+    final var report = new AdapterHealthReport(() -> List.of(adapter("silent", () -> null)));
+
+    Assertions.assertTrue(report.collect().isEmpty());
+    Assertions
+        .assertEquals(
+            AdapterHealth.Status.UNKNOWN,
+            AdapterHealthReport.overallStatus(report.collect()),
+            "nothing was checked, so nothing is claimed");
+
+  }
+
+  @Test
+  @DisplayName("An adapter which throws is reported as down, naming what happened")
+  public void throwingAdapterIsDown() {
+
+    final var report = new AdapterHealthReport(
+        () -> List
+            .of(adapter("broken", () -> {
+              throw new IllegalStateException("the check itself is broken");
+            })));
+
+    final var healths = report.collect();
+    Assertions.assertEquals(1, healths.size());
+    Assertions
+        .assertEquals(
+            AdapterHealth.Status.DOWN,
+            healths
+                .getFirst()
+                .status());
+    Assertions
+        .assertTrue(
+            healths
+                .getFirst()
+                .description()
+                .contains("the check itself is broken"));
+
+  }
+
+  @Test
+  @DisplayName("An unconfigured adapter next to a healthy one keeps the application up")
+  public void unconfiguredAdapterDoesNotDragTheApplicationDown() {
+
+    final var report = new AdapterHealthReport(
+        () -> List
+            .of(
+                adapter("running", () -> AdapterHealth.up("running", "dummy", "ok", java.util.Map.of())),
+                adapter(
+                    "planned",
+                    () -> AdapterHealth.unknown("planned", "dummy", "not configured yet", java.util.Map.of()))));
+
+    Assertions
+        .assertEquals(
+            AdapterHealth.Status.UP,
+            AdapterHealthReport.overallStatus(report.collect()));
+
+  }
+
+  @Test
+  @DisplayName("One adapter which is down is enough to report the application down")
+  public void oneDownAdapterIsEnough() {
+
+    final var report = new AdapterHealthReport(
+        () -> List
+            .of(
+                adapter("running", () -> AdapterHealth.up("running", "dummy", "ok", java.util.Map.of())),
+                adapter(
+                    "unreachable",
+                    () -> AdapterHealth
+                        .down("unreachable", "dummy", "Connection refused", java.util.Map.of()))));
+
+    Assertions
+        .assertEquals(
+            AdapterHealth.Status.DOWN,
+            AdapterHealthReport.overallStatus(report.collect()));
+
+  }
+
+  @Test
+  @DisplayName("A detail without a value is left out")
+  public void emptyDetailsAreDropped() {
+
+    final var details = AdapterHealth
+        .detailsBuilder()
+        .with("address", "http://localhost:26500")
+        .with("tenant", null)
+        .with("region", "   ")
+        .build();
+
+    Assertions.assertEquals(java.util.Map.of("address", "http://localhost:26500"), details);
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/DeliveryMdcTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/DeliveryMdcTest.java
@@ -1,0 +1,98 @@
+package io.vanillabp.migration.test.observability;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.MDC;
+
+import io.vanillabp.integration.adapter.migration.observability.DeliveryMdc;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The logging context of a delivery (story 92): the keys are there while the work
+ * runs, they are gone afterwards, and what the application put on the thread survives
+ * both.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class DeliveryMdcTest {
+
+  @AfterEach
+  public void clearMdc() {
+
+    MDC.clear();
+
+  }
+
+  @Test
+  @DisplayName("A delivery sets the keys and gives the thread back as it found it")
+  public void keysAreSetAndRestored() {
+
+    MDC.put("application.key", "kept");
+    MDC.put(DeliveryMdc.WORKFLOW_AGGREGATE_ID, "an-outer-value");
+
+    try (var ignored = DeliveryMdc
+        .ofTaskDelivery("c8", "module", "Process", "4711", "approve", "job-1")) {
+
+      Assertions.assertEquals("c8", MDC.get(DeliveryMdc.ADAPTER));
+      Assertions.assertEquals("module", MDC.get(DeliveryMdc.WORKFLOW_MODULE));
+      Assertions.assertEquals("Process", MDC.get(DeliveryMdc.BPMN_PROCESS));
+      Assertions.assertEquals("4711", MDC.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID));
+      Assertions.assertEquals("approve", MDC.get(DeliveryMdc.TASK_DEFINITION));
+      Assertions.assertEquals("job-1", MDC.get(DeliveryMdc.DELIVERY_ID));
+      Assertions.assertEquals("kept", MDC.get("application.key"));
+
+    }
+
+    Assertions
+        .assertEquals(
+            "an-outer-value",
+            MDC.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID),
+            "a nested delivery gives the outer one its context back");
+    Assertions.assertNull(MDC.get(DeliveryMdc.ADAPTER));
+    Assertions.assertEquals("kept", MDC.get("application.key"));
+
+  }
+
+  @Test
+  @DisplayName("A delivery which throws restores the context as well")
+  public void keysAreRestoredOnTheFailurePath() {
+
+    Assertions
+        .assertThrows(
+            IllegalStateException.class,
+            () -> {
+              try (var ignored = DeliveryMdc
+                  .ofTaskDelivery("c8", "module", "Process", "4711", "approve", "job-1")) {
+                throw new IllegalStateException("the handler threw");
+              }
+            });
+
+    DeliveryMdc.KEYS.forEach(key -> Assertions.assertNull(MDC.get(key)));
+
+  }
+
+  @Test
+  @DisplayName("A phase-two dispatch knows no task and says so")
+  public void phaseTwoDispatchLeavesTheTaskKeysEmpty() {
+
+    MDC.put(DeliveryMdc.TASK_DEFINITION, "left-over-from-somewhere");
+
+    try (var ignored = DeliveryMdc.ofPhaseTwoDispatch("c8", "module", "Process", "4711")) {
+
+      Assertions.assertEquals("c8", MDC.get(DeliveryMdc.ADAPTER));
+      Assertions.assertEquals("4711", MDC.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID));
+      Assertions
+          .assertNull(
+              MDC.get(DeliveryMdc.TASK_DEFINITION),
+              "an outbox entry belongs to no task, so the key has to be absent rather than stale");
+      Assertions.assertNull(MDC.get(DeliveryMdc.DELIVERY_ID));
+
+    }
+
+    Assertions.assertEquals("left-over-from-somewhere", MDC.get(DeliveryMdc.TASK_DEFINITION));
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/MicrometerVanillaBpMetricsTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/MicrometerVanillaBpMetricsTest.java
@@ -166,10 +166,14 @@ public class MicrometerVanillaBpMetricsTest {
   public void pendingOutboxEntriesAreGauged() {
 
     final var pending = new java.util.concurrent.atomic.AtomicLong(3);
-    final var metrics = new MicrometerVanillaBpMetrics();
+    // no holding period, so the test sees what the store says right now
+    final var metrics = new MicrometerVanillaBpMetrics(java.time.Duration.ZERO);
 
     // registered BEFORE the registry exists - which is what a startup does
-    metrics.registerPendingOutboxEntries("JdbcPhaseTwoOutbox", pending::get);
+    metrics
+        .registerPendingOutboxEntries(
+            "JdbcPhaseTwoOutbox",
+            () -> java.util.OptionalLong.of(pending.get()));
 
     final var registry = new SimpleMeterRegistry();
     metrics.bindTo(registry);
@@ -192,6 +196,56 @@ public class MicrometerVanillaBpMetricsTest {
                 .gauge()
                 .value(),
             "a gauge reports what the store says now, not what it said at startup");
+
+  }
+
+  @Test
+  @DisplayName("Reading the pending gauge does not query the store on every collection")
+  public void thePendingGaugeIsHeldBetweenCollections() {
+
+    final var queries = new java.util.concurrent.atomic.AtomicInteger();
+    final var metrics = new MicrometerVanillaBpMetrics(java.time.Duration.ofMinutes(5));
+    metrics
+        .registerPendingOutboxEntries(
+            "JdbcPhaseTwoOutbox",
+            () -> java.util.OptionalLong.of(queries.incrementAndGet()));
+
+    final var registry = new SimpleMeterRegistry();
+    metrics.bindTo(registry);
+    final var gauge = registry
+        .get(VanillaBpMetrics.OUTBOX_PENDING)
+        .gauge();
+
+    Assertions.assertEquals(1.0, gauge.value());
+    Assertions.assertEquals(1.0, gauge.value());
+    Assertions.assertEquals(1.0, gauge.value());
+
+    Assertions
+        .assertEquals(
+            1,
+            queries.get(),
+            "a dashboard next to a scrape must not turn watching the outbox into load on it");
+
+  }
+
+  @Test
+  @DisplayName("A store which cannot say leaves a gap rather than reporting zero")
+  public void anUnavailableStoreReportsNoMeasurement() {
+
+    final var metrics = new MicrometerVanillaBpMetrics(java.time.Duration.ZERO);
+    metrics.registerPendingOutboxEntries("JdbcPhaseTwoOutbox", java.util.OptionalLong::empty);
+
+    final var registry = new SimpleMeterRegistry();
+    metrics.bindTo(registry);
+
+    Assertions
+        .assertTrue(
+            Double
+                .isNaN(registry
+                    .get(VanillaBpMetrics.OUTBOX_PENDING)
+                    .gauge()
+                    .value()),
+            "a zero would be a claim nobody checked");
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/MicrometerVanillaBpMetricsTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/observability/MicrometerVanillaBpMetricsTest.java
@@ -1,0 +1,198 @@
+package io.vanillabp.migration.test.observability;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics;
+import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * The Micrometer side of what the core records (story 92): the meters carry the tags
+ * a deployment fixes and nothing which grows with the number of workflows, they
+ * survive a registry which arrives late, and recording before any registry exists
+ * costs nothing.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MicrometerVanillaBpMetricsTest {
+
+  @Test
+  @DisplayName("Nothing is recorded before a registry was bound")
+  public void recordsAreDroppedWithoutARegistry() {
+
+    final var metrics = new MicrometerVanillaBpMetrics();
+
+    Assertions
+        .assertDoesNotThrow(
+            () -> {
+              metrics
+                  .taskDelivered(
+                      "c8", "module", "Process", "task", VanillaBpMetrics.DeliveryOutcome.COMPLETED, 1_000L);
+              metrics.outboxDispatchStarted("START_WORKFLOW", true);
+              metrics.outboxDispatchFailed("START_WORKFLOW", false);
+              metrics.taskRedeliveryDeduplicated("c8", "module", "Process", "task");
+            },
+            "beans are built before the metrics infrastructure binds them");
+
+    final var registry = new SimpleMeterRegistry();
+    metrics.bindTo(registry);
+    Assertions
+        .assertTrue(
+            registry
+                .getMeters()
+                .isEmpty(),
+            "what happened before the binding is gone, not counted twice");
+
+  }
+
+  @Test
+  @DisplayName("A delivery is counted by outcome and measured, tagged by where it happened")
+  public void deliveriesAreCountedAndMeasured() {
+
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new MicrometerVanillaBpMetrics();
+    metrics.bindTo(registry);
+
+    metrics
+        .taskDelivered("c8", "module", "Process", "task", VanillaBpMetrics.DeliveryOutcome.COMPLETED, 5_000_000L);
+    metrics
+        .taskDelivered("c8", "module", "Process", "task", VanillaBpMetrics.DeliveryOutcome.COMPLETED, 7_000_000L);
+    metrics
+        .taskDelivered("c8", "module", "Process", "task", VanillaBpMetrics.DeliveryOutcome.FAILED, 1_000_000L);
+
+    Assertions
+        .assertEquals(
+            2.0,
+            registry
+                .get(VanillaBpMetrics.TASK_DELIVERIES)
+                .tag(VanillaBpMetrics.TAG_OUTCOME, "completed")
+                .counter()
+                .count());
+    Assertions
+        .assertEquals(
+            1.0,
+            registry
+                .get(VanillaBpMetrics.TASK_DELIVERIES)
+                .tag(VanillaBpMetrics.TAG_OUTCOME, "failed")
+                .counter()
+                .count());
+
+    final var timer = registry
+        .get(VanillaBpMetrics.TASK_DELIVERY_DURATION)
+        .tag(VanillaBpMetrics.TAG_ADAPTER, "c8")
+        .tag(VanillaBpMetrics.TAG_WORKFLOW_MODULE, "module")
+        .tag(VanillaBpMetrics.TAG_BPMN_PROCESS, "Process")
+        .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, "task")
+        .timer();
+    Assertions
+        .assertEquals(
+            3L,
+            timer.count(),
+            "the timer measures the delivery, whatever it ended with");
+    Assertions.assertEquals(13.0, timer.totalTime(TimeUnit.MILLISECONDS), 0.001);
+
+  }
+
+  @Test
+  @DisplayName("A value nobody supplied is named rather than left empty")
+  public void missingTagValuesAreNamed() {
+
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new MicrometerVanillaBpMetrics();
+    metrics.bindTo(registry);
+
+    metrics.taskDelivered(null, "module", "Process", "  ", VanillaBpMetrics.DeliveryOutcome.PENDING, 1L);
+
+    Assertions
+        .assertEquals(
+            1.0,
+            registry
+                .get(VanillaBpMetrics.TASK_DELIVERIES)
+                .tag(VanillaBpMetrics.TAG_ADAPTER, VanillaBpMetrics.TAG_VALUE_UNKNOWN)
+                .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, VanillaBpMetrics.TAG_VALUE_UNKNOWN)
+                .counter()
+                .count());
+
+  }
+
+  @Test
+  @DisplayName("The outbox counts its dispatches, its retries and its failures")
+  public void outboxDispatchesAreCounted() {
+
+    final var registry = new SimpleMeterRegistry();
+    final var metrics = new MicrometerVanillaBpMetrics();
+    metrics.bindTo(registry);
+
+    metrics.outboxDispatchStarted("START_WORKFLOW", false);
+    metrics.outboxDispatchStarted("START_WORKFLOW", true);
+    metrics.outboxDispatchFailed("START_WORKFLOW", false);
+    metrics.outboxDispatchFailed("START_WORKFLOW", true);
+
+    Assertions
+        .assertEquals(
+            2.0,
+            registry
+                .get(VanillaBpMetrics.OUTBOX_DISPATCHES)
+                .tag(VanillaBpMetrics.TAG_OPERATION, "START_WORKFLOW")
+                .counter()
+                .count());
+    Assertions
+        .assertEquals(
+            1.0,
+            registry
+                .get(VanillaBpMetrics.OUTBOX_RETRIES)
+                .counter()
+                .count(),
+            "only the dispatch of an entry which was attempted before is a retry");
+    Assertions
+        .assertEquals(
+            1.0,
+            registry
+                .get(VanillaBpMetrics.OUTBOX_FAILURES)
+                .tag(VanillaBpMetrics.TAG_PERMANENT, "true")
+                .counter()
+                .count(),
+            "a failure repeating cannot fix is told apart from one which can");
+
+  }
+
+  @Test
+  @DisplayName("A store which can count its waiting entries gets a gauge, whenever it registers")
+  public void pendingOutboxEntriesAreGauged() {
+
+    final var pending = new java.util.concurrent.atomic.AtomicLong(3);
+    final var metrics = new MicrometerVanillaBpMetrics();
+
+    // registered BEFORE the registry exists - which is what a startup does
+    metrics.registerPendingOutboxEntries("JdbcPhaseTwoOutbox", pending::get);
+
+    final var registry = new SimpleMeterRegistry();
+    metrics.bindTo(registry);
+
+    Assertions
+        .assertEquals(
+            3.0,
+            registry
+                .get(VanillaBpMetrics.OUTBOX_PENDING)
+                .tag(VanillaBpMetrics.TAG_STORE, "JdbcPhaseTwoOutbox")
+                .gauge()
+                .value());
+
+    pending.set(11);
+    Assertions
+        .assertEquals(
+            11.0,
+            registry
+                .get(VanillaBpMetrics.OUTBOX_PENDING)
+                .gauge()
+                .value(),
+            "a gauge reports what the store says now, not what it said at startup");
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/processservice/PhaseTwoRouterTest.java
@@ -1,5 +1,6 @@
 package io.vanillabp.migration.test.processservice;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verify;
@@ -41,6 +42,61 @@ public class PhaseTwoRouterTest {
     when(processService.getBpmnProcessId()).thenReturn("TestProcess");
 
     testee.register(processService);
+
+  }
+
+  @Test
+  @DisplayName("A dispatch is counted, a repeated one as a retry, and a failure by whether it can be repeated")
+  public void dispatchesAreCounted() {
+
+    when(processService.getWorkflowModuleId()).thenReturn("test-module");
+    when(processService.getBpmnProcessId()).thenReturn("TestProcess");
+    when(processService.convertAggregateId("42")).thenReturn(42L);
+
+    final var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+    final var metrics = new io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics();
+    metrics.bindTo(registry);
+    testee.setMetrics(metrics);
+    registerProcessService();
+
+    final var call = PhaseTwoCall
+        .of(PhaseTwoOperation.START_WORKFLOW, "test-module", "TestProcess", "42", "test-adapter", Map.of());
+    testee.dispatch(call);
+    testee.dispatch(call, true);
+
+    assertEquals(
+        2.0,
+        registry
+            .get(io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.OUTBOX_DISPATCHES)
+            .tag(
+                io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.TAG_OPERATION,
+                PhaseTwoOperation.START_WORKFLOW.name())
+            .counter()
+            .count());
+    assertEquals(
+        1.0,
+        registry
+            .get(io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.OUTBOX_RETRIES)
+            .counter()
+            .count());
+
+    // a failure the adapter called permanent is told apart from one worth repeating
+    Mockito
+        .doThrow(new io.vanillabp.integration.spi.PhaseTwoPermanentFailure("no such process", null))
+        .when(processService)
+        .startWorkflowPhaseTwo(42L, "test-adapter", false);
+    assertThrowsExactly(
+        io.vanillabp.integration.spi.PhaseTwoPermanentFailure.class,
+        () -> testee.dispatch(call));
+    assertEquals(
+        1.0,
+        registry
+            .get(io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.OUTBOX_FAILURES)
+            .tag(
+                io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.TAG_PERMANENT,
+                "true")
+            .counter()
+            .count());
 
   }
 

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/AdapterDeploymentService.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/AdapterDeploymentService.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
 import io.vanillabp.integration.extension.spi.ExtensionWiringService;
 
 /**
@@ -34,6 +35,38 @@ public interface AdapterDeploymentService<BPMN, PC> extends ExtensionWiringServi
    * @return The type of the adapter implementing this interface
    */
   String getAdapterType();
+
+  /**
+   * What this adapter can say about the BPMS it talks to right now, asked by the
+   * platform integration whenever a health endpoint is called (Spring Boot Actuator's
+   * health, Quarkus' readiness). The typical implementation is the cheapest question
+   * the BPMS answers - Camunda 8 asks the cluster for its topology, which is what
+   * Camunda's own starter does.
+   * <p>
+   * The default is <code>null</code>: an adapter which has nothing to check is
+   * ABSENT from the endpoint rather than reported as healthy, and an adapter written
+   * before this existed keeps working unchanged.
+   * <p>
+   * Two rules of the contract are worth repeating here, because they are easy to get
+   * wrong (see {@link AdapterHealth}):
+   * <ul>
+   * <li>an adapter whose connection is not configured yet answers
+   * {@link AdapterHealth.Status#UNKNOWN}, never {@link AdapterHealth.Status#DOWN} -
+   * the application booted with a guiding warning on purpose;</li>
+   * <li>the implementation must RETURN rather than throw, and it must come back
+   * within a bounded time - the platform calls it on the thread serving the health
+   * request. A failure to reach the BPMS is a {@link AdapterHealth.Status#DOWN} with
+   * the reason in the description, not an exception (the core turns a thrown one into
+   * {@link AdapterHealth.Status#DOWN} as a backstop).</li>
+   * </ul>
+   *
+   * @return What the adapter found, or <code>null</code> to contribute nothing
+   */
+  default AdapterHealth checkHealth() {
+
+    return null;
+
+  }
 
   /**
    * Reads the given BPMN input stream and transforms it into the model type.

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/health/AdapterHealth.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/health/AdapterHealth.java
@@ -1,0 +1,133 @@
+package io.vanillabp.integration.adapter.spi.health;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What one BPMS adapter says about the BPMS it talks to, reported by
+ * {@link io.vanillabp.integration.adapter.spi.AdapterDeploymentService#checkHealth()}
+ * and translated by the platform integration into whatever that platform publishes
+ * (a Spring Boot Actuator health indicator, a Quarkus readiness check).
+ * <p>
+ * An adapter which has nothing to contribute returns <code>null</code> instead of a
+ * health: absent is honest, {@link Status#UP} would be a claim nobody checked.
+ * <p>
+ * Two rules follow from VanillaBP's configuration UX and are part of this contract:
+ * <ul>
+ * <li>an adapter which is not configured yet reports {@link Status#UNKNOWN}, never
+ * {@link Status#DOWN} - the application booted with a guiding warning on purpose, and
+ * a health endpoint must not turn that into an outage;</li>
+ * <li>the {@link #details()} name the adapter id and the address it tried, so an
+ * operator can act on the endpoint's output without reading the application's
+ * configuration.</li>
+ * </ul>
+ *
+ * @param adapterId The id of the adapter instance
+ * @param adapterType The adapter's type (e.g. <code>camunda8</code>)
+ * @param status What the adapter found
+ * @param description One sentence for a human, e.g. what failed
+ * @param details Named values an operator needs, e.g. the address and the version of
+ *          the BPMS
+ */
+public record AdapterHealth(
+                            String adapterId,
+                            String adapterType,
+                            Status status,
+                            String description,
+                            Map<String, String> details) {
+
+  /**
+   * The three answers an adapter may give.
+   */
+  public enum Status {
+
+    /**
+     * The BPMS answered.
+     */
+    UP,
+
+    /**
+     * The BPMS did not answer, or answered with a defect. This is the only status
+     * which makes an application unhealthy.
+     */
+    DOWN,
+
+    /**
+     * Nothing was checked, and that is not a defect: the adapter is not configured
+     * yet, or the check was switched off.
+     */
+    UNKNOWN
+  }
+
+  /**
+   * Builds the details map of an adapter health, dropping entries without a value so
+   * the endpoint never shows an empty line.
+   */
+  public static class DetailsBuilder {
+
+    private final Map<String, String> details = new LinkedHashMap<>();
+
+    /**
+     * @param name The name of the detail
+     * @param value The value, ignored if <code>null</code> or blank
+     * @return This builder
+     */
+    public DetailsBuilder with(
+        final String name,
+        final String value) {
+
+      if ((value != null) && !value.isBlank()) {
+        details.put(name, value);
+      }
+      return this;
+
+    }
+
+    public Map<String, String> build() {
+
+      return Map.copyOf(details);
+
+    }
+
+  }
+
+  /**
+   * @return A builder for the {@link #details()} of an adapter health
+   */
+  public static DetailsBuilder detailsBuilder() {
+
+    return new DetailsBuilder();
+
+  }
+
+  public static AdapterHealth up(
+      final String adapterId,
+      final String adapterType,
+      final String description,
+      final Map<String, String> details) {
+
+    return new AdapterHealth(adapterId, adapterType, Status.UP, description, details);
+
+  }
+
+  public static AdapterHealth down(
+      final String adapterId,
+      final String adapterType,
+      final String description,
+      final Map<String, String> details) {
+
+    return new AdapterHealth(adapterId, adapterType, Status.DOWN, description, details);
+
+  }
+
+  public static AdapterHealth unknown(
+      final String adapterId,
+      final String adapterType,
+      final String description,
+      final Map<String, String> details) {
+
+    return new AdapterHealth(adapterId, adapterType, Status.UNKNOWN, description, details);
+
+  }
+
+}

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/observability/CachedGaugeValue.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/observability/CachedGaugeValue.java
@@ -1,0 +1,183 @@
+package io.vanillabp.integration.adapter.spi.observability;
+
+import java.time.Duration;
+import java.util.OptionalLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Holds the value of a gauge whose measurement costs something, so that reading the
+ * metric does not.
+ * <p>
+ * <b>The rule this exists for.</b> A gauge is read every time somebody collects, and
+ * nobody expects looking to be expensive. Prometheus scrapes every fifteen seconds by
+ * default, a dashboard asks in between, and every instance of the application answers
+ * separately - a gauge backed by a database query turns a dashboard into load on the
+ * very system it is watching. VanillaBP's promise is therefore that reading a metric
+ * never costs more than reading a number, and this class is how it is kept: whatever
+ * really has to be asked is asked at most once per
+ * {@code vanillabp.metrics.gauge-cache}, and everybody else gets the number that came
+ * back.
+ * <p>
+ * It lives in the adapter SPI because the promise is not the platform's alone. A BPMS
+ * adapter registering a gauge of its own - the backlog of a queue, the size of
+ * something the BPMS holds - keeps the same promise with the same class. A value which
+ * is already in memory (a counter, the free permits of a semaphore) needs none of this
+ * and should not be wrapped: caching it would only make it stale.
+ * <p>
+ * <b>What it guarantees.</b>
+ * <ul>
+ * <li>Within one time-to-live the supplier runs exactly once, however many collectors
+ * ask. A second thread arriving while the first one is asking waits for that answer
+ * rather than starting a second query.</li>
+ * <li>A supplier which throws does not reach the metrics backend and does not poison
+ * the gauge: the failure is answered with "no measurement" for the rest of the window
+ * and the next window asks again. A database which was down for a minute is therefore
+ * back in the metric a minute later, without anybody having hammered it meanwhile.</li>
+ * <li>A time-to-live of zero (or a negative one) switches the holding off, which is
+ * what a test wants when it has just changed something and needs to see it.</li>
+ * </ul>
+ */
+public final class CachedGaugeValue {
+
+  /**
+   * What the supplier answered and when, as one object so a reader never sees a value
+   * from one measurement with the timestamp of another.
+   */
+  private record Measurement(
+                             long takenAtNanos,
+                             OptionalLong value) {
+  }
+
+  private final Duration timeToLive;
+
+  private final Supplier<OptionalLong> measure;
+
+  /**
+   * The clock, in nanoseconds of an arbitrary origin - injectable so a test does not
+   * have to wait for a window to pass.
+   */
+  private final LongSupplier nanoClock;
+
+  /**
+   * Serializes the measuring, so concurrent collectors produce one query and not one
+   * each.
+   */
+  private final ReentrantLock measuring = new ReentrantLock();
+
+  private volatile Measurement current;
+
+  /**
+   * @param timeToLive How long one measurement is reused; zero or negative switches
+   *          the holding off
+   * @param measure What really has to be asked, answering
+   *          {@link OptionalLong#empty()} where it cannot say
+   */
+  public CachedGaugeValue(
+      final Duration timeToLive,
+      final Supplier<OptionalLong> measure) {
+
+    this(timeToLive, measure, System::nanoTime);
+
+  }
+
+  /**
+   * @param timeToLive How long one measurement is reused
+   * @param measure What really has to be asked
+   * @param nanoClock The clock to age a measurement by (tests hand in their own)
+   */
+  public CachedGaugeValue(
+      final Duration timeToLive,
+      final Supplier<OptionalLong> measure,
+      final LongSupplier nanoClock) {
+
+    this.timeToLive = timeToLive == null
+        ? Duration.ZERO
+        : timeToLive;
+    this.measure = measure;
+    this.nanoClock = nanoClock;
+
+  }
+
+  /**
+   * Wraps an expensive measurement into a supplier a gauge can read on every
+   * collection.
+   *
+   * @param timeToLive How long one measurement is reused
+   * @param measure What really has to be asked
+   * @return A supplier answering from the held measurement
+   */
+  public static Supplier<OptionalLong> holding(
+      final Duration timeToLive,
+      final Supplier<OptionalLong> measure) {
+
+    final var held = new CachedGaugeValue(timeToLive, measure);
+    return held::get;
+
+  }
+
+  /**
+   * The value a gauge reports right now: the held measurement while it is young
+   * enough, a fresh one otherwise.
+   *
+   * @return The value, or {@link OptionalLong#empty()} where the measurement could not
+   *         be taken
+   */
+  public OptionalLong get() {
+
+    if (timeToLive.isZero() || timeToLive.isNegative()) {
+      return takeMeasurement();
+    }
+
+    final var held = current;
+    if (isYoungEnough(held)) {
+      return held.value();
+    }
+
+    measuring.lock();
+    try {
+      // somebody else may have measured while this thread waited for the lock - that
+      // answer is what this collection reports, instead of asking a second time
+      final var measured = current;
+      if (isYoungEnough(measured)) {
+        return measured.value();
+      }
+      final var fresh = new Measurement(nanoClock.getAsLong(), takeMeasurement());
+      current = fresh;
+      return fresh.value();
+    } finally {
+      measuring.unlock();
+    }
+
+  }
+
+  private boolean isYoungEnough(
+      final Measurement measurement) {
+
+    return (measurement != null) && ((nanoClock.getAsLong() - measurement.takenAtNanos()) < timeToLive.toNanos());
+
+  }
+
+  /**
+   * Asks the supplier, turning a failure into "no measurement". A gauge must never be
+   * the reason an application fails, and a metrics backend calling it must never see
+   * an exception.
+   */
+  private OptionalLong takeMeasurement() {
+
+    try {
+      final var measured = measure.get();
+      return measured == null
+          ? OptionalLong.empty()
+          : measured;
+    } catch (final RuntimeException e) {
+      org.slf4j.LoggerFactory
+          .getLogger(CachedGaugeValue.class)
+          .debug("A gauge's measurement failed and is reported as absent", e);
+      return OptionalLong.empty();
+    }
+
+  }
+
+}

--- a/migration-adapter/spi/src/test/java/io/vanillabp/integration/adapter/spi/observability/CachedGaugeValueTest.java
+++ b/migration-adapter/spi/src/test/java/io/vanillabp/integration/adapter/spi/observability/CachedGaugeValueTest.java
@@ -1,0 +1,197 @@
+package io.vanillabp.integration.adapter.spi.observability;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.OptionalLong;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 92: a gauge is read on every collection, so what stands behind it must not be a
+ * query. What is pinned here is the promise the class makes - one measurement per
+ * window whoever asks, a failure which does not stay, and a way to switch the holding
+ * off for a test which needs to see the real value.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class CachedGaugeValueTest {
+
+  /**
+   * A clock the test moves itself, so no window has to be waited out.
+   */
+  private final AtomicLong nanos = new AtomicLong();
+
+  private CachedGaugeValue held(
+      final Duration timeToLive,
+      final java.util.function.Supplier<OptionalLong> measure) {
+
+    return new CachedGaugeValue(timeToLive, measure, nanos::get);
+
+  }
+
+  @Test
+  @DisplayName("Within one window the measurement is taken once, however often it is read")
+  public void oneMeasurementPerWindow() {
+
+    final var measurements = new AtomicInteger();
+    final var value = held(
+        Duration.ofSeconds(10),
+        () -> OptionalLong.of(measurements.incrementAndGet()));
+
+    assertEquals(OptionalLong.of(1), value.get());
+    assertEquals(OptionalLong.of(1), value.get());
+    nanos.addAndGet(Duration.ofSeconds(9).toNanos());
+    assertEquals(OptionalLong.of(1), value.get());
+
+    assertEquals(1, measurements.get(), "a scrape and a dashboard together cost one query");
+
+  }
+
+  @Test
+  @DisplayName("Once the window passed the next read measures again")
+  public void theNextWindowMeasuresAgain() {
+
+    final var measurements = new AtomicInteger();
+    final var value = held(
+        Duration.ofSeconds(10),
+        () -> OptionalLong.of(measurements.incrementAndGet()));
+
+    assertEquals(OptionalLong.of(1), value.get());
+    nanos.addAndGet(Duration.ofSeconds(10).toNanos());
+
+    assertEquals(OptionalLong.of(2), value.get(), "the number an operator sees stays current");
+    assertEquals(2, measurements.get());
+
+  }
+
+  @Test
+  @DisplayName("Without a window every read measures")
+  public void aZeroWindowSwitchesTheHoldingOff() {
+
+    final var measurements = new AtomicInteger();
+    final var value = held(
+        Duration.ZERO,
+        () -> OptionalLong.of(measurements.incrementAndGet()));
+
+    value.get();
+    value.get();
+    value.get();
+
+    assertEquals(3, measurements.get(), "which is what a test wants after it changed something");
+
+  }
+
+  @Test
+  @DisplayName("A failing measurement is absent for the window and gone in the next one")
+  public void aFailureDoesNotStay() {
+
+    final var failing = new java.util.concurrent.atomic.AtomicBoolean(true);
+    final var measurements = new AtomicInteger();
+    final var value = held(
+        Duration.ofSeconds(10),
+        () -> {
+          measurements.incrementAndGet();
+          if (failing.get()) {
+            throw new IllegalStateException("the database is not there");
+          }
+          return OptionalLong.of(42);
+        });
+
+    assertTrue(value.get().isEmpty(), "the exception must not reach the metrics backend");
+    assertTrue(value.get().isEmpty());
+    assertEquals(1, measurements.get(), "and a broken database is not asked again within the window");
+
+    failing.set(false);
+    nanos.addAndGet(Duration.ofSeconds(10).toNanos());
+
+    assertEquals(OptionalLong.of(42), value.get(), "a database which came back is back in the metric");
+
+  }
+
+  @Test
+  @DisplayName("A supplier answering nothing is passed through as nothing")
+  public void anEmptyMeasurementStaysEmpty() {
+
+    final var value = held(Duration.ofSeconds(10), OptionalLong::empty);
+
+    assertFalse(value.get().isPresent());
+
+  }
+
+  @Test
+  @DisplayName("Collectors arriving at the same moment produce one measurement, not one each")
+  public void concurrentCollectorsShareOneMeasurement() throws Exception {
+
+    final var collectors = 8;
+    final var measurements = new AtomicInteger();
+    final var insideTheMeasurement = new CountDownLatch(1);
+    final var value = held(
+        Duration.ofSeconds(10),
+        () -> {
+          measurements.incrementAndGet();
+          try {
+            // hold the first measurement open so the others really are concurrent
+            insideTheMeasurement.await(5, TimeUnit.SECONDS);
+          } catch (final InterruptedException e) {
+            Thread
+                .currentThread()
+                .interrupt();
+          }
+          return OptionalLong.of(7);
+        });
+
+    final var allReady = new CountDownLatch(collectors);
+    final var allDone = new CountDownLatch(collectors);
+    try (var collecting = Executors.newFixedThreadPool(collectors)) {
+      for (var collector = 0; collector < collectors; ++collector) {
+        collecting
+            .execute(() -> {
+              allReady.countDown();
+              try {
+                assertEquals(OptionalLong.of(7), value.get());
+              } finally {
+                allDone.countDown();
+              }
+            });
+      }
+      assertTrue(allReady.await(5, TimeUnit.SECONDS));
+      // the first collector is now inside the measurement, the others are queued
+      Thread.sleep(100);
+      insideTheMeasurement.countDown();
+      assertTrue(allDone.await(10, TimeUnit.SECONDS));
+    }
+
+    assertEquals(
+        1,
+        measurements.get(),
+        "eight collectors at the same moment must not become eight queries");
+
+  }
+
+  @Test
+  @DisplayName("The factory hands out a supplier a gauge can read")
+  public void theFactoryProducesASupplier() {
+
+    final var measurements = new AtomicInteger();
+    final var gaugeValue = CachedGaugeValue
+        .holding(
+            Duration.ofMinutes(5),
+            () -> OptionalLong.of(measurements.incrementAndGet()));
+
+    assertEquals(OptionalLong.of(1), gaugeValue.get());
+    assertEquals(OptionalLong.of(1), gaugeValue.get());
+
+  }
+
+}

--- a/quarkus-integration/README.md
+++ b/quarkus-integration/README.md
@@ -208,6 +208,29 @@ manages an aggregate.
   `TaskDeliveryRetentionCleanup`, which calls `cleanUpExpiredRecords` per
   `vanillabp.outbox.retention`.
 
+## What is published where (story 92)
+
+Both contributions follow the recipe the election cache's meters established: the runtime
+module declares an optional dependency (`micrometer-core`, `microprofile-health-api`), the
+producer references its types, and a build step registers the producer only when the matching
+EXTENSION is on the deployment classpath. The extension's processor class is the signal, not
+the presence of the API classes: those can arrive transitively without the extension, and then
+nothing produces the `MeterRegistry` the producer needs.
+
+- `VanillaBpMetricsBuildStepProcessor` looks for `io.quarkus.micrometer.deployment.MicrometerProcessor`
+  and registers `VanillaBpMetricsProducer`.
+- `VanillaBpHealthBuildStepProcessor` looks for
+  `io.quarkus.smallrye.health.deployment.SmallRyeHealthProcessor` and registers
+  `VanillaBpReadinessCheck`.
+
+Both beans are `setUnremovable()`: Micrometer resp. SmallRye Health collect them at startup,
+nothing injects them.
+
+The pending-entry gauges of the outbox stores are registered by a `StartupEvent` observer with
+`@Priority(APPLICATION + 800)`, which is later than the outbox dispatchers' own observers. They
+create their table on startup, and a store asked before its table exists cannot count, so
+without the priority the gauge would silently never appear.
+
 ## Noteworthy & Contributors
 
 [VanillaBP](https://www.github.com/vanillabp/spi-for-java) was developed by [Phactum](https://www.phactum.at) with the

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/health/VanillaBpHealthBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/health/VanillaBpHealthBuildStepProcessor.java
@@ -1,0 +1,61 @@
+package io.vanillabp.integration.deployment.health;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.vanillabp.integration.runtime.health.VanillaBpReadinessCheck;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Publishes the adapters' health as a readiness check - but only for an application
+ * which uses the SmallRye Health extension. VanillaBP does not bring it: a health
+ * endpoint is the application's decision, and an application without one has to boot
+ * unchanged.
+ * <p>
+ * The signal is the extension's build-step class on the DEPLOYMENT classpath, the
+ * same way the Micrometer extension is detected for the meters.
+ */
+@Slf4j
+public class VanillaBpHealthBuildStepProcessor {
+
+  private static final String HEALTH_EXTENSION_PROCESSOR = "io.quarkus.smallrye.health.deployment.SmallRyeHealthProcessor";
+
+  /**
+   * @param additionalBeans Producer used to register the readiness check
+   */
+  @BuildStep
+  void registerAdapterHealthCheck(
+      final BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+    if (!isHealthExtensionPresent()) {
+      return;
+    }
+
+    log.debug("SmallRye Health found: the BPMS adapters report the readiness check 'vanillabp'");
+
+    additionalBeans
+        .produce(AdditionalBeanBuildItem
+            .builder()
+            .addBeanClass(VanillaBpReadinessCheck.class)
+            .setUnremovable() // collected by SmallRye Health, never injected
+            .build());
+
+  }
+
+  private static boolean isHealthExtensionPresent() {
+
+    try {
+      Class.forName(
+          HEALTH_EXTENSION_PROCESSOR,
+          false,
+          Thread
+              .currentThread()
+              .getContextClassLoader());
+      return true;
+    } catch (final ClassNotFoundException | LinkageError e) {
+      return false;
+    }
+
+  }
+
+}

--- a/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/VanillaBpMetricsBuildStepProcessor.java
+++ b/quarkus-integration/deployment/src/main/java/io/vanillabp/integration/deployment/processservice/VanillaBpMetricsBuildStepProcessor.java
@@ -1,0 +1,66 @@
+package io.vanillabp.integration.deployment.processservice;
+
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.vanillabp.integration.runtime.processservice.VanillaBpMetricsProducer;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Publishes what VanillaBP counts about its deliveries and its outbox as Micrometer
+ * meters - but only for an application which uses Micrometer. VanillaBP does not
+ * bring it: metrics are the application's decision, and an application without them
+ * has to boot unchanged.
+ * <p>
+ * The signal is the Micrometer extension's build-step class on the DEPLOYMENT
+ * classpath, exactly as the election cache's meters do it (see
+ * {@code WorkflowAdapterCacheMetricsBuildStepProcessor} for why the presence of
+ * Micrometer's own classes would not be enough).
+ */
+@Slf4j
+public class VanillaBpMetricsBuildStepProcessor {
+
+  private static final String MICROMETER_EXTENSION_PROCESSOR = "io.quarkus.micrometer.deployment.MicrometerProcessor";
+
+  /**
+   * @param additionalBeans Producer used to register the metrics' producer
+   */
+  @BuildStep
+  void registerVanillaBpMetrics(
+      final BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+
+    if (!isMicrometerExtensionPresent()) {
+      return;
+    }
+
+    log.debug(
+        "Micrometer found: task deliveries and the phase-two outbox report meters '{}.*' resp. '{}.*'",
+        io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.TASK_DELIVERIES,
+        io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.OUTBOX_DISPATCHES);
+
+    additionalBeans
+        .produce(AdditionalBeanBuildItem
+            .builder()
+            .addBeanClass(VanillaBpMetricsProducer.class)
+            .setUnremovable() // applied by Micrometer's own startup, never injected
+            .build());
+
+  }
+
+  private static boolean isMicrometerExtensionPresent() {
+
+    try {
+      Class.forName(
+          MICROMETER_EXTENSION_PROCESSOR,
+          false,
+          Thread
+              .currentThread()
+              .getContextClassLoader());
+      return true;
+    } catch (final ClassNotFoundException | LinkageError e) {
+      return false;
+    }
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/pom.xml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/pom.xml
@@ -61,6 +61,16 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-orm</artifactId>
     </dependency>
+    <!-- story 92: the delivery meters and the readiness check of the adapters are
+         published only where the application brings these extensions -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-micrometer</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-health</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-jacoco</artifactId>

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TaskProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TaskProcessWiringSource.java
@@ -27,7 +27,8 @@ public class TaskProcessWiringSource implements DummyTaskWiringSource {
             new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
             new BpmnTaskSpec("Activity_Fail", "failTask"),
             new BpmnTaskSpec("Activity_Async", "asyncTask"),
-            new BpmnTaskSpec("Activity_Bind", "bindParameters"))
+            new BpmnTaskSpec("Activity_Bind", "bindParameters"),
+            new BpmnTaskSpec("Activity_Mdc", "recordMdc"))
         : List.of();
 
   }

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TaskWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TaskWorkflowService.java
@@ -57,6 +57,25 @@ public class TaskWorkflowService {
 
   }
 
+  /**
+   * What the logging context held while the handler ran - the assertion of the MDC
+   * VanillaBP puts around every delivery (story 92).
+   */
+  public static final java.util.Map<String, String> MDC_DURING_TASK = new java.util.concurrent.ConcurrentHashMap<>();
+
+  @WorkflowTask
+  public void recordMdc(
+      final TaskAggregate aggregate) {
+
+    MDC_DURING_TASK.clear();
+    final var context = org.slf4j.MDC.getCopyOfContextMap();
+    if (context != null) {
+      MDC_DURING_TASK.putAll(context);
+    }
+    aggregate.setStatus("mdc-recorded");
+
+  }
+
   @WorkflowTask
   public void failTask(
       final TaskAggregate aggregate) {

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TestHealthSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TestHealthSource.java
@@ -1,0 +1,31 @@
+package io.vanillabp.integration.test.deployment;
+
+import java.util.function.Function;
+
+import io.vanillabp.adapter.dummy.runtime.DummyHealthSource;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * Plays what the dummy adapter finds when it asks its BPMS. The answer is a static
+ * field so a test can change it between assertions without rebuilding the
+ * application.
+ */
+@ApplicationScoped
+public class TestHealthSource implements DummyHealthSource {
+
+  /**
+   * What to answer, set by the test; the default contributes nothing, which is what
+   * an adapter without a check does.
+   */
+  public static Function<String, AdapterHealth> answer = adapterId -> null;
+
+  @Override
+  public AdapterHealth healthOf(
+      final String adapterId) {
+
+    return answer.apply(adapterId);
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TestMeterRegistryProducer.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/deployment/TestMeterRegistryProducer.java
@@ -1,0 +1,23 @@
+package io.vanillabp.integration.test.deployment;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+/**
+ * A registry backend for the test: Quarkus adds every {@code MeterRegistry} bean to
+ * its composite, and only a composite WITH a child actually records measurements.
+ */
+@ApplicationScoped
+public class TestMeterRegistryProducer {
+
+  @Produces
+  @Singleton
+  public SimpleMeterRegistry simpleMeterRegistry() {
+
+    return new SimpleMeterRegistry();
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ObservabilityTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/ObservabilityTest.java
@@ -1,0 +1,269 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.migration.observability.DeliveryMdc;
+import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.runtime.health.VanillaBpReadinessCheck;
+import io.vanillabp.integration.test.deployment.TaskAggregate;
+import io.vanillabp.integration.test.deployment.TaskAggregatePersistence;
+import io.vanillabp.integration.test.deployment.TaskProcessWiringSource;
+import io.vanillabp.integration.test.deployment.TaskWorkflowService;
+import io.vanillabp.integration.test.deployment.TestHealthSource;
+import io.vanillabp.integration.test.deployment.TestMeterRegistryProducer;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Acceptance test of what an operator gets to see on Quarkus (story 92): every task
+ * delivery is counted by outcome and measured, it carries a logging context naming
+ * the workflow it belongs to, and the BPMS adapters contribute what they know about
+ * their BPMS to the readiness check.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ObservabilityTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TaskProcess";
+
+  private static final String ADAPTER = "demo1";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("observability/application.yaml", "application.yaml")
+          .addClass(TaskAggregate.class)
+          .addClass(TaskAggregatePersistence.class)
+          .addClass(TaskWorkflowService.class)
+          .addClass(io.vanillabp.integration.test.deployment.RequestScopedProbe.class)
+          .addClass(TaskProcessWiringSource.class)
+          .addClass(TestMeterRegistryProducer.class)
+          .addClass(TestHealthSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/TaskProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  TaskAggregatePersistence persistence;
+
+  @Inject
+  SimpleMeterRegistry meterRegistry;
+
+  @Inject
+  @org.eclipse.microprofile.health.Readiness
+  VanillaBpReadinessCheck readinessCheck;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> ADAPTER.equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return "job-"
+            + aggregateId;
+      }
+
+    };
+
+  }
+
+  @Test
+  @DisplayName("Every delivery is counted by its outcome, measured, and carries its workflow in the log context")
+  public void deliveriesAreCountedMeasuredAndLogged() {
+
+    final var dummyAdapter = dummyAdapter();
+
+    persistence.seed("q-1");
+    dummyAdapter.invokeTask(MODULE, PROCESS, context("processTask", "q-1"));
+    persistence.seed("q-2");
+    dummyAdapter.invokeTask(MODULE, PROCESS, context("raiseBpmnError", "q-2"));
+    persistence.seed("q-3");
+    assertThrows(
+        RuntimeException.class,
+        () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("failTask", "q-3")));
+
+    assertEquals(1.0, deliveries("processTask", "completed"));
+    assertEquals(1.0, deliveries("raiseBpmnError", "bpmn-error"));
+    assertEquals(1.0, deliveries("failTask", "failed"));
+
+    final var timer = meterRegistry
+        .get(VanillaBpMetrics.TASK_DELIVERY_DURATION)
+        .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, "processTask")
+        .timer();
+    assertEquals(1L, timer.count());
+    assertTrue(timer.totalTime(TimeUnit.NANOSECONDS) > 0);
+
+    persistence.seed("q-4");
+    dummyAdapter.invokeTask(MODULE, PROCESS, context("recordMdc", "q-4"));
+
+    final var during = TaskWorkflowService.MDC_DURING_TASK;
+    assertEquals(ADAPTER, during.get(DeliveryMdc.ADAPTER));
+    assertEquals(MODULE, during.get(DeliveryMdc.WORKFLOW_MODULE));
+    assertEquals(PROCESS, during.get(DeliveryMdc.BPMN_PROCESS));
+    assertEquals("q-4", during.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID));
+    assertEquals("recordMdc", during.get(DeliveryMdc.TASK_DEFINITION));
+    assertEquals("job-q-4", during.get(DeliveryMdc.DELIVERY_ID));
+
+    DeliveryMdc.KEYS
+        .forEach(key -> assertNull(
+            org.slf4j.MDC.get(key),
+            "the key '%s' has to be gone once the delivery is done".formatted(key)));
+
+  }
+
+  private double deliveries(
+      final String taskDefinition,
+      final String outcome) {
+
+    return meterRegistry
+        .get(VanillaBpMetrics.TASK_DELIVERIES)
+        .tag(VanillaBpMetrics.TAG_ADAPTER, ADAPTER)
+        .tag(VanillaBpMetrics.TAG_WORKFLOW_MODULE, MODULE)
+        .tag(VanillaBpMetrics.TAG_BPMN_PROCESS, PROCESS)
+        .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, taskDefinition)
+        .tag(VanillaBpMetrics.TAG_OUTCOME, outcome)
+        .counter()
+        .count();
+
+  }
+
+  @Test
+  @DisplayName("An unconfigured adapter is not an outage, an unreachable one is, and both name the adapter")
+  public void readinessReportsWhatTheAdaptersFound() {
+
+    try {
+
+      TestHealthSource.answer = adapterId -> null;
+      final var nothing = readinessCheck.call();
+      assertEquals(HealthCheckResponse.Status.UP, nothing.getStatus());
+      assertTrue(
+          nothing
+              .getData()
+              .isEmpty() || nothing
+                  .getData()
+                  .get()
+                  .isEmpty(),
+          "an adapter which checks nothing is absent rather than reported as healthy");
+
+      TestHealthSource.answer = adapterId -> AdapterHealth
+          .unknown(
+              adapterId,
+              "dummy",
+              "The adapter is not configured yet",
+              AdapterHealth
+                  .detailsBuilder()
+                  .with("address", "<none>")
+                  .build());
+      final var unconfigured = readinessCheck.call();
+      assertEquals(
+          HealthCheckResponse.Status.UP,
+          unconfigured.getStatus(),
+          "an application which booted with a guiding warning is not an outage");
+      assertEquals(
+          "UNKNOWN",
+          unconfigured
+              .getData()
+              .orElseThrow()
+              .get(ADAPTER
+                  + ".status"));
+
+      TestHealthSource.answer = adapterId -> AdapterHealth
+          .down(
+              adapterId,
+              "dummy",
+              "Connection refused",
+              AdapterHealth
+                  .detailsBuilder()
+                  .with("address", "http://localhost:26500")
+                  .build());
+      final var unreachable = readinessCheck.call();
+      assertEquals(HealthCheckResponse.Status.DOWN, unreachable.getStatus());
+      final var data = unreachable
+          .getData()
+          .orElseThrow();
+      assertEquals("Connection refused", data.get(ADAPTER
+          + ".description"));
+      assertEquals(
+          "http://localhost:26500",
+          data.get(ADAPTER
+              + ".address"),
+          "the address is what lets an operator act without reading the configuration");
+
+      TestHealthSource.answer = adapterId -> {
+        throw new IllegalStateException("the check itself is broken");
+      };
+      final var broken = readinessCheck.call();
+      assertEquals(HealthCheckResponse.Status.DOWN, broken.getStatus());
+      assertFalse(
+          broken
+              .getData()
+              .orElseThrow()
+              .get(ADAPTER
+                  + ".description")
+              .toString()
+              .isBlank());
+
+    } finally {
+      TestHealthSource.answer = adapterId -> null;
+    }
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/observability/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/observability/application.yaml
@@ -1,0 +1,15 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:observability;DB_CLOSE_DELAY=-1
+vanillabp:
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentService.java
@@ -71,6 +71,23 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
   private final Instance<DummyProcessVersionSource> processVersionSource;
 
   /**
+   * Test hook standing in for what a real adapter asks its BPMS (see
+   * {@link DummyHealthSource}).
+   */
+  private final Instance<DummyHealthSource> healthSource;
+
+  @Override
+  public io.vanillabp.integration.adapter.spi.health.AdapterHealth checkHealth() {
+
+    return healthSource.isResolvable()
+        ? healthSource
+            .get()
+            .healthOf(adapterId)
+        : null;
+
+  }
+
+  /**
    * The versions of the deployed BPMN processes, cached like a real adapter caches
    * them - the test's {@link DummyProcessVersionSource} plays the BPMS query.
    */
@@ -140,7 +157,8 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
       final BpmsInitiatedStartInvoker bpmsInitiatedStartInvoker,
       final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource,
       final WorkflowEndedInvoker workflowEndedInvoker,
-      final Instance<DummyProcessVersionSource> processVersionSource) {
+      final Instance<DummyProcessVersionSource> processVersionSource,
+      final Instance<DummyHealthSource> healthSource) {
 
     this.adapterId = adapterId;
     this.listeners = listeners;
@@ -150,6 +168,7 @@ public class DummyDeploymentService implements AdapterDeploymentService<Object, 
     this.bpmsInitiatedStartSource = bpmsInitiatedStartSource;
     this.workflowEndedInvoker = workflowEndedInvoker;
     this.processVersionSource = processVersionSource;
+    this.healthSource = healthSource;
 
   }
 

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyDeploymentServiceProducer.java
@@ -47,7 +47,8 @@ public class DummyDeploymentServiceProducer {
       final io.vanillabp.integration.adapter.migration.workflowtask.WorkflowTaskRegistry workflowTaskRegistry,
       @Any final Instance<DummyTaskWiringSource> taskWiringSource,
       @Any final Instance<DummyBpmsInitiatedStartSource> bpmsInitiatedStartSource,
-      @Any final Instance<DummyProcessVersionSource> processVersionSource) {
+      @Any final Instance<DummyProcessVersionSource> processVersionSource,
+      @Any final Instance<DummyHealthSource> healthSource) {
 
     return properties
         .adapterTypes()
@@ -58,7 +59,7 @@ public class DummyDeploymentServiceProducer {
         .sorted()
         .<AdapterDeploymentService<Object, Object>>map(
             adapterId -> new DummyDeploymentService(
-                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource, workflowTaskRegistry, processVersionSource))
+                adapterId, deploymentListeners, workflowTaskRegistry, taskWiringSource, workflowTaskRegistry, bpmsInitiatedStartSource, workflowTaskRegistry, processVersionSource, healthSource))
         .toList();
 
   }

--- a/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyHealthSource.java
+++ b/quarkus-integration/integration-tests/dummy-adapter/runtime/src/main/java/io/vanillabp/adapter/dummy/runtime/DummyHealthSource.java
@@ -1,0 +1,22 @@
+package io.vanillabp.adapter.dummy.runtime;
+
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to play what a real
+ * adapter finds when it asks its BPMS: without a bean the adapter contributes
+ * nothing to the health endpoint (which is what an adapter without a check does),
+ * with one it contributes whatever the test returns - including an exception, to
+ * cover the adapter which cannot answer its own question.
+ */
+@FunctionalInterface
+public interface DummyHealthSource {
+
+  /**
+   * @param adapterId The adapter ID being asked
+   * @return What the adapter found, or <code>null</code> to contribute nothing
+   */
+  AdapterHealth healthOf(
+      String adapterId);
+
+}

--- a/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxMetricsTest.java
+++ b/quarkus-integration/integration-tests/outbox-integration-tests/src/test/java/io/vanillabp/integration/it/OutboxMetricsTest.java
@@ -1,0 +1,88 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * What the phase-two outbox reports about itself (story 92): the entries waiting to
+ * be dispatched are a gauge, and every dispatch is counted. Those are the numbers an
+ * operator looks at when a BPMS is unreachable - the outbox is where a broken
+ * connection piles up first.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OutboxMetricsTest {
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addClass(TestMeterRegistryProducer.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideRuntimeConfigKey("quarkus.datasource.jdbc.url", "jdbc:h2:mem:outbox-metrics-it;DB_CLOSE_DELAY=-1");
+
+  @Inject
+  WorkflowService workflowService;
+
+  @Inject
+  RecordingPhaseTwoListener listener;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  SimpleMeterRegistry meterRegistry;
+
+  @Test
+  @DisplayName("The waiting entries are a gauge and every dispatch is counted")
+  public void outboxReportsItsBacklogAndItsDispatches() throws Exception {
+
+    listener.reset();
+
+    final var pending = meterRegistry
+        .get(VanillaBpMetrics.OUTBOX_PENDING)
+        .gauge();
+    assertNotNull(pending, "a store which can count its waiting entries publishes the gauge");
+    assertEquals(
+        0.0,
+        pending.value(),
+        "nothing was scheduled yet, so nothing is waiting");
+
+    userTransaction.begin();
+    workflowService.startWorkflow("metrics-test");
+    userTransaction.commit();
+
+    listener.awaitInvocations(1, 30_000);
+
+    assertTrue(
+        meterRegistry
+            .get(VanillaBpMetrics.OUTBOX_DISPATCHES)
+            .tag(VanillaBpMetrics.TAG_OPERATION, PhaseTwoOperation.START_WORKFLOW.name())
+            .counter()
+            .count() >= 1.0,
+        "the dispatch of the started workflow's phase two has to be counted");
+
+  }
+
+}

--- a/quarkus-integration/runtime/pom.xml
+++ b/quarkus-integration/runtime/pom.xml
@@ -24,6 +24,13 @@
       <artifactId>micrometer-core</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- optional: the adapters' health is published only for an application using
+         the SmallRye Health extension (see VanillaBpReadinessCheck) -->
+    <dependency>
+      <groupId>org.eclipse.microprofile.health</groupId>
+      <artifactId>microprofile-health-api</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-narayana-jta</artifactId>

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterProperties.java
@@ -92,6 +92,13 @@ public interface QuarkusMigrationAdapterProperties {
   DeliveryProperties delivery();
 
   /**
+   * What VanillaBP publishes as metrics (story 92).
+   *
+   * @return The metrics configuration
+   */
+  MetricsProperties metrics();
+
+  /**
    * The adapter configuration. The properties in detail are defined by the
    * respective VanillaBP adapter Quarkus extension.
    */
@@ -399,6 +406,25 @@ public interface QuarkusMigrationAdapterProperties {
      */
     @WithDefault("PT1H")
     Duration timeToLive();
+
+  }
+
+  /**
+   * What VanillaBP publishes as metrics. There is one setting, and it exists because
+   * reading a metric must not cost anything worth noticing (story 92).
+   */
+  interface MetricsProperties {
+
+    /**
+     * How long the measurement of a gauge which has to ask somebody - the number of
+     * waiting outbox entries, for instance - is reused before it is taken again. Ten
+     * seconds is one collection interval, a little under Prometheus' default scrape;
+     * <code>PT0S</code> measures on every collection.
+     *
+     * @return The duration one measurement is held for
+     */
+    @WithDefault("PT10S")
+    Duration gaugeCache();
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/config/QuarkusMigrationAdapterPropertiesMapper.java
@@ -12,6 +12,7 @@ import org.mapstruct.factory.Mappers;
 import io.vanillabp.integration.adapter.migration.config.AdapterConfigProperties;
 import io.vanillabp.integration.adapter.migration.config.AdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.DeliveryProperties;
+import io.vanillabp.integration.adapter.migration.config.MetricsProperties;
 import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
 import io.vanillabp.integration.adapter.migration.config.TaskAdapterProperties;
@@ -76,6 +77,9 @@ public interface QuarkusMigrationAdapterPropertiesMapper {
   @Mapping(target = "maxTaskAge", qualifiedByName = "unwrapDuration")
   DeliveryProperties toCore(
       QuarkusMigrationAdapterProperties.DeliveryProperties deliveryProperties);
+
+  MetricsProperties toCore(
+      QuarkusMigrationAdapterProperties.MetricsProperties metricsProperties);
 
   @Mapping(target = "outfadedVersions", qualifiedByName = "unwrapOutfadedVersions")
   AdapterConfigProperties toCore(

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/health/VanillaBpReadinessCheck.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/health/VanillaBpReadinessCheck.java
@@ -1,0 +1,105 @@
+package io.vanillabp.integration.runtime.health;
+
+import java.util.List;
+
+import org.eclipse.microprofile.health.HealthCheck;
+import org.eclipse.microprofile.health.HealthCheckResponse;
+import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
+import org.eclipse.microprofile.health.Readiness;
+
+import io.vanillabp.integration.adapter.migration.health.AdapterHealthReport;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Publishes what VanillaBP's BPMS adapters say about their BPMS as the readiness
+ * check <code>vanillabp</code>, so <code>/q/health/ready</code> shows a cluster an
+ * application cannot reach.
+ * <p>
+ * Readiness rather than liveness on purpose: an unreachable BPMS means this instance
+ * cannot do its work, not that the JVM is broken - restarting it changes nothing.
+ * <p>
+ * MicroProfile Health knows UP and DOWN and nothing in between, so the
+ * {@link AdapterHealth.Status#UNKNOWN} of an adapter which is not configured yet is
+ * reported as UP with its status in the data. The application booted with a guiding
+ * warning on purpose, and an incomplete configuration must not read as an outage. An
+ * adapter contributing nothing at all is absent from the data rather than reported as
+ * healthy.
+ * <p>
+ * This class is registered as a bean ONLY if the application uses the SmallRye Health
+ * extension (see {@code VanillaBpHealthBuildStepProcessor}).
+ */
+@Readiness
+@ApplicationScoped
+public class VanillaBpReadinessCheck implements HealthCheck {
+
+  /**
+   * The adapters' deployment services, one per configured adapter id. Collected the
+   * way the deployment runner collects them: element beans plus the flattened
+   * <code>List</code> beans of adapters with runtime-config multiplicity.
+   */
+  @Inject
+  @Any
+  Instance<AdapterDeploymentService<?, ?>> adapterDeploymentServices;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> adapterDeploymentServiceLists;
+
+  private AdapterHealthReport report;
+
+  @PostConstruct
+  void initialize() {
+
+    report = new AdapterHealthReport(
+        () -> java.util.stream.Stream
+            .concat(
+                adapterDeploymentServices.stream(),
+                adapterDeploymentServiceLists
+                    .stream()
+                    .filter(java.util.Objects::nonNull)
+                    .flatMap(List::stream))
+            .filter(java.util.Objects::nonNull)
+            .<AdapterDeploymentService<?, ?>>map(service -> service)
+            .toList());
+
+  }
+
+  @Override
+  public HealthCheckResponse call() {
+
+    final var healths = report.collect();
+    final HealthCheckResponseBuilder response = HealthCheckResponse
+        .named(AdapterHealthReport.HEALTH_NAME)
+        .status(AdapterHealthReport.overallStatus(healths) != AdapterHealth.Status.DOWN);
+    healths
+        .forEach(health -> {
+          final var prefix = health.adapterId()
+              + ".";
+          response.withData(prefix
+              + "status",
+              health
+                  .status()
+                  .name());
+          response.withData(prefix
+              + "type", health.adapterType());
+          if (health.description() != null) {
+            response.withData(prefix
+                + "description", health.description());
+          }
+          health
+              .details()
+              .forEach((
+                  name,
+                  value) -> response.withData(prefix + name, value));
+        });
+    return response.build();
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutbox.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutbox.java
@@ -98,6 +98,35 @@ public class JdbcPhaseTwoOutbox implements PhaseTwoOutbox {
 
   }
 
+  /**
+   * Counts the entries waiting for their dispatch. A single indexed count over the
+   * outbox table, which holds what did not run yet plus what is kept until the
+   * retention passes - the same table the dispatcher polls.
+   */
+  @Override
+  public java.util.OptionalLong pendingCalls() {
+
+    if (!dataSource.isResolvable()) {
+      return java.util.OptionalLong.empty();
+    }
+    final var countPending = "SELECT COUNT(*) FROM %s WHERE STATUS = ?"
+        .formatted(tableName(dispatcher.getProperties()));
+    try (var connection = dataSource.get().getConnection(); var statement = connection.prepareStatement(countPending)) {
+      statement.setString(1, JdbcPhaseTwoOutboxDispatcher.STATUS_OPEN);
+      try (var resultSet = statement.executeQuery()) {
+        return resultSet.next()
+            ? java.util.OptionalLong.of(resultSet.getLong(1))
+            : java.util.OptionalLong.empty();
+      }
+    } catch (final SQLException e) {
+      // a metric must never be the reason an application fails - the gauge reports
+      // nothing for this collection and the next one tries again
+      log.debug("Could not count the pending entries of the JDBC phase-two outbox", e);
+      return java.util.OptionalLong.empty();
+    }
+
+  }
+
   @Override
   public boolean schedule(
       final PhaseTwoCall call) {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutbox.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/MongoPhaseTwoOutbox.java
@@ -86,6 +86,29 @@ public class MongoPhaseTwoOutbox implements PhaseTwoOutbox {
 
   }
 
+  /**
+   * Counts the entries waiting for their dispatch - a single count over the same
+   * collection the dispatcher polls.
+   */
+  @Override
+  public java.util.OptionalLong pendingCalls() {
+
+    if (!mongoClient.isResolvable()) {
+      return java.util.OptionalLong.empty();
+    }
+    try {
+      return java.util.OptionalLong
+          .of(dispatcher
+              .outboxCollection()
+              .countDocuments(new Document("status", STATUS_OPEN)));
+    } catch (final RuntimeException e) {
+      // a metric must never be the reason an application fails
+      log.debug("Could not count the pending entries of the MongoDB phase-two outbox", e);
+      return java.util.OptionalLong.empty();
+    }
+
+  }
+
   @Override
   public boolean schedule(
       final PhaseTwoCall call) {

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/PhaseTwoRouterProducer.java
@@ -23,12 +23,39 @@ import jakarta.transaction.TransactionSynchronizationRegistry;
 @ApplicationScoped
 public class PhaseTwoRouterProducer {
 
+  /**
+   * @param transactionRegistry Provides the transaction a dispatch runs in
+   * @param metrics What dispatches are counted into (story 92); unsatisfied where the
+   *          application uses no Micrometer extension
+   * @return The router
+   */
   @Produces
   @Singleton
   public PhaseTwoRouter phaseTwoRouter(
-      final TransactionSynchronizationRegistry transactionRegistry) {
+      final TransactionSynchronizationRegistry transactionRegistry,
+      final jakarta.enterprise.inject.Instance<io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics> metrics) {
 
-    return new PhaseTwoRouter(new QuarkusTransactionRunner(transactionRegistry));
+    final var router = new PhaseTwoRouter(new QuarkusTransactionRunner(transactionRegistry));
+    router.setMetrics(vanillaBpMetricsOf(metrics));
+    return router;
+
+  }
+
+  /**
+   * The metrics implementation to use: the Micrometer one where the application uses
+   * the Micrometer extension,
+   * {@link io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics#NONE}
+   * otherwise.
+   *
+   * @param metrics The injected metrics
+   * @return What to record into, never <code>null</code>
+   */
+  public static io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics vanillaBpMetricsOf(
+      final jakarta.enterprise.inject.Instance<io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics> metrics) {
+
+    return ((metrics != null) && metrics.isResolvable())
+        ? metrics.get()
+        : io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE;
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/ProcessServiceBaseCdiBean.java
@@ -157,6 +157,13 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
   @Inject
   Instance<io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics> workflowAdapterCacheStatistics;
 
+  /**
+   * What deliveries of this process are counted into (story 92); unsatisfied where
+   * the application uses no Micrometer extension.
+   */
+  @Inject
+  Instance<io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics> vanillaBpMetrics;
+
   @Getter
   MigrationProcessService<A> migrationProcessService;
 
@@ -225,6 +232,8 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
                 : null);
     this.migrationProcessService = new MigrationProcessService<>(
         getWorkflowModuleId(), getBpmnProcessId(), getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache, taskDeliveryLogResolver, transactionRunnerResolver);
+    this.migrationProcessService
+        .setMetrics(PhaseTwoRouterProducer.vanillaBpMetricsOf(vanillaBpMetrics));
 
     // register as phase-two dispatch target: outbox entries for this workflow
     // module/BPMN process are routed here after the local transaction was committed
@@ -282,6 +291,8 @@ public abstract class ProcessServiceBaseCdiBean<A> extends ProcessServiceBase<A>
           key -> {
             final var secondaryProcessService = new MigrationProcessService<>(
                 moduleId, bpmnProcessId, getWorkflowAggregateClass(), properties, getAggregatePersistence(), processServices, phaseTwoOutboxResolver, electionCache, taskDeliveryLogResolver, transactionRunnerResolver);
+            secondaryProcessService
+                .setMetrics(PhaseTwoRouterProducer.vanillaBpMetricsOf(vanillaBpMetrics));
             if (phaseTwoRouter.isResolvable()) {
               phaseTwoRouter
                   .get()

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/VanillaBpMetricsProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/VanillaBpMetricsProducer.java
@@ -22,11 +22,20 @@ import jakarta.inject.Singleton;
 @ApplicationScoped
 public class VanillaBpMetricsProducer {
 
+  /**
+   * @param properties The VanillaBP configuration, carrying how long the measurement of
+   *          a gauge which has to ask somebody is reused
+   * @return The meters of deliveries and outbox
+   */
   @Produces
   @Singleton
-  public MicrometerVanillaBpMetrics vanillaBpMetrics() {
+  public MicrometerVanillaBpMetrics vanillaBpMetrics(
+      final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
 
-    return new MicrometerVanillaBpMetrics();
+    return new MicrometerVanillaBpMetrics(
+        properties
+            .getMetrics()
+            .resolvedGaugeCache());
 
   }
 
@@ -63,9 +72,7 @@ public class VanillaBpMetricsProducer {
           .forEach(outbox -> metrics
               .registerPendingOutboxEntries(
                   storeNameOf(outbox),
-                  () -> outbox
-                      .pendingCalls()
-                      .orElse(0)));
+                  outbox::pendingCalls));
     }
 
   }

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/VanillaBpMetricsProducer.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/processservice/VanillaBpMetricsProducer.java
@@ -1,0 +1,95 @@
+package io.vanillabp.integration.runtime.processservice;
+
+import io.quarkus.runtime.StartupEvent;
+import io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics;
+import io.vanillabp.integration.spi.PhaseTwoOutbox;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.event.Observes;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Singleton;
+
+/**
+ * Publishes what VanillaBP counts about its deliveries and its outbox as Micrometer
+ * meters. Quarkus applies every {@code MeterBinder} bean to its registry, so
+ * producing the binder is all it takes.
+ * <p>
+ * This class is registered as a bean ONLY if the application uses the Micrometer
+ * extension (see {@code VanillaBpMetricsBuildStepProcessor}) - it references
+ * Micrometer types and must not be loaded otherwise. That is the same mechanism the
+ * election cache's meters use.
+ */
+@ApplicationScoped
+public class VanillaBpMetricsProducer {
+
+  @Produces
+  @Singleton
+  public MicrometerVanillaBpMetrics vanillaBpMetrics() {
+
+    return new MicrometerVanillaBpMetrics();
+
+  }
+
+  /**
+   * How late this runs: AFTER the outbox dispatchers, which create their table on
+   * startup as well ({@code VanillaBpDeploymentRunner.OUTBOX_DISPATCHER_STARTUP_PRIORITY}).
+   * A store asked before its table exists cannot count, and no gauge would be
+   * published for it.
+   */
+  private static final int STARTUP_PRIORITY = jakarta.interceptor.Interceptor.Priority.APPLICATION + 800;
+
+  /**
+   * Publishes how many entries wait in each outbox store, for the stores which can
+   * count them ({@link PhaseTwoOutbox#pendingCalls()}). The gauge is tagged with the
+   * class name of the store, because an application may run several of them.
+   *
+   * @param startup The startup event - the outbox stores must not be materialized
+   *          while the beans are still being built
+   * @param metrics The metrics to register the gauges with
+   * @param outboxes All outbox stores of the application
+   */
+  void registerOutboxPendingGauges(
+      @Observes
+      @jakarta.annotation.Priority(STARTUP_PRIORITY) final StartupEvent startup,
+      final MicrometerVanillaBpMetrics metrics,
+      @jakarta.enterprise.inject.Any final Instance<PhaseTwoOutbox> outboxes) {
+
+    if (!outboxes.isUnsatisfied()) {
+      outboxes
+          .stream()
+          .filter(outbox -> outbox
+              .pendingCalls()
+              .isPresent())
+          .forEach(outbox -> metrics
+              .registerPendingOutboxEntries(
+                  storeNameOf(outbox),
+                  () -> outbox
+                      .pendingCalls()
+                      .orElse(0)));
+    }
+
+  }
+
+  /**
+   * The name of an outbox store as the <code>store</code> tag shows it. CDI hands out
+   * client proxies, whose class name carries a suffix nobody wants to read in a
+   * dashboard, so the superclass is used where there is one.
+   *
+   * @param outbox The outbox store
+   * @return The name to tag its gauge with
+   */
+  private static String storeNameOf(
+      final PhaseTwoOutbox outbox) {
+
+    final var candidate = outbox.getClass();
+    return candidate
+        .getSimpleName()
+        .contains("_ClientProxy")
+            ? candidate
+                .getSuperclass()
+                .getSimpleName()
+            : candidate.getSimpleName();
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
+++ b/quarkus-integration/runtime/src/test/java/io/vanillabp/integration/runtime/test/config/QuarkusMigrationAdapterPropertiesMapperTest.java
@@ -170,6 +170,10 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                                                 Duration timeToLive) implements QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties {
   }
 
+  private record MetricsProperties(
+                                   Duration gaugeCache) implements QuarkusMigrationAdapterProperties.MetricsProperties {
+  }
+
   private record Properties(
                             Optional<List<String>> prioritizedAdapters,
                             Optional<String> resourcesLocation,
@@ -178,7 +182,8 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
                             QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
                             QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache,
                             QuarkusMigrationAdapterProperties.TransactionsProperties transactions,
-                            QuarkusMigrationAdapterProperties.DeliveryProperties delivery) implements QuarkusMigrationAdapterProperties {
+                            QuarkusMigrationAdapterProperties.DeliveryProperties delivery,
+                            QuarkusMigrationAdapterProperties.MetricsProperties metrics) implements QuarkusMigrationAdapterProperties {
 
     /**
      * Without a transaction and without a delivery section.
@@ -192,7 +197,7 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
         final QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache) {
 
       this(
-          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, null, null);
+          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, null, null, null);
 
     }
 
@@ -209,7 +214,25 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
         final QuarkusMigrationAdapterProperties.TransactionsProperties transactions) {
 
       this(
-          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, transactions, null);
+          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, transactions, null, null);
+
+    }
+
+    /**
+     * Without a metrics section.
+     */
+    private Properties(
+        final Optional<List<String>> prioritizedAdapters,
+        final Optional<String> resourcesLocation,
+        final Map<String, QuarkusMigrationAdapterProperties.AdapterConfiguration> adapters,
+        final Map<String, QuarkusMigrationAdapterProperties.WorkflowModuleProperties> workflowModules,
+        final QuarkusMigrationAdapterProperties.PhaseTwoOutboxProperties outbox,
+        final QuarkusMigrationAdapterProperties.WorkflowAdapterCacheProperties workflowAdapterCache,
+        final QuarkusMigrationAdapterProperties.TransactionsProperties transactions,
+        final QuarkusMigrationAdapterProperties.DeliveryProperties delivery) {
+
+      this(
+          prioritizedAdapters, resourcesLocation, adapters, workflowModules, outbox, workflowAdapterCache, transactions, delivery, null);
 
     }
 
@@ -344,6 +367,38 @@ public class QuarkusMigrationAdapterPropertiesMapperTest {
     final var coreDefaults = new io.vanillabp.integration.adapter.migration.config.WorkflowAdapterCacheProperties();
     assertEquals(coreDefaults.getMaxEntries(), mappedDefaults.getMaxEntries());
     assertEquals(coreDefaults.getTimeToLive(), mappedDefaults.getTimeToLive());
+
+  }
+
+  @Test
+  @DisplayName("Story 92: the interface's @WithDefault gauge-cache equals the core default")
+  public void metricsDefaultsMatchCoreDefaults() {
+
+    final var config = new SmallRyeConfigBuilder()
+        .withMapping(QuarkusMigrationAdapterProperties.class)
+        .build();
+    final var mappedDefaults = QuarkusMigrationAdapterPropertiesMapper.INSTANCE
+        .toCore(
+            config
+                .getConfigMapping(QuarkusMigrationAdapterProperties.class)
+                .metrics());
+
+    final var coreDefaults = new io.vanillabp.integration.adapter.migration.config.MetricsProperties();
+    assertEquals(coreDefaults.getGaugeCache(), mappedDefaults.getGaugeCache());
+
+  }
+
+  @Test
+  @DisplayName("Story 92: a configured gauge-cache travels into the core model")
+  public void configuredGaugeCacheTravels() {
+
+    final var properties = new Properties(
+        Optional.empty(), Optional.empty(), Map.of(), Map
+            .of(), null, null, null, null, new MetricsProperties(Duration.ofSeconds(30)));
+
+    final var core = QuarkusMigrationAdapterPropertiesMapper.INSTANCE.toCore(properties);
+
+    assertEquals(Duration.ofSeconds(30), core.getMetrics().getGaugeCache());
 
   }
 

--- a/spring-boot-integration/README.md
+++ b/spring-boot-integration/README.md
@@ -97,6 +97,29 @@ aggregate is detected once in `SpringPersistenceTechnology`, shared by both reso
   `SmartInitializingSingleton`, not while the bean is built - the DDL must not
   materialize the data source before the application's configuration is complete.
 
+## What is published where (story 92)
+
+Both contributions are optional dependencies of this module, so an application which brings
+neither boots unchanged.
+
+Metrics ride on `micrometer-core`. `MicrometerVanillaBpMetrics` is a bean of the nested
+`WorkflowAdapterCacheMetricsConfiguration`, conditional on the `MeterRegistry` class BY NAME:
+the annotation of a nested configuration class is read reflectively, so a class literal of an
+absent optional dependency would blow up before the condition is evaluated. The Actuator's
+metrics auto-configuration binds it like any other `MeterBinder`. The pending-entry gauges of
+the outbox stores are registered by a `SmartInitializingSingleton`, not while the beans are
+built: resolving the stores earlier would materialize persistence infrastructure before the
+application asked for it.
+
+Health rides on `spring-boot-health` (Spring Boot 4 moved `HealthIndicator` out of the
+Actuator artifact into that one). The bean is named `vanillabpHealthIndicator`, because the
+bean name minus the suffix is what names the health component, and it has to stay `vanillabp`.
+
+The process services get the metrics from `ProcessServiceBeanRegistrar` right after they are
+built, primary and secondary alike; `PhaseTwoRouter` gets them from the auto-configuration.
+A setter rather than another constructor parameter: the metrics exist once per application
+while process services exist per BPMN process, and that constructor is long enough.
+
 ## Noteworthy & Contributors
 
 [VanillaBP](https://www.github.com/vanillabp/spi-for-java) was developed by [Phactum](https://www.phactum.at) with the

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/DummyAdapterBeanRegistrar.java
@@ -65,7 +65,9 @@ public class DummyAdapterBeanRegistrar implements BeanRegistrar {
                               .beanProvider(DummyBpmsInitiatedStartSource.class), supplierContext
                                   .bean(WorkflowTaskRegistry.class), supplierContext
                                       .beanProvider(
-                                          io.vanillabp.adapter.dummy.springboot.deployment.DummyProcessVersionSource.class))));
+                                          io.vanillabp.adapter.dummy.springboot.deployment.DummyProcessVersionSource.class), supplierContext
+                                              .beanProvider(
+                                                  io.vanillabp.adapter.dummy.springboot.deployment.DummyHealthSource.class))));
 
         });
 

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DeploymentService.java
@@ -61,6 +61,22 @@ public class DeploymentService implements AdapterDeploymentService<Object, Objec
   private final ObjectProvider<DummyProcessVersionSource> processVersionSource;
 
   /**
+   * Test hook standing in for what a real adapter asks its BPMS (see
+   * {@link DummyHealthSource}).
+   */
+  private final ObjectProvider<DummyHealthSource> healthSource;
+
+  @Override
+  public io.vanillabp.integration.adapter.spi.health.AdapterHealth checkHealth() {
+
+    final var source = healthSource.getIfAvailable();
+    return source == null
+        ? null
+        : source.healthOf(adapterId);
+
+  }
+
+  /**
    * The versions of the deployed BPMN processes, cached like a real adapter caches
    * them - the test's {@link DummyProcessVersionSource} plays the BPMS query.
    */

--- a/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyHealthSource.java
+++ b/spring-boot-integration/integration-tests/dummy-adapter/src/main/java/io/vanillabp/adapter/dummy/springboot/deployment/DummyHealthSource.java
@@ -1,0 +1,22 @@
+package io.vanillabp.adapter.dummy.springboot.deployment;
+
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+
+/**
+ * Optional hook of the dummy adapter used by integration tests to play what a real
+ * adapter finds when it asks its BPMS: without a bean the adapter contributes
+ * nothing to the health endpoint (which is what an adapter without a check does),
+ * with one it contributes whatever the test returns - including an exception, to
+ * cover the adapter which cannot answer its own question.
+ */
+@FunctionalInterface
+public interface DummyHealthSource {
+
+  /**
+   * @param adapterId The adapter ID being asked
+   * @return What the adapter found, or <code>null</code> to contribute nothing
+   */
+  AdapterHealth healthOf(
+      String adapterId);
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/pom.xml
+++ b/spring-boot-integration/integration-tests/main-integration-test/pom.xml
@@ -70,6 +70,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <!-- the health support the adapters' health indicator needs (optional in the
+           integration itself, see VanillaBpHealthIndicator) -->
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-health</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>test-utils</artifactId>
     </dependency>

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
@@ -280,6 +280,14 @@ public class InboundIdempotencyTest {
     try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
 
       final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      // story 92: a redelivery answered from the record is counted, because a rising
+      // rate means the BPMS hands work out again - usually too short a lock
+      final var registry = new io.micrometer.core.instrument.simple.SimpleMeterRegistry();
+      context
+          .getBean(io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics.class)
+          .bindTo(registry);
+
       // (a) the same delivery twice: handler once, both answered COMPLETED
       storeAggregate("4711");
       final var first = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4711", "job-1"));
@@ -323,6 +331,19 @@ public class InboundIdempotencyTest {
       dummyAdapter.invokeTask(MODULE, PROCESS, delivery("undeduplicatedTask", "4714", "job-5"));
       Assertions.assertEquals(2, DeliveryConfiguration.AGGREGATES.get("4714").getInvocations());
       Assertions.assertEquals(0, recordCount(context, "4714"));
+
+      // (e) what the metrics saw: exactly the two redeliveries answered from a record
+      // (a) and (b), and nothing for the deliveries which ran the handler
+      Assertions.assertEquals(
+          2.0,
+          registry
+              .get(
+                  io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.TASK_REDELIVERIES_DEDUPLICATED)
+              .counters()
+              .stream()
+              .mapToDouble(io.micrometer.core.instrument.Counter::count)
+              .sum(),
+          "a repeated delivery answered from the record is what this meter counts");
 
     }
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/ObservabilityTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/ObservabilityTest.java
@@ -23,6 +23,8 @@ import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
 import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
 import io.vanillabp.adapter.dummy.springboot.deployment.DummyHealthSource;
 import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.config.MetricsProperties;
+import io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties;
 import io.vanillabp.integration.adapter.migration.observability.DeliveryMdc;
 import io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics;
 import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
@@ -440,11 +442,9 @@ public class ObservabilityTest {
 
   }
 
-  @Test
-  @DisplayName("Without Micrometer the application boots and reports no metrics")
-  public void withoutMicrometerNoMeters() {
+  private ApplicationContextRunner contextRunner() {
 
-    new ApplicationContextRunner()
+    return new ApplicationContextRunner()
         .withPropertyValues("spring.config.location=classpath:application.yaml")
         .withInitializer(new ConfigDataApplicationContextInitializer())
         .withUserConfiguration(WorkflowModuleConfiguration.class, TestPersistenceConfiguration.class)
@@ -453,7 +453,72 @@ public class ObservabilityTest {
                 .of(
                     DummyAdapterConfiguration.class, DummyAdapterProcessServiceConfiguration.class,
                     WorkflowModuleAutoConfiguration.class,
-                    SpringBootMigrationAdapterAutoConfiguration.class))
+                    SpringBootMigrationAdapterAutoConfiguration.class));
+
+  }
+
+  @Test
+  @DisplayName("How long a gauge's measurement is held is configured and validated at startup")
+  public void theGaugeCacheIsBoundAndValidated() {
+
+    contextRunner()
+        .run(context -> Assertions
+            .assertEquals(
+                MetricsProperties.DEFAULT_GAUGE_CACHE,
+                context
+                    .getBean(MigrationAdapterProperties.class)
+                    .getMetrics()
+                    .resolvedGaugeCache(),
+                "an unconfigured application holds a measurement for one collection interval"));
+
+    contextRunner()
+        .withPropertyValues("vanillabp.metrics.gauge-cache=PT0S")
+        .run(context -> Assertions
+            .assertEquals(
+                java.time.Duration.ZERO,
+                context
+                    .getBean(MigrationAdapterProperties.class)
+                    .getMetrics()
+                    .resolvedGaugeCache(),
+                "zero is how a test asks for the real value on every collection"));
+
+    contextRunner()
+        .withPropertyValues("vanillabp.metrics.gauge-cache=-PT1S")
+        .run(context -> {
+          final var failure = context.getStartupFailure();
+          Assertions.assertNotNull(failure, "a negative span has to end the boot");
+          Assertions
+              .assertTrue(
+                  messagesOf(failure).contains(MetricsProperties.GAUGE_CACHE_PROPERTY),
+                  "and the message has to name the property but got: "
+                      + messagesOf(failure));
+        });
+
+  }
+
+  /**
+   * The messages along the chain of causes - a startup failure wraps the guiding one.
+   */
+  private static String messagesOf(
+      final Throwable failure) {
+
+    final var messages = new StringBuilder();
+    for (var cause = failure; cause != null; cause = cause.getCause() == cause
+        ? null
+        : cause.getCause()) {
+      messages
+          .append(cause.getMessage())
+          .append('\n');
+    }
+    return messages.toString();
+
+  }
+
+  @Test
+  @DisplayName("Without Micrometer the application boots and reports no metrics")
+  public void withoutMicrometerNoMeters() {
+
+    contextRunner()
         .withClassLoader(new FilteredClassLoader(MeterRegistry.class))
         .run(context -> {
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/ObservabilityTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/ObservabilityTest.java
@@ -1,0 +1,472 @@
+package io.vanillabp.integration.test.workflowtask;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.health.contributor.Status;
+import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyHealthSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.observability.DeliveryMdc;
+import io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics;
+import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.health.VanillaBpHealthIndicator;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+
+/**
+ * Acceptance test of what an operator gets to see (story 92) on Spring Boot: every
+ * task delivery is counted by outcome and measured, it carries a logging context
+ * naming the workflow it belongs to, and the BPMS adapters contribute what they know
+ * about their BPMS to the health endpoint.
+ * <p>
+ * The dummy adapter plays the BPMS, as in {@link WorkflowTaskProcessingTest} whose
+ * fixture (aggregate, handlers, persistence) this test reuses - what is asserted here
+ * is not the delivery but what the delivery leaves behind.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class ObservabilityTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "TaskProcess";
+
+  private static final String ADAPTER = "test";
+
+  /**
+   * What the dummy adapter answers when it is asked for its health - set per test.
+   */
+  private static final AtomicReference<DummyHealthSource> HEALTH = new AtomicReference<>();
+
+  @Configuration
+  static class ObservabilityConfiguration {
+
+    @Bean
+    DummyHealthSource dummyHealthSource() {
+
+      return adapterId -> {
+        final var source = HEALTH.get();
+        return source == null
+            ? null
+            : source.healthOf(adapterId);
+      };
+
+    }
+
+  }
+
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        adapters:
+          test:
+            type: dummy
+            test: 1
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/workflowtask
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            TaskProcessingWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            WorkflowTaskProcessingTest.TaskProcessingConfiguration.class,
+            ObservabilityConfiguration.class,
+            DeploymentTest.TestConfig.class)
+        .run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp() throws IOException {
+
+    return SpringBootTestApplication
+        .builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  private TaskInvocationContext context(
+      final String taskDefinition,
+      final String aggregateId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return "delivery-"
+            + aggregateId;
+      }
+
+    };
+
+  }
+
+  private void storeAggregate(
+      final String id) {
+
+    final var aggregate = new TaskProcessingAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("new");
+    WorkflowTaskProcessingTest.TaskProcessingConfiguration.AGGREGATES.put(id, aggregate);
+
+  }
+
+  @Test
+  @DisplayName("Every delivery is counted by its outcome and measured")
+  public void deliveriesAreCountedByOutcomeAndMeasured() throws IOException {
+
+    HEALTH.set(null);
+    WorkflowTaskProcessingTest.TaskProcessingConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var registry = new SimpleMeterRegistry();
+      context
+          .getBean(MicrometerVanillaBpMetrics.class)
+          .bindTo(registry);
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      storeAggregate("m-1");
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("processTask", "m-1"));
+      storeAggregate("m-2");
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("raiseBpmnError", "m-2"));
+      storeAggregate("m-3");
+      dummyAdapter.invokeTask(MODULE, PROCESS, context("asyncTask", "m-3"));
+      storeAggregate("m-4");
+      Assertions
+          .assertThrows(
+              IllegalStateException.class,
+              () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("failTask", "m-4")));
+
+      Assertions
+          .assertEquals(
+              1.0,
+              deliveries(registry, "processTask", "completed"),
+              "a handler which returned is one completed delivery");
+      Assertions
+          .assertEquals(
+              1.0,
+              deliveries(registry, "raiseBpmnError", "bpmn-error"),
+              "a TaskException is a BPMN error, not a failure");
+      Assertions
+          .assertEquals(
+              1.0,
+              deliveries(registry, "asyncTask", "pending"),
+              "a task waiting for its asynchronous completion is pending");
+      Assertions
+          .assertEquals(
+              1.0,
+              deliveries(registry, "failTask", "failed"),
+              "a rolled-back delivery is counted as failed");
+
+      final var timer = registry
+          .get(VanillaBpMetrics.TASK_DELIVERY_DURATION)
+          .tag(VanillaBpMetrics.TAG_ADAPTER, ADAPTER)
+          .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, "processTask")
+          .timer();
+      Assertions.assertEquals(1L, timer.count(), "the delivery is measured as well");
+      Assertions
+          .assertTrue(
+              timer.totalTime(java.util.concurrent.TimeUnit.NANOSECONDS) > 0,
+              "and the measurement is not zero");
+
+      Assertions
+          .assertEquals(
+              List.of(ADAPTER),
+              registry
+                  .get(VanillaBpMetrics.TASK_DELIVERIES)
+                  .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, "processTask")
+                  .tag(VanillaBpMetrics.TAG_OUTCOME, "completed")
+                  .counter()
+                  .getId()
+                  .getTags()
+                  .stream()
+                  .filter(tag -> tag
+                      .getKey()
+                      .equals(VanillaBpMetrics.TAG_ADAPTER))
+                  .map(io.micrometer.core.instrument.Tag::getValue)
+                  .toList(),
+              "the adapter is a tag, never part of the meter's name");
+
+    }
+
+  }
+
+  private double deliveries(
+      final SimpleMeterRegistry registry,
+      final String taskDefinition,
+      final String outcome) {
+
+    return registry
+        .get(VanillaBpMetrics.TASK_DELIVERIES)
+        .tag(VanillaBpMetrics.TAG_ADAPTER, ADAPTER)
+        .tag(VanillaBpMetrics.TAG_WORKFLOW_MODULE, MODULE)
+        .tag(VanillaBpMetrics.TAG_BPMN_PROCESS, PROCESS)
+        .tag(VanillaBpMetrics.TAG_TASK_DEFINITION, taskDefinition)
+        .tag(VanillaBpMetrics.TAG_OUTCOME, outcome)
+        .counter()
+        .count();
+
+  }
+
+  @Test
+  @DisplayName("The logging context names the workflow while the handler runs, and is gone afterwards")
+  public void mdcIsSetDuringDeliveryAndRestoredAfterwards() throws IOException {
+
+    HEALTH.set(null);
+    WorkflowTaskProcessingTest.TaskProcessingConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+
+      org.slf4j.MDC.put("application.own.key", "untouched");
+      try {
+
+        storeAggregate("mdc-1");
+        dummyAdapter.invokeTask(MODULE, PROCESS, context("recordMdc", "mdc-1"));
+
+        final var during = TaskProcessingWorkflowService.MDC_DURING_TASK;
+        Assertions.assertEquals(ADAPTER, during.get(DeliveryMdc.ADAPTER));
+        Assertions.assertEquals(MODULE, during.get(DeliveryMdc.WORKFLOW_MODULE));
+        Assertions.assertEquals(PROCESS, during.get(DeliveryMdc.BPMN_PROCESS));
+        Assertions.assertEquals("mdc-1", during.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID));
+        Assertions.assertEquals("recordMdc", during.get(DeliveryMdc.TASK_DEFINITION));
+        Assertions.assertEquals("delivery-mdc-1", during.get(DeliveryMdc.DELIVERY_ID));
+        Assertions
+            .assertEquals(
+                "untouched",
+                during.get("application.own.key"),
+                "VanillaBP sets its own keys and touches nothing else");
+
+        DeliveryMdc.KEYS
+            .forEach(key -> Assertions
+                .assertNull(
+                    org.slf4j.MDC.get(key),
+                    "the key '%s' has to be gone once the delivery is done".formatted(key)));
+
+        // the same on the failure path: a handler which throws must not leave its
+        // workflow in the context of whatever the thread does next
+        storeAggregate("mdc-2");
+        Assertions
+            .assertThrows(
+                IllegalStateException.class,
+                () -> dummyAdapter.invokeTask(MODULE, PROCESS, context("recordMdcAndFail", "mdc-2")));
+        Assertions
+            .assertEquals(
+                "mdc-2",
+                TaskProcessingWorkflowService.MDC_DURING_TASK.get(DeliveryMdc.WORKFLOW_AGGREGATE_ID));
+        DeliveryMdc.KEYS
+            .forEach(key -> Assertions
+                .assertNull(
+                    org.slf4j.MDC.get(key),
+                    "the key '%s' has to be gone after a failed delivery as well".formatted(key)));
+
+        Assertions.assertEquals("untouched", org.slf4j.MDC.get("application.own.key"));
+
+      } finally {
+        org.slf4j.MDC.remove("application.own.key");
+      }
+
+    }
+
+  }
+
+  @Test
+  @DisplayName("An adapter which is not configured yet is not an outage, and the detail names it")
+  public void unconfiguredAdapterIsNotUnhealthy() throws IOException {
+
+    HEALTH
+        .set(adapterId -> AdapterHealth
+            .unknown(
+                adapterId,
+                "dummy",
+                "The adapter is not configured yet",
+                AdapterHealth
+                    .detailsBuilder()
+                    .with("address", "<none>")
+                    .build()));
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var health = context
+          .getBean(VanillaBpHealthIndicator.class)
+          .health();
+
+      Assertions
+          .assertEquals(
+              Status.UNKNOWN,
+              health.getStatus(),
+              "an application which booted with a guiding warning is not an outage");
+      Assertions
+          .assertTrue(
+              health
+                  .getDetails()
+                  .containsKey(ADAPTER),
+              "the detail is named after the adapter id, so an operator knows which system is meant");
+
+    }
+
+  }
+
+  @Test
+  @DisplayName("An unreachable BPMS is down, naming the adapter and the address")
+  public void unreachableBpmsIsDown() throws IOException {
+
+    HEALTH
+        .set(adapterId -> AdapterHealth
+            .down(
+                adapterId,
+                "dummy",
+                "Connection refused",
+                AdapterHealth
+                    .detailsBuilder()
+                    .with("address", "http://localhost:26500")
+                    .build()));
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var health = context
+          .getBean(VanillaBpHealthIndicator.class)
+          .health();
+
+      Assertions.assertEquals(Status.DOWN, health.getStatus());
+      @SuppressWarnings("unchecked")
+      final var detail = (java.util.Map<String, Object>) health
+          .getDetails()
+          .get(ADAPTER);
+      Assertions.assertEquals("DOWN", detail.get("status"));
+      Assertions.assertEquals("Connection refused", detail.get("description"));
+      Assertions
+          .assertEquals(
+              "http://localhost:26500",
+              detail.get("address"),
+              "the address is what lets an operator act without reading the configuration");
+
+    }
+
+  }
+
+  @Test
+  @DisplayName("An adapter contributing nothing is absent, one which throws is down")
+  public void adapterWithoutCheckIsAbsentAndAThrowingOneIsDown() throws IOException {
+
+    HEALTH.set(null);
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var indicator = context.getBean(VanillaBpHealthIndicator.class);
+      Assertions
+          .assertTrue(
+              indicator
+                  .health()
+                  .getDetails()
+                  .isEmpty(),
+              "an adapter which checks nothing is absent rather than reported as healthy");
+
+      HEALTH
+          .set(adapterId -> {
+            throw new IllegalStateException("the check itself is broken");
+          });
+      final var broken = indicator.health();
+      Assertions.assertEquals(Status.DOWN, broken.getStatus());
+      @SuppressWarnings("unchecked")
+      final var detail = (java.util.Map<String, Object>) broken
+          .getDetails()
+          .get(ADAPTER);
+      Assertions
+          .assertTrue(
+              detail
+                  .get("description")
+                  .toString()
+                  .contains("the check itself is broken"),
+              "an adapter which cannot answer its own question is a defect worth seeing, but got: "
+                  + detail);
+
+    }
+
+  }
+
+  @Test
+  @DisplayName("Without Micrometer the application boots and reports no metrics")
+  public void withoutMicrometerNoMeters() {
+
+    new ApplicationContextRunner()
+        .withPropertyValues("spring.config.location=classpath:application.yaml")
+        .withInitializer(new ConfigDataApplicationContextInitializer())
+        .withUserConfiguration(WorkflowModuleConfiguration.class, TestPersistenceConfiguration.class)
+        .withConfiguration(
+            AutoConfigurations
+                .of(
+                    DummyAdapterConfiguration.class, DummyAdapterProcessServiceConfiguration.class,
+                    WorkflowModuleAutoConfiguration.class,
+                    SpringBootMigrationAdapterAutoConfiguration.class))
+        .withClassLoader(new FilteredClassLoader(MeterRegistry.class))
+        .run(context -> {
+
+          Assertions.assertNull(context.getStartupFailure(), "the application has to boot");
+          Assertions
+              .assertEquals(
+                  0,
+                  context
+                      .getBeanNamesForType(MicrometerVanillaBpMetrics.class).length,
+                  "nothing of Micrometer is loaded where the application does not bring it");
+
+        });
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/TaskProcessingWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/TaskProcessingWorkflowService.java
@@ -44,6 +44,41 @@ public class TaskProcessingWorkflowService {
 
   }
 
+  /**
+   * What the logging context held while the handler ran - the assertion of the MDC
+   * VanillaBP puts around every delivery (story 92). A map rather than a log line,
+   * because a test has to see the keys and not their rendering.
+   */
+  public static final java.util.Map<String, String> MDC_DURING_TASK = new java.util.concurrent.ConcurrentHashMap<>();
+
+  @WorkflowTask
+  public void recordMdc(
+      final TaskProcessingAggregate aggregate) {
+
+    captureMdc();
+    aggregate.setStatus("mdc-recorded");
+
+  }
+
+  @WorkflowTask
+  public void recordMdcAndFail(
+      final TaskProcessingAggregate aggregate) {
+
+    captureMdc();
+    throw new IllegalStateException("failed after recording the context");
+
+  }
+
+  private static void captureMdc() {
+
+    MDC_DURING_TASK.clear();
+    final var context = org.slf4j.MDC.getCopyOfContextMap();
+    if (context != null) {
+      MDC_DURING_TASK.putAll(context);
+    }
+
+  }
+
   @WorkflowTask
   public void failTask(
       final TaskProcessingAggregate aggregate) {

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/WorkflowTaskProcessingTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/workflowtask/WorkflowTaskProcessingTest.java
@@ -165,7 +165,9 @@ public class WorkflowTaskProcessingTest {
                   new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
                   new BpmnTaskSpec("Activity_Fail", "failTask"),
                   new BpmnTaskSpec("Activity_Async", "asyncTask"),
-                  new BpmnTaskSpec("Activity_Bind", "bindParameters"))
+                  new BpmnTaskSpec("Activity_Bind", "bindParameters"),
+                  new BpmnTaskSpec("Activity_Mdc", "recordMdc"),
+                  new BpmnTaskSpec("Activity_MdcFail", "recordMdcAndFail"))
               : List.of();
 
     }

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/pom.xml
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/pom.xml
@@ -29,6 +29,13 @@
 
   <dependencies>
     <dependency>
+      <!-- story 92: the outbox' own meters exist where the application brings
+           Micrometer -->
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>

--- a/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/OutboxMetricsTest.java
+++ b/spring-boot-integration/integration-tests/outbox-jpa-integration-test/src/test/java/io/vanillabp/integration/test/outbox/OutboxMetricsTest.java
@@ -1,0 +1,79 @@
+package io.vanillabp.integration.test.outbox;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics;
+import io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics;
+import io.vanillabp.integration.spi.PhaseTwoOperation;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.spi.process.ProcessService;
+
+/**
+ * What the phase-two outbox reports about itself on Spring Boot (story 92). gruelbox
+ * has no API for its backlog, so the number is read off its own table - which is why
+ * this test runs against the real store rather than a double.
+ */
+@SpringBootTest(classes = TestApplication.class)
+@ExtendWith(SuppressOutputExtension.class)
+@SuppressOutputExtension.SuppressBackgroundOutput
+public class OutboxMetricsTest {
+
+  @Autowired
+  private ProcessService<Aggregate> processService;
+
+  @Autowired
+  private TransactionTemplate transactionTemplate;
+
+  @Autowired
+  private RecordingPhaseTwoListener listener;
+
+  @Autowired
+  private MicrometerVanillaBpMetrics metrics;
+
+  @Test
+  @DisplayName("The waiting entries are a gauge and every dispatch is counted")
+  public void outboxReportsItsBacklogAndItsDispatches() throws Exception {
+
+    listener.reset();
+
+    final var registry = new SimpleMeterRegistry();
+    metrics.bindTo(registry);
+
+    final var pending = registry
+        .get(VanillaBpMetrics.OUTBOX_PENDING)
+        .tag(VanillaBpMetrics.TAG_STORE, "GruelboxPhaseTwoOutbox")
+        .gauge();
+    assertEquals(
+        0.0,
+        pending.value(),
+        "gruelbox marks a dispatched entry processed, so nothing of the earlier tests is waiting");
+
+    transactionTemplate
+        .execute(status -> {
+          final var aggregate = new Aggregate();
+          aggregate.setContent("metrics-test");
+          return processService.startWorkflow(aggregate);
+        });
+
+    listener.awaitInvocations(1, 30_000);
+
+    assertTrue(
+        registry
+            .get(VanillaBpMetrics.OUTBOX_DISPATCHES)
+            .tag(VanillaBpMetrics.TAG_OPERATION, PhaseTwoOperation.START_WORKFLOW.name())
+            .counter()
+            .count() >= 1.0,
+        "the dispatch of the started workflow's phase two has to be counted");
+
+  }
+
+}

--- a/spring-boot-integration/runtime/pom.xml
+++ b/spring-boot-integration/runtime/pom.xml
@@ -62,6 +62,13 @@
       <artifactId>micrometer-core</artifactId>
       <optional>true</optional>
     </dependency>
+    <!-- optional: the adapters' health is published only where the application brings
+         Spring Boot's health support (see VanillaBpHealthIndicator) -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-health</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/health/VanillaBpHealthIndicator.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/health/VanillaBpHealthIndicator.java
@@ -1,0 +1,76 @@
+package io.vanillabp.integration.health;
+
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.HealthIndicator;
+import org.springframework.boot.health.contributor.Status;
+
+import io.vanillabp.integration.adapter.migration.health.AdapterHealthReport;
+import io.vanillabp.integration.adapter.spi.health.AdapterHealth;
+
+/**
+ * Publishes what VanillaBP's BPMS adapters say about their BPMS under the health
+ * component <code>vanillabp</code>, so <code>/actuator/health</code> shows a cluster
+ * an application cannot reach.
+ * <p>
+ * The shape of the output follows from two rules of {@link AdapterHealth}. Adapters
+ * are listed by their id, each with what it found and the details it supplied - the
+ * address above all, so the endpoint alone tells an operator which system is meant.
+ * And an adapter which is not configured yet contributes {@link Status#UNKNOWN},
+ * which Spring Boot answers with HTTP 200: the application booted with a guiding
+ * warning on purpose, and an incomplete configuration must not read as an outage.
+ * <p>
+ * The indicator exists only where the application brings Spring Boot's health
+ * support; an adapter contributing nothing is absent from the output rather than
+ * reported as healthy.
+ */
+public class VanillaBpHealthIndicator implements HealthIndicator {
+
+  private final AdapterHealthReport report;
+
+  public VanillaBpHealthIndicator(
+      final AdapterHealthReport report) {
+
+    this.report = report;
+
+  }
+
+  @Override
+  public Health health() {
+
+    final var healths = report.collect();
+    final var builder = new Health.Builder(statusOf(AdapterHealthReport.overallStatus(healths)));
+    healths
+        .forEach(health -> builder
+            .withDetail(
+                health.adapterId(),
+                detailsOf(health)));
+    return builder.build();
+
+  }
+
+  private static java.util.Map<String, Object> detailsOf(
+      final AdapterHealth health) {
+
+    final var detail = new java.util.LinkedHashMap<String, Object>();
+    detail.put("status", statusOf(health.status()).getCode());
+    detail.put("type", health.adapterType());
+    if (health.description() != null) {
+      detail.put("description", health.description());
+    }
+    detail.putAll(health.details());
+    return detail;
+
+  }
+
+  private static Status statusOf(
+      final AdapterHealth.Status status) {
+
+    return switch (status) {
+      case UP -> Status.UP;
+      case DOWN -> Status.DOWN;
+      case UNKNOWN -> Status.UNKNOWN;
+    };
+
+  }
+
+}

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutbox.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutbox.java
@@ -1,11 +1,14 @@
 package io.vanillabp.integration.outbox.gruelbox;
 
+import java.util.OptionalLong;
+
+import javax.sql.DataSource;
+
 import com.gruelbox.transactionoutbox.AlreadyScheduledException;
 import com.gruelbox.transactionoutbox.TransactionOutbox;
 
 import io.vanillabp.integration.spi.PhaseTwoCall;
 import io.vanillabp.integration.spi.PhaseTwoOutbox;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -22,11 +25,81 @@ import lombok.extern.slf4j.Slf4j;
  * a unique request ID are retained by gruelbox until the configured retention
  * threshold passes (the contract's "DONE instead of delete").
  */
-@RequiredArgsConstructor
 @Slf4j
 public class GruelboxPhaseTwoOutbox implements PhaseTwoOutbox {
 
   private final TransactionOutbox transactionOutbox;
+
+  /**
+   * Where gruelbox' table lives, needed to count the entries waiting for their
+   * dispatch. <code>null</code> where the caller did not supply one - the pending
+   * meter is then absent rather than wrong.
+   */
+  private final DataSource dataSource;
+
+  /**
+   * The table gruelbox stores its entries in.
+   */
+  private final String tableName;
+
+  /**
+   * Creates an outbox which cannot count its pending entries - kept for tests.
+   *
+   * @param transactionOutbox The gruelbox transaction outbox
+   */
+  public GruelboxPhaseTwoOutbox(
+      final TransactionOutbox transactionOutbox) {
+
+    this(transactionOutbox, null, null);
+
+  }
+
+  /**
+   * @param transactionOutbox The gruelbox transaction outbox
+   * @param dataSource Where gruelbox' table lives
+   * @param tableName The table gruelbox stores its entries in
+   */
+  public GruelboxPhaseTwoOutbox(
+      final TransactionOutbox transactionOutbox,
+      final DataSource dataSource,
+      final String tableName) {
+
+    this.transactionOutbox = transactionOutbox;
+    this.dataSource = dataSource;
+    this.tableName = tableName;
+
+  }
+
+  /**
+   * Counts the entries gruelbox has not processed yet. gruelbox has no API for it, so
+   * the count reads its table directly - along the index it creates itself
+   * (<code>IX_TXNO_OUTBOX_1</code> over <code>processed, blocked,
+   * nextAttemptTime</code>), which is why one column is enough and no dialect-specific
+   * literal is needed: the driver knows how to write a boolean into whatever type the
+   * column has on this database.
+   */
+  @Override
+  public OptionalLong pendingCalls() {
+
+    if ((dataSource == null) || (tableName == null)) {
+      return OptionalLong.empty();
+    }
+    final var countPending = "SELECT COUNT(*) FROM %s WHERE processed = ?".formatted(tableName);
+    try (var connection = dataSource.getConnection(); var statement = connection.prepareStatement(countPending)) {
+      statement.setBoolean(1, false);
+      try (var resultSet = statement.executeQuery()) {
+        return resultSet.next()
+            ? OptionalLong.of(resultSet.getLong(1))
+            : OptionalLong.empty();
+      }
+    } catch (final java.sql.SQLException e) {
+      // a metric must never be the reason an application fails - the gauge reports
+      // nothing for this collection and the next one tries again
+      log.debug("Could not count the pending entries of gruelbox' outbox table '{}'", tableName, e);
+      return OptionalLong.empty();
+    }
+
+  }
 
   @Override
   public boolean schedule(

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/gruelbox/GruelboxPhaseTwoOutboxAutoConfiguration.java
@@ -163,13 +163,26 @@ public class GruelboxPhaseTwoOutboxAutoConfiguration {
 
   /**
    * @param transactionOutbox The gruelbox transaction outbox
+   * @param dataSource The data source holding gruelbox' table, used to count the
+   *          entries waiting for their dispatch (story 92)
+   * @param vanillaBpProperties The bound <code>vanillabp.*</code> tree, naming the
+   *          table where the application configured one of its own
    * @return The {@link PhaseTwoOutbox} used by the process services
    */
   @Bean(DEFAULT_OUTBOX_BEAN_NAME)
   public GruelboxPhaseTwoOutbox vanillaBpGruelboxPhaseTwoOutbox(
-      @Qualifier(DEFAULT_TRANSACTION_OUTBOX_BEAN_NAME) final TransactionOutbox transactionOutbox) {
+      @Qualifier(DEFAULT_TRANSACTION_OUTBOX_BEAN_NAME) final TransactionOutbox transactionOutbox,
+      final DataSource dataSource,
+      final VanillaBpConfigurationProperties vanillaBpProperties) {
 
-    return new GruelboxPhaseTwoOutbox(transactionOutbox);
+    final var customTable = vanillaBpProperties
+        .getOutbox()
+        .getJdbc()
+        .getTable();
+    return new GruelboxPhaseTwoOutbox(
+        transactionOutbox, dataSource, customTable == null
+            ? DEFAULT_OUTBOX_TABLE_NAME
+            : customTable);
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutbox.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/outbox/mongo/MongoPhaseTwoOutbox.java
@@ -49,6 +49,27 @@ public class MongoPhaseTwoOutbox implements PhaseTwoOutbox {
    */
   private final String collection;
 
+  /**
+   * Counts the entries waiting for their dispatch - a single count over the same
+   * collection the dispatcher polls.
+   */
+  @Override
+  public java.util.OptionalLong pendingCalls() {
+
+    try {
+      return java.util.OptionalLong
+          .of(mongoTemplate
+              .count(
+                  Query.query(Criteria.where("status").is(PhaseTwoOutboxEntry.STATUS_OPEN)),
+                  collection));
+    } catch (final RuntimeException e) {
+      // a metric must never be the reason an application fails
+      log.debug("Could not count the pending entries of the MongoDB phase-two outbox", e);
+      return java.util.OptionalLong.empty();
+    }
+
+  }
+
   @Override
   public boolean schedule(
       final PhaseTwoCall call) {

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/ProcessServiceBeanRegistrar.java
@@ -370,8 +370,19 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
                       supplierContext.bean(
                           io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheStatistics.class));
 
+              // what deliveries of this process are counted into (story 92); absent
+              // where the application brings no metrics backend
+              final var metrics = SpringBootMigrationAdapterAutoConfiguration
+                  .vanillaBpMetricsOf(
+                      supplierContext
+                          .beanProvider(
+                              io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.class));
+
               final var processServiceBean = new ProcessServiceSpringBean<A>(
                   workflowModuleId, bpmnProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, phaseTwoRouter, workflowAdapterCache, taskDeliveryLogResolver, transactionRunnerResolver);
+              processServiceBean
+                  .getMigrationProcessService()
+                  .setMetrics(metrics);
 
               // register ALL classes declaring this aggregate under ALL their
               // declared BPMN process IDs: @WorkflowTask handlers per (module,
@@ -397,6 +408,7 @@ public class ProcessServiceBeanRegistrar implements BeanRegistrar {
                       key -> {
                         final var secondaryProcessService = new MigrationProcessService<A>(
                             declaringModuleId, declaredProcessId, workflowAggregateType, properties, aggregatePersistenceAware, migratableProcessServices, phaseTwoOutboxResolver, workflowAdapterCache, taskDeliveryLogResolver, transactionRunnerResolver);
+                        secondaryProcessService.setMetrics(metrics);
                         if (phaseTwoRouter != null) {
                           phaseTwoRouter.register(secondaryProcessService);
                         }

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -219,9 +219,30 @@ public class SpringBootMigrationAdapterAutoConfiguration {
    */
   @Bean
   @ConditionalOnMissingBean(PhaseTwoRouter.class)
-  public PhaseTwoRouter vanillaBpPhaseTwoRouter() {
+  public PhaseTwoRouter vanillaBpPhaseTwoRouter(
+      final org.springframework.beans.factory.ObjectProvider<io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics> metrics) {
 
-    return new PhaseTwoRouter();
+    final var router = new PhaseTwoRouter();
+    router.setMetrics(vanillaBpMetricsOf(metrics));
+    return router;
+
+  }
+
+  /**
+   * The metrics implementation to use: the Micrometer one where the application
+   * brings Micrometer,
+   * {@link io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics#NONE}
+   * otherwise. Micrometer is optional, so the bean may legitimately be absent.
+   *
+   * @param metrics The provider of the metrics bean
+   * @return What to record into, never <code>null</code>
+   */
+  public static io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics vanillaBpMetricsOf(
+      final org.springframework.beans.factory.ObjectProvider<io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics> metrics) {
+
+    return metrics
+        .getIfAvailable(
+            () -> io.vanillabp.integration.adapter.migration.observability.VanillaBpMetrics.NONE);
 
   }
 
@@ -319,6 +340,109 @@ public class SpringBootMigrationAdapterAutoConfiguration {
 
       return new io.vanillabp.integration.adapter.migration.processservice.WorkflowAdapterCacheMeters(
           statistics);
+
+    }
+
+    /**
+     * What VanillaBP counts about its deliveries and its outbox (story 92). It is a
+     * {@code MeterBinder} as well, so the Actuator hands it the registry the same way
+     * it hands it to the election cache's meters - nothing of VanillaBP asks for a
+     * registry itself.
+     *
+     * @return The metrics of deliveries and outbox
+     */
+    @Bean
+    @ConditionalOnMissingBean
+    public io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics vanillaBpMetrics() {
+
+      return new io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics();
+
+    }
+
+    /**
+     * Publishes how many entries wait in each outbox store, for the stores which can
+     * count them
+     * ({@link io.vanillabp.integration.spi.PhaseTwoOutbox#pendingCalls()}). The
+     * gauge is tagged with the bean name of the store, because an application may
+     * run several of them (mixed persistence, a dedicated outbox for one aggregate).
+     * <p>
+     * The stores are resolved lazily: touching them while the beans are built would
+     * materialize persistence infrastructure long before the application asked for
+     * it.
+     *
+     * @param metrics The metrics to register the gauges with
+     * @param outboxes All outbox stores of the application
+     * @return The registration, run once the context is ready
+     */
+    @Bean
+    public org.springframework.beans.factory.SmartInitializingSingleton vanillaBpOutboxPendingGauges(
+        final io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics metrics,
+        final org.springframework.beans.factory.ObjectProvider<io.vanillabp.integration.spi.PhaseTwoOutbox> outboxes) {
+
+      return () -> outboxes
+          .stream()
+          .filter(outbox -> outbox
+              .pendingCalls()
+              .isPresent())
+          .forEach(outbox -> metrics
+              .registerPendingOutboxEntries(
+                  outbox
+                      .getClass()
+                      .getSimpleName(),
+                  () -> outbox
+                      .pendingCalls()
+                      .orElse(0)));
+
+    }
+
+  }
+
+  /**
+   * Asks every BPMS adapter what it can say about its BPMS - the platform-neutral
+   * half of the health contribution (story 92). The adapters are resolved on every
+   * call, so an adapter which materializes late is asked as well.
+   *
+   * @param deploymentServices The adapters' deployment services, one per configured
+   *          adapter id
+   * @return The report
+   */
+  @Bean
+  @ConditionalOnMissingBean
+  public io.vanillabp.integration.adapter.migration.health.AdapterHealthReport vanillaBpAdapterHealthReport(
+      final org.springframework.beans.factory.ObjectProvider<io.vanillabp.integration.adapter.spi.AdapterDeploymentService<?, ?>> deploymentServices) {
+
+    return new io.vanillabp.integration.adapter.migration.health.AdapterHealthReport(
+        () -> deploymentServices
+            .stream()
+            .toList());
+
+  }
+
+  /**
+   * Publishes the adapters' health under the component <code>vanillabp</code> of
+   * Spring Boot's health endpoint, where the application brings the health support.
+   * An application without it boots unchanged and publishes nothing.
+   */
+  @org.springframework.context.annotation.Configuration(proxyBeanMethods = false)
+  // by NAME for the same reason the metrics configuration uses names: the annotation
+  // of a nested configuration class is read reflectively
+  @org.springframework.boot.autoconfigure.condition.ConditionalOnClass(
+      name = "org.springframework.boot.health.contributor.HealthIndicator")
+  public static class AdapterHealthConfiguration {
+
+    /**
+     * The bean name decides the name of the health component, so it has to stay
+     * <code>vanillabp</code> + the suffix Spring Boot strips.
+     *
+     * @param report What the adapters answered
+     * @return The health indicator
+     */
+    @Bean("vanillabpHealthIndicator")
+    @ConditionalOnMissingBean(name = "vanillabpHealthIndicator")
+    public io.vanillabp.integration.health.VanillaBpHealthIndicator vanillabpHealthIndicator(
+        final io.vanillabp.integration.adapter.migration.health.AdapterHealthReport report) {
+
+      return new io.vanillabp.integration.health.VanillaBpHealthIndicator(report);
 
     }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/processservice/SpringBootMigrationAdapterAutoConfiguration.java
@@ -349,13 +349,19 @@ public class SpringBootMigrationAdapterAutoConfiguration {
      * it hands it to the election cache's meters - nothing of VanillaBP asks for a
      * registry itself.
      *
+     * @param properties The VanillaBP configuration, carrying how long the measurement
+     *          of a gauge which has to ask somebody is reused
      * @return The metrics of deliveries and outbox
      */
     @Bean
     @ConditionalOnMissingBean
-    public io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics vanillaBpMetrics() {
+    public io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics vanillaBpMetrics(
+        final io.vanillabp.integration.adapter.migration.config.MigrationAdapterProperties properties) {
 
-      return new io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics();
+      return new io.vanillabp.integration.adapter.migration.observability.MicrometerVanillaBpMetrics(
+          properties
+              .getMetrics()
+              .resolvedGaugeCache());
 
     }
 
@@ -389,9 +395,7 @@ public class SpringBootMigrationAdapterAutoConfiguration {
                   outbox
                       .getClass()
                       .getSimpleName(),
-                  () -> outbox
-                      .pendingCalls()
-                      .orElse(0)));
+                  outbox::pendingCalls));
 
     }
 

--- a/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/utils/impl/MongoDbSpringDataUtilTest.java
+++ b/spring-boot-integration/runtime/src/test/java/io/vanillabp/integration/test/utils/impl/MongoDbSpringDataUtilTest.java
@@ -59,7 +59,10 @@ class MongoDbSpringDataUtilTest {
   @EnableAutoConfiguration(
       exclude = {
           SslAutoConfiguration.class, // MongoDb is not available via SSL
-          WorkflowModuleAutoConfiguration.class, // see resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+          // ... and without it there are no SslBundles, which the health support wants
+          // to report on. It arrived with story 92 as an optional dependency of this
+          // module, so it is on this module's test classpath as well
+          org.springframework.boot.health.autoconfigure.application.SslHealthContributorAutoConfiguration.class, WorkflowModuleAutoConfiguration.class, // see resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
           SpringBootMigrationAdapterAutoConfiguration.class // see resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
       })
   @EnableMongoRepositories(


### PR DESCRIPTION
Story 92. An application could not tell a quiet system from a stalled one: no meter on any delivery, no health contribution anywhere, no log line saying which workflow it belonged to. On a remote BPMS that is worse than it sounds, because the poll belongs to the application, so a blocked handler stops the asking and the backlog sits in the cluster unseen.

## What this adds

**Metrics**, through the optional-Micrometer wiring the election cache already proved on both platforms, rather than a second mechanism. Every name starts with `vanillabp.`, and where a measurement happened is a tag:

| Meter | Tags |
|---|---|
| `vanillabp.task.deliveries` (counter) | `adapter`, `workflow.module`, `bpmn.process`, `task.definition`, `outcome` |
| `vanillabp.task.delivery.duration` (timer) | the same, without `outcome` |
| `vanillabp.task.redeliveries.deduplicated` (counter) | the same |
| `vanillabp.outbox.pending` (gauge) | `store` |
| `vanillabp.outbox.dispatches` / `.retries` / `.failures` (counters) | `operation`, plus `permanent` on failures |

The tag values are what a deployment fixes, so no meter grows a time series per workflow. Nothing that identifies a single workflow is ever a tag.

**Health**, as an SPI method `AdapterDeploymentService#checkHealth()` defaulting to `null`. An adapter which checks nothing is absent from the endpoint rather than reported as healthy; one which is not configured yet answers `UNKNOWN`, because an application which booted with a guiding warning has not failed. Spring Boot gets the health component `vanillabp`, Quarkus the readiness check of the same name, both only where the platform's health support is on the classpath.

**A logging context** of six MDC keys around every task delivery and every phase-two dispatch: adapter, workflow module, BPMN process, workflow aggregate id, task definition and the BPMS' own delivery id. Restored afterwards on the failure path as well, and no key of the application is touched. This is strictly more than the Camunda 8.9 client sets.

## Where it lives

`MigrationProcessService#executeWorkflowTask` carries all three. It is where the transaction is opened, so the timer measures the handler plus its commit, and it is where a delivery which threw still produces an outcome to count. The platform modules do the wiring and nothing else.

`PhaseTwoOutbox#pendingCalls()` is new, an `OptionalLong` defaulting to empty: a store which cannot count publishes no gauge, which is honest where a zero would not be. All four stores implement it with one indexed count; gruelbox has no API for its backlog, so its store reads the table gruelbox created, along the index gruelbox created with it.

## No new property

Metrics are on where Micrometer is present, health where the platform's health support is, and the MDC costs one try-with-resources per delivery. That is said explicitly in the wiki, because "no configuration needed" is information too.

## Tests

- Core: the Micrometer binding (names, tags, the registry which arrives late), the MDC scope (set, restored, failure path, foreign keys untouched) and the health report (absent, throwing, `UNKNOWN` next to `UP`).
- Spring Boot: an acceptance test delivering through the dummy adapter and asserting the counters per outcome, the timer, the MDC during and after the handler, and the three health answers; plus the outbox meters against gruelbox' real table, and a boot without Micrometer.
- Quarkus: the same acceptance test shape with `QuarkusExtensionTest`, plus the outbox gauge against the JDBC store.

Full build green on both platforms (31 min). Coverage: Spring Boot 89 %, Quarkus 87 %; the new packages are at 99 % / 100 % (core) and 97 % (Spring). The Quarkus readiness check reads 0 % in the aggregate because `deployment-integration-tests`, where its test lives, is not one of the modules that report aggregates - it is tested, just not counted.

## Documentation

New wiki page [Observability](https://github.com/vanillabp/adapter-platform-integration/wiki/Observability) with every meter and the question it answers, the health endpoint per platform, the MDC keys and a log pattern to paste. The paragraph an operator needs at three in the morning is the first section. `UPGRADE.md` and the three module READMEs carry the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7HLKaJvVpdCiSYxhwHJTc

---

## Addendum: reading a metric must not cost a query

Review finding on `outbox.pending`: it counted rows on every collection, in every instance. Prometheus scrapes every fifteen seconds by default, a dashboard asks alongside it, and nobody expects looking to be expensive - so watching the outbox turned into load on the outbox. The rule is general and is now written down as one.

`CachedGaugeValue` holds one measurement for `vanillabp.metrics.gauge-cache`, **default `PT10S`**: one collection interval, a little under Prometheus' scrape, so every scrape still gets a measurement of its own while everything asking alongside it reads for free. `PT0S` switches the holding off, which is what a test wants when it has just changed something.

It lives in the **adapter SPI**, not in the core's runtime, because the promise is not the platform's alone: a BPMS adapter registering a gauge of its own owes the same thing and depends on the SPI. A value already in memory does **not** belong in it - holding those would only make them stale, which is why the Camunda 8 execution-slot gauges stay exact (checked; they read a record field and a semaphore).

Two guarantees worth reviewing:

- Concurrent collectors are serialized rather than allowed to race, so eight arriving at the same moment produce one query. Handing the late ones a stale value would be cheaper and was rejected: on the first collection there is nothing stale to hand out, and the wait is bounded by the query the first collector already pays for.
- A measurement which throws is answered as absent for the rest of the window and taken again in the next one. Not caching the failure would hammer a database which is down, caching it forever would poison the gauge, and the exception never leaves the class.

The wrapping happens once, in `MicrometerVanillaBpMetrics`, so a store cannot forget it. On the way there `registerPendingOutboxEntries` takes a `Supplier<OptionalLong>` instead of a `LongSupplier`, so a store which cannot say right now leaves a gap in the graph rather than reporting a zero nobody checked.

**Tests**: `CachedGaugeValueTest` (one measurement per window, a new one after it, every read without a window, a failure which does not stay, eight concurrent collectors producing one query), the gauge held between collections and the NaN of an unavailable store, the property bound and validated on Spring Boot, and the Quarkus `@WithDefault` pinned against the core default like every other duplicated default.

**Docs**: new wiki section [looking is free](https://github.com/vanillabp/adapter-platform-integration/wiki/Observability#looking-is-free) with the property table, the reasoning in `migration-adapter/README.md`, and `UPGRADE.md`.

Second full build green, 31:01 min, coverage unchanged at Spring Boot 89 % / Quarkus 87 %. Deliberately nothing outside the metric classes and the configuration, so PR #61 (story 97) stays conflict-free.
