### PR TITLE
feat(delivery): keep the record of a task which is still open

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -513,6 +513,23 @@ the record of a task nobody hands out any more expires as it always did.
   `createSchemaIfNotExists` therefore verify the columns added later as well, and the
   message names the `ALTER TABLE` which repairs it.
 
+#### Two instances creating the schema at once
+
+`createSchemaIfNotExists` asks the JDBC metadata and then runs the DDL, because
+`CREATE TABLE IF NOT EXISTS` is not portable. Between the question and the statement another
+instance may have created the same table: a rolling deployment or a scale-up from zero starts
+two of them at the same moment, and the loser used to end its boot over a "table already
+exists".
+
+A refused DDL therefore asks the metadata once more, through a connection of its own
+(`JdbcSchema.tableExistsQuietly` - a failed statement leaves the current connection in an
+aborted transaction where the pool does not commit each statement by itself). Is the table
+there, the loser has nothing left to do and says so on DEBUG; is it still missing, the DDL
+really failed and the message is the one it always was. Deliberately no SQL state: every
+database reports that collision differently, and the metadata question is the portable answer.
+The Quarkus phase-two outbox does the same for its own table. The MongoDB stores need nothing:
+MongoDB answers a `createIndex` of an index which is already there with its name.
+
 #### Process versions (`version` attribute)
 
 The `version` attribute of `@WorkflowTask`, `@WorkflowStartedByBpms` and

--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -468,12 +468,50 @@ waiting legitimately.
 - Deliberately no callback into the application. An application which knows its task is
   obsolete has `ProcessService#cancelTask`; one which lost track of it could not answer a
   liveness question truthfully anyway.
-- Residual: the record itself still expires with `vanillabp.outbox.retention`, and its
-  timestamp is never refreshed (refreshing it would erase the very age this measures). A
-  task open longer than the retention therefore loses the record which answers its
-  redelivery, exactly as before this story - the story shrinks the exposure from the old
-  fourteen-day horizon to the retention, it does not remove it. Roadmap entry 97 carries
-  the decision about what to do with a pending record when the retention passes.
+- The record itself used to expire with `vanillabp.outbox.retention` while its task was
+  still open, which is the exposure this story shrank from the old fourteen-day horizon to
+  the retention without removing it. Story 97 closed it with a second timestamp on the
+  record (see the next section); the age measured here keeps counting from the first one,
+  which is why refreshing that one was never an option.
+
+#### The record of a task which is still open (story 97)
+
+The record which answers the redeliveries of an open task was deleted once
+`vanillabp.outbox.retention` passed, seven days by default. A task open for longer lost the
+record, and the next redelivery reached the `@WorkflowTask` method a second time.
+
+The record therefore carries a second timestamp. `RECORDED_AT` keeps meaning the moment the
+handler ran, which is what the age of an open task is measured from, and `LAST_SEEN_AT`
+carries the moment the BPMS last redelivered that task. The retention cleanup deletes by the
+second one, so a task which is still being redelivered keeps the record answering it while
+the record of a task nobody hands out any more expires as it always did.
+
+- `MigrationProcessService.stillOpen` is the trigger, and it belongs to the core rather
+  than to any adapter: it runs on every redelivery whose recorded outcome is
+  `COMPLETION_PENDING`, whichever BPMS redelivered. It reports the key to the store through
+  `TaskDeliveryLog.stillOpen(deliveryKey)`, whose default implementation does nothing, so
+  a store written by an application stays valid.
+- Nothing is written there. The redelivery runs in the transaction of the workflow
+  aggregate, and an UPDATE per renewal of every open task has no business in it, so the key
+  lands in `OpenTaskTouches` and the timer which already runs the retention cleanup writes
+  what accumulated. Losing that memory to a crash costs one interval of refreshments,
+  because a record only expires when a whole retention passes without a single one. The
+  memory is bounded for the same reason.
+- Writing goes in blocks of `OpenTaskTouches.BLOCK_SIZE` keys: one
+  `UPDATE ... SET LAST_SEEN_AT = ? WHERE DELIVERY_KEY = ?` executed as a JDBC batch instead
+  of an `IN` list, whose length is capped differently by every database (Oracle at 1000
+  expressions, SQL Server at about 2100 parameters). The MongoDB stores of both platforms
+  do the same with an unordered bulk write per block.
+- Two alternatives were rejected for the same reason: a cleanup which skips
+  `COMPLETION_PENDING`, and one collective `UPDATE ... WHERE OUTCOME = 'COMPLETION_PENDING'`.
+  Either of them keeps the record of a task which never completes alive for good, and a
+  store which only grows is worse than the defect being fixed.
+- The column belongs to `io.vanillabp:vanillabp-schema` (changelog plus generated SQL). The
+  startup check of story 75 looked at the TABLE only, which is exactly the case a new column
+  slips through: a table created by an earlier version exists, so the check passed and the
+  missing column would have surfaced at the first delivery. `validateSchemaExists` and
+  `createSchemaIfNotExists` therefore verify the columns added later as well, and the
+  message names the `ALTER TABLE` which repairs it.
 
 #### Process versions (`version` attribute)
 

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDelivery.java
@@ -30,10 +30,11 @@ import java.time.Instant;
  *          <code>null</code>
  * @param bpmnErrorName The BPMN error name of an outcome carrying one, otherwise
  *          <code>null</code>
- * @param recordedAt When the delivery was processed. Every store persisted this
- *          value from the beginning, because the retention deletes by it; it is part
- *          of the record so the core can answer the one question a retention cannot:
- *          how long a task has been open. A task the BPMS keeps redelivering is
+ * @param recordedAt When the delivery was processed. It is part of the record so the
+ *          core can answer the one question a retention cannot: how long a task has
+ *          been open. The value never moves, which is why a store keeps a second
+ *          timestamp of its own to delete by (see
+ *          {@link TaskDeliveryLog#stillOpen(String)}). A task the BPMS keeps redelivering is
  *          answered from the record it wrote when the handler ran, so the difference
  *          between that moment and now IS the age of the open task, and a task nobody
  *          will ever complete is the only thing that age ever grows into. See

--- a/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
+++ b/migration-adapter/business-spi/src/main/java/io/vanillabp/integration/spi/TaskDeliveryLog.java
@@ -30,9 +30,10 @@ import java.util.Optional;
  * <strong>Retention:</strong> records are deleted asynchronously once
  * <code>vanillabp.outbox.retention</code> passed (default 7 days) - the same
  * retention the outbox uses, since both keep a deduplication window open. A BPMS
- * redelivering a task later than that runs the business code again; a task open for
- * longer than the retention is a workflow waiting for something, not a delivery in
- * flight.
+ * redelivering a task later than that runs the business code again. The period counts
+ * from the last redelivery the record answered ({@link #stillOpen(String)}), so a task
+ * which stays open keeps the record answering it and the clock starts once nobody hands
+ * that task out any more.
  * <p>
  * <strong>Release at the end of a workflow:</strong> where
  * <code>vanillabp.delivery.release-on-workflow-end</code> is switched on, the records of
@@ -73,6 +74,39 @@ public interface TaskDeliveryLog {
    */
   boolean record(
       TaskDelivery delivery);
+
+  /**
+   * Reports that the BPMS delivered a task again whose record says the task is still
+   * open, so this record is still in use and has to outlive the retention. Called by the
+   * core within the transaction of that redelivery, for every delivery answered with
+   * <code>COMPLETION_PENDING</code>.
+   * <p>
+   * A store deleting by age keeps a SECOND timestamp per record for it: the retention
+   * counts from the last redelivery, while {@link TaskDelivery#recordedAt()} keeps
+   * meaning the moment the handler ran - which is what the age of an open task is
+   * measured from (<code>vanillabp.delivery.max-task-age</code>). Refreshing
+   * <code>recordedAt</code> instead would erase that age, and keeping every pending
+   * record forever would leave the record of a task nobody ever completes in the store
+   * for good.
+   * <p>
+   * <strong>Not a write per call.</strong> An open task is redelivered as often as the
+   * BPMS renews its lock, and the redelivery runs in the transaction of the workflow
+   * aggregate. Implementations therefore remember the key and refresh their records in
+   * bulk, out of band - the stores VanillaBP ships do it from the timer which already
+   * runs the retention cleanup. Losing such a memory to a crash costs one interval of
+   * refreshments and nothing more, because a record only expires when a whole retention
+   * passes without a single one.
+   * <p>
+   * The default implementation does nothing, which keeps every store written before this
+   * existed valid: its records expire as they always did.
+   *
+   * @param deliveryKey The identity of the redelivered delivery (see
+   *          {@link TaskDelivery#deliveryKey()})
+   */
+  default void stillOpen(
+      final String deliveryKey) {
+
+  }
 
   /**
    * Deletes the records of ONE workflow, called when it ended and nothing of it can be

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -377,6 +377,9 @@ public class JdbcTaskDeliveryStore {
             "CREATE INDEX %s_AGE ON %s (LAST_SEEN_AT)".formatted(tableName, tableName));
       }
     } catch (final SQLException e) {
+      if (createdConcurrently()) {
+        return;
+      }
       throw new IllegalStateException(
           """
               Could not create the task-delivery table '%s'! Set 'vanillabp.outbox.create-schema' to \
@@ -384,6 +387,34 @@ public class JdbcTaskDeliveryStore {
               the table needs a unique DELIVERY_KEY and is described in the platform integration's \
               README."""
               .formatted(tableName), e);
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Whether the DDL failed because another instance created the table between the check and the
+   * statement. Two instances starting together both see no table and both create it, and the
+   * loser's deployment is fine - it just has nothing left to do (see
+   * {@link JdbcSchema#tableExistsQuietly(Connection, String)}).
+   *
+   * @return Whether the table is there now
+   */
+  private boolean createdConcurrently() {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      if (!JdbcSchema.tableExistsQuietly(connection, tableName)) {
+        return false;
+      }
+      log.debug(
+          "The task-delivery table '{}' was created by another instance starting at the same moment",
+          tableName);
+      return true;
+    } catch (final SQLException e) {
+      return false;
     } finally {
       release(connection);
     }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/JdbcTaskDeliveryStore.java
@@ -6,6 +6,7 @@ import java.sql.SQLIntegrityConstraintViolationException;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 import io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema;
@@ -20,10 +21,12 @@ import lombok.extern.slf4j.Slf4j;
  * persists the workflow aggregate, otherwise the record and the aggregate would not
  * commit together.
  * <p>
- * A record is INSERTed once and never updated: the delivery key is the primary key, so
+ * A record is INSERTed once and never rewritten: the delivery key is the primary key, so
  * two nodes processing the same delivery concurrently end up with one record and the
  * loser learns it from the constraint violation ({@link #record(TaskDelivery)} returns
- * <code>false</code> then, exactly like a duplicate outbox entry).
+ * <code>false</code> then, exactly like a duplicate outbox entry). The only column which
+ * ever changes afterwards is <code>LAST_SEEN_AT</code>, the moment the BPMS last
+ * redelivered the task the record answers - what the retention counts from (story 97).
  * <p>
  * The DDL is kept portable the same way the Quarkus outbox does it: table existence is
  * checked via JDBC metadata (<code>CREATE TABLE IF NOT EXISTS</code> is not supported
@@ -49,12 +52,20 @@ public class JdbcTaskDeliveryStore {
   private static final String INSERT_DELIVERY = """
       INSERT INTO %s \
       (DELIVERY_KEY, WORKFLOW_MODULE_ID, BPMN_PROCESS_ID, AGGREGATE_ID, TASK_DEFINITION, OUTCOME, \
-      BPMN_ERROR_CODE, BPMN_ERROR_NAME, RECORDED_AT) \
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)""";
+      BPMN_ERROR_CODE, BPMN_ERROR_NAME, RECORDED_AT, LAST_SEEN_AT) \
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""";
+
+  // one key per execution instead of an IN list, whose length is capped differently by
+  // every database (Oracle at 1000 expressions, SQL Server at about 2100 parameters) -
+  // the statement is executed as a JDBC batch, which knows no such limit
+  private static final String TOUCH_DELIVERY = """
+      UPDATE %s \
+      SET LAST_SEEN_AT = ? \
+      WHERE DELIVERY_KEY = ?""";
 
   private static final String DELETE_EXPIRED_DELIVERIES = """
       DELETE FROM %s \
-      WHERE RECORDED_AT < ?""";
+      WHERE LAST_SEEN_AT < ?""";
 
   private static final String DELETE_DELIVERIES_OF_WORKFLOW = """
       DELETE FROM %s \
@@ -68,9 +79,13 @@ public class JdbcTaskDeliveryStore {
 
   private final String insertDelivery;
 
+  private final String touchDelivery;
+
   private final String deleteExpiredDeliveries;
 
   private final String deleteDeliveriesOfWorkflow;
+
+  private final OpenTaskTouches touches;
 
   public JdbcTaskDeliveryStore(
       final JdbcConnectionAccess connectionAccess,
@@ -80,8 +95,10 @@ public class JdbcTaskDeliveryStore {
     this.tableName = tableName;
     this.selectDelivery = SELECT_DELIVERY.formatted(tableName);
     this.insertDelivery = INSERT_DELIVERY.formatted(tableName);
+    this.touchDelivery = TOUCH_DELIVERY.formatted(tableName);
     this.deleteExpiredDeliveries = DELETE_EXPIRED_DELIVERIES.formatted(tableName);
     this.deleteDeliveriesOfWorkflow = DELETE_DELIVERIES_OF_WORKFLOW.formatted(tableName);
+    this.touches = new OpenTaskTouches(tableName, this::refreshLastSeen);
 
   }
 
@@ -155,11 +172,13 @@ public class JdbcTaskDeliveryStore {
         statement.setString(6, delivery.outcome());
         statement.setString(7, delivery.bpmnErrorCode());
         statement.setString(8, delivery.bpmnErrorName());
-        statement.setTimestamp(
-            9,
-            Timestamp.from(delivery.recordedAt() == null
-                ? Instant.now()
-                : delivery.recordedAt()));
+        final var recordedAt = Timestamp.from(delivery.recordedAt() == null
+            ? Instant.now()
+            : delivery.recordedAt());
+        statement.setTimestamp(9, recordedAt);
+        // the record was seen the moment it was written; a redelivery of a task which
+        // stays open moves this one and leaves RECORDED_AT where it is
+        statement.setTimestamp(10, recordedAt);
         statement.executeUpdate();
       }
       return true;
@@ -188,15 +207,81 @@ public class JdbcTaskDeliveryStore {
   }
 
   /**
-   * Deletes the records older than the given retention period - the deduplication
-   * window closes with them. A plain, idempotent DELETE: several application instances
-   * may run it concurrently.
+   * Remembers that the record of this delivery is still answering the redeliveries of an
+   * open task, so the retention has to count from now rather than from the moment the
+   * handler ran (story 97). Nothing is written here - the key is collected and the next
+   * {@link #deleteExpired(Duration)} writes what accumulated.
+   *
+   * @param deliveryKey The delivery's identity
+   */
+  public void stillOpen(
+      final String deliveryKey) {
+
+    touches.remember(deliveryKey);
+
+  }
+
+  /**
+   * Writes <code>LAST_SEEN_AT</code> for the open tasks redelivered since the last run.
+   * Called by {@link #deleteExpired(Duration)} and usable on demand (e.g. by tests).
+   *
+   * @return The number of records refreshed
+   */
+  public int refreshOpenTasks() {
+
+    return touches.flush();
+
+  }
+
+  /**
+   * Writes <code>LAST_SEEN_AT</code> of one block of records, as a JDBC batch of the same
+   * statement. A key whose record was deleted meanwhile updates nothing, which is the
+   * right answer: the record is gone and the next redelivery writes a new one.
+   *
+   * @param deliveryKeys The keys of one block
+   */
+  private void refreshLastSeen(
+      final List<String> deliveryKeys) {
+
+    Connection connection = null;
+    try {
+      connection = connectionAccess.acquire();
+      try (var statement = connection.prepareStatement(touchDelivery)) {
+        final var now = Timestamp.from(Instant.now());
+        for (final var deliveryKey : deliveryKeys) {
+          statement.setTimestamp(1, now);
+          statement.setString(2, deliveryKey);
+          statement.addBatch();
+        }
+        statement.executeBatch();
+      }
+    } catch (final SQLException e) {
+      throw new RuntimeException(
+          "Could not refresh the records of %d open tasks in table '%s'!"
+              .formatted(deliveryKeys.size(), tableName), e);
+    } finally {
+      release(connection);
+    }
+
+  }
+
+  /**
+   * Refreshes the records of the open tasks redelivered since the last run and then
+   * deletes the records nobody has seen for the given retention period - the
+   * deduplication window closes with them. A plain, idempotent DELETE: several
+   * application instances may run it concurrently.
+   * <p>
+   * The two belong together and in this order: refreshing first is what keeps the record
+   * of a task which is still being redelivered, and deleting by <code>LAST_SEEN_AT</code>
+   * is what lets the record of a task nobody redelivers any more expire after all.
    *
    * @param retention How long a record is kept
    * @return The number of records deleted
    */
   public int deleteExpired(
       final Duration retention) {
+
+    refreshOpenTasks();
 
     Connection connection = null;
     try {
@@ -263,7 +348,16 @@ public class JdbcTaskDeliveryStore {
   }
 
   /**
-   * Creates the table (and the index the cleanup reads) unless it exists already.
+   * The columns a table has to carry beyond the ones every version of VanillaBP wrote.
+   * Only what was ADDED later belongs in here: a table which predates the addition exists
+   * and looks fine, and the missing column would surface at the first write.
+   */
+  private static final List<String> ADDED_COLUMNS = List.of("LAST_SEEN_AT");
+
+  /**
+   * Creates the table (and the index the cleanup reads) unless it exists already. A table
+   * which exists is checked for the columns a later version of VanillaBP added, because
+   * creating nothing is the one case in which a table of an older version passes unnoticed.
    *
    * @throws IllegalStateException If the DDL fails - naming the way out (manage the
    *           schema manually)
@@ -274,12 +368,13 @@ public class JdbcTaskDeliveryStore {
     try {
       connection = connectionAccess.acquire();
       if (JdbcSchema.tableExists(connection, tableName)) {
+        validateColumns(connection);
         return;
       }
       try (var statement = connection.createStatement()) {
         statement.executeUpdate(buildCreateTable(connection, tableName));
         statement.executeUpdate(
-            "CREATE INDEX %s_AGE ON %s (RECORDED_AT)".formatted(tableName, tableName));
+            "CREATE INDEX %s_AGE ON %s (LAST_SEEN_AT)".formatted(tableName, tableName));
       }
     } catch (final SQLException e) {
       throw new IllegalStateException(
@@ -296,13 +391,19 @@ public class JdbcTaskDeliveryStore {
   }
 
   /**
-   * Verifies that the table exists, for an application which creates its schema itself (story 75).
+   * Verifies that the table exists AND carries the columns this version writes, for an
+   * application which creates its schema itself (story 75).
    * <p>
    * Without this check a missing table surfaces at the first delivery, which is hours after the
    * deployment and looks like a bug of the application. The message names the table, the property
    * which would have created it and the artifact which contains the statements.
+   * <p>
+   * The columns are checked for the same reason (story 97): an application which applied an
+   * earlier changelog of VanillaBP has the table but not everything the current version writes
+   * into it, and a table which exists would otherwise pass the check and fail at the first
+   * delivery.
    *
-   * @throws IllegalStateException If the table is missing
+   * @throws IllegalStateException If the table or one of its columns is missing
    */
   public void validateSchemaExists() {
 
@@ -310,6 +411,7 @@ public class JdbcTaskDeliveryStore {
     try {
       connection = connectionAccess.acquire();
       if (JdbcSchema.tableExists(connection, tableName)) {
+        validateColumns(connection);
         return;
       }
       throw new IllegalStateException(
@@ -328,6 +430,38 @@ public class JdbcTaskDeliveryStore {
           "Could not check whether the task-delivery table '%s' exists!".formatted(tableName), e);
     } finally {
       release(connection);
+    }
+
+  }
+
+  /**
+   * Verifies the columns which a later version of VanillaBP added to the table. The
+   * message names the column, the statement which adds it and the artifact whose
+   * changelog does it, because that is the whole remedy.
+   *
+   * @param connection The connection to the database holding the table
+   * @throws IllegalStateException If a column is missing
+   */
+  private void validateColumns(
+      final Connection connection) throws SQLException {
+
+    for (final var column : ADDED_COLUMNS) {
+      if (JdbcSchema.columnExists(connection, tableName, column)) {
+        continue;
+      }
+      throw new IllegalStateException(
+          """
+              The task-delivery table '%s' has no column '%s'! It was added to the table of \
+              VanillaBP after your database was created, and without it the records of the tasks \
+              your application leaves open cannot be kept alive - they would expire while the tasks \
+              are still being redelivered. Either
+              - apply the current schema of VanillaBP with your migration tool: the artifact \
+              'io.vanillabp:vanillabp-schema' ships the Liquibase changelog \
+              'vanillabp/schema/changelog.xml' and the SQL generated from it for Flyway, or
+              - add the column yourself: ALTER TABLE %s ADD %s TIMESTAMP (the type your database \
+              uses for the existing column RECORDED_AT), filled with the value of RECORDED_AT and \
+              NOT NULL."""
+              .formatted(tableName, column, tableName, column));
     }
 
   }
@@ -400,8 +534,9 @@ public class JdbcTaskDeliveryStore {
         OUTCOME VARCHAR(32) NOT NULL, \
         BPMN_ERROR_CODE VARCHAR(255), \
         BPMN_ERROR_NAME VARCHAR(255), \
-        RECORDED_AT %s NOT NULL)"""
-        .formatted(tableName, timestampType);
+        RECORDED_AT %s NOT NULL, \
+        LAST_SEEN_AT %s NOT NULL)"""
+        .formatted(tableName, timestampType, timestampType);
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/OpenTaskTouches.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/delivery/OpenTaskTouches.java
@@ -1,0 +1,156 @@
+package io.vanillabp.integration.adapter.migration.delivery;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * The delivery keys of the open tasks a BPMS redelivered since the last refresh, kept
+ * until the store writes them in one go (story 97). Shared by every
+ * {@link io.vanillabp.integration.spi.TaskDeliveryLog} implementation of both platforms,
+ * because they differ in HOW a record is refreshed, not in when and in which portions.
+ * <p>
+ * A task left open by a <code>&#64;TaskId</code> handler is redelivered as often as the
+ * BPMS renews its lock, and every redelivery is answered from the record written when the
+ * handler ran. The record therefore has to outlive the retention as long as redeliveries
+ * keep coming, which is what the second timestamp of a record is for. Writing it per
+ * redelivery would put an UPDATE into the transaction of every renewal of every open
+ * task, so the key is remembered here instead and the timer which already runs the
+ * retention cleanup writes what accumulated.
+ * <p>
+ * Refreshing happens in blocks of {@value #BLOCK_SIZE} keys, one statement per block
+ * rather than one <code>IN</code> list: the length of such a list is capped differently
+ * by every database (Oracle at 1000 expressions, SQL Server at about 2100 parameters), and
+ * a batch of the same statement has no such limit.
+ * <p>
+ * Losing the memory to a crash costs one interval of refreshments, because a record only
+ * expires when a whole retention passes without a single one. That is also why the memory
+ * is bounded at {@value #MAX_REMEMBERED} keys: it is a hint, not a fact to be kept safe.
+ */
+@Slf4j
+public class OpenTaskTouches {
+
+  /**
+   * How many keys are written per statement execution.
+   */
+  public static final int BLOCK_SIZE = 500;
+
+  /**
+   * How many keys are remembered at most between two refreshes.
+   */
+  public static final int MAX_REMEMBERED = 100000;
+
+  private final String name;
+
+  private final Consumer<List<String>> refresh;
+
+  private final java.util.Set<String> keys = ConcurrentHashMap.newKeySet();
+
+  private final AtomicBoolean overflowReported = new AtomicBoolean();
+
+  /**
+   * @param name Names the store refreshed (log messages)
+   * @param refresh Writes the second timestamp of the records of one block of keys
+   */
+  public OpenTaskTouches(
+      final String name,
+      final Consumer<List<String>> refresh) {
+
+    this.name = name;
+    this.refresh = refresh;
+
+  }
+
+  /**
+   * Remembers that the record of this delivery is still answering redeliveries.
+   *
+   * @param deliveryKey The delivery's identity
+   */
+  public void remember(
+      final String deliveryKey) {
+
+    if (deliveryKey == null) {
+      return;
+    }
+    if (keys.size() >= MAX_REMEMBERED) {
+      if (overflowReported.compareAndSet(false, true)) {
+        log.warn(
+            """
+                More than {} open tasks of '{}' were redelivered since the last refresh of their \
+                delivery records - the keys beyond that are dropped, and a record which is not \
+                refreshed for a whole 'vanillabp.outbox.retention' is deleted although its task is \
+                still open, so its next redelivery reaches the @WorkflowTask method again. Either \
+                that many tasks are open at once and the retention should be raised, or tasks are \
+                waiting which nobody will ever complete - 'vanillabp.delivery.max-task-age' reports \
+                those.""",
+            MAX_REMEMBERED,
+            name);
+      }
+      return;
+    }
+    keys.add(deliveryKey);
+
+  }
+
+  /**
+   * How many keys are waiting to be written.
+   *
+   * @return The number of keys remembered
+   */
+  public int size() {
+
+    return keys.size();
+
+  }
+
+  /**
+   * Writes what accumulated, in blocks. Keys are taken out of the memory as they are
+   * collected, so a redelivery arriving while this runs is remembered for the next
+   * round rather than lost.
+   * <p>
+   * A failing block is logged and its keys are gone: the next redelivery of that task
+   * remembers it again, and the record survives as long as one refresh per retention
+   * period gets through.
+   *
+   * @return The number of records refreshed
+   */
+  public int flush() {
+
+    if (keys.isEmpty()) {
+      return 0;
+    }
+    final var block = new ArrayList<String>(BLOCK_SIZE);
+    var refreshed = 0;
+    try {
+      for (final var iterator = keys.iterator(); iterator.hasNext();) {
+        block.add(iterator.next());
+        iterator.remove();
+        if (block.size() < BLOCK_SIZE) {
+          continue;
+        }
+        refresh.accept(List.copyOf(block));
+        refreshed += block.size();
+        block.clear();
+      }
+      if (!block.isEmpty()) {
+        refresh.accept(List.copyOf(block));
+        refreshed += block.size();
+      }
+    } catch (final RuntimeException e) {
+      log.warn(
+          "Could not refresh the delivery records of {} open tasks of '{}'",
+          block.size(),
+          name,
+          e);
+    }
+    overflowReported.set(false);
+    log.debug("Refreshed the delivery records of {} open tasks of '{}'", refreshed, name);
+    return refreshed;
+
+  }
+
+}

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
@@ -84,4 +84,32 @@ public final class JdbcSchema {
 
   }
 
+  /**
+   * Whether the table exists, without letting the question itself fail. Asked after a
+   * <code>CREATE TABLE</code> was refused: two instances starting at the same moment (a rolling
+   * deployment, a scale-up from zero) both see no table and both run the DDL, and the loser gets
+   * a "table already exists" which is no failure of that deployment. Which error a database
+   * reports for it differs per product, so the answer is not a guessed SQL state but the metadata
+   * question asked once more.
+   * <p>
+   * Ask it through a CONNECTION OF ITS OWN: where the pool does not commit each statement by
+   * itself, the failed DDL left the current connection in an aborted transaction and every
+   * further question on it would fail as well.
+   *
+   * @param connection A connection of its own, not the one the DDL failed on
+   * @param tableName The table to look for
+   * @return Whether the table exists now; <code>false</code> also when the metadata cannot be read
+   */
+  public static boolean tableExistsQuietly(
+      final Connection connection,
+      final String tableName) {
+
+    try {
+      return tableExists(connection, tableName);
+    } catch (final SQLException e) {
+      return false;
+    }
+
+  }
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/jdbc/JdbcSchema.java
@@ -47,4 +47,41 @@ public final class JdbcSchema {
 
   }
 
+  /**
+   * Whether a column of that name exists in a table, asked of the JDBC metadata like
+   * {@link #tableExists(Connection, String)} is. Used where a table was created by an
+   * earlier version of VanillaBP or handed over by the application: the table alone does
+   * not prove that everything the current version writes has a place to go, and a missing
+   * column would surface at the first delivery rather than at startup.
+   *
+   * @param connection The connection to the database holding the table
+   * @param tableName The table, spelled as the application configured it
+   * @param columnName The column to look for
+   * @return Whether the column exists
+   * @throws SQLException If the metadata cannot be read
+   */
+  public static boolean columnExists(
+      final Connection connection,
+      final String tableName,
+      final String columnName) throws SQLException {
+
+    final var metaData = connection.getMetaData();
+    // see tableExists on the spelling of unquoted identifiers
+    for (final var table : List.of(
+        tableName,
+        tableName.toLowerCase())) {
+      for (final var column : List.of(
+          columnName,
+          columnName.toLowerCase())) {
+        try (var columns = metaData.getColumns(null, null, table, column)) {
+          if (columns.next()) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+
+  }
+
 }

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/processservice/MigrationProcessService.java
@@ -669,7 +669,7 @@ public class MigrationProcessService<A> {
       if (deliveryLog != null) {
         final var recorded = deliveryLog
             .recordedDelivery(deliveryKey)
-            .flatMap(delivery -> recordedOutcomeOf(delivery, context));
+            .flatMap(delivery -> recordedOutcomeOf(deliveryLog, delivery, context));
         if (recorded.isPresent()) {
           log.info(
               "Skipping the repeated delivery of task '{}' (BPMN process '{}' of workflow module "
@@ -993,6 +993,7 @@ public class MigrationProcessService<A> {
    * any log at all, and the WARN says why.
    */
   private java.util.Optional<WorkflowTaskOutcome> recordedOutcomeOf(
+      final TaskDeliveryLog deliveryLog,
       final TaskDelivery delivery,
       final TaskInvocationContext context) {
 
@@ -1001,7 +1002,7 @@ public class MigrationProcessService<A> {
           .of(
               switch (WorkflowTaskOutcome.Kind.valueOf(delivery.outcome())) {
                 case COMPLETED -> WorkflowTaskOutcome.completed();
-                case COMPLETION_PENDING -> stillOpen(delivery, context);
+                case COMPLETION_PENDING -> stillOpen(deliveryLog, delivery, context);
                 case BPMN_ERROR -> WorkflowTaskOutcome
                     .bpmnError(delivery.bpmnErrorCode(), delivery.bpmnErrorName());
               });
@@ -1035,14 +1036,25 @@ public class MigrationProcessService<A> {
    * otherwise fill the log with the same line every time its lock is renewed. The memory
    * of what was already reported is bounded and lives in this process service - losing
    * an entry costs one repeated WARN, which is why it needs nothing durable.
+   * <p>
+   * This is also the one place which knows that a record is still in use, whichever BPMS
+   * redelivered: the store is told so (story 97) and keeps the record alive as long as
+   * redeliveries keep coming, while the timestamp this age is measured from stays where
+   * it is. The store collects the key rather than writing it here - the redelivery runs
+   * in the transaction of the workflow aggregate, and an UPDATE per renewal of every open
+   * task has no business in it.
    *
+   * @param deliveryLog The store the record came from
    * @param delivery The record answering this delivery
    * @param context The invocation context of the repeated delivery
    * @return The outcome, carrying the age and whether it passed the maximum
    */
   private WorkflowTaskOutcome stillOpen(
+      final TaskDeliveryLog deliveryLog,
       final TaskDelivery delivery,
       final TaskInvocationContext context) {
+
+    deliveryLog.stillOpen(delivery.deliveryKey());
 
     if (delivery.recordedAt() == null) {
       // a store written before the timestamp was part of the record - the task is

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/JdbcTaskDeliverySchemaTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/JdbcTaskDeliverySchemaTest.java
@@ -20,6 +20,11 @@ import io.vanillabp.integration.test.utils.SuppressOutputExtension;
  * Story 75: an application which creates its schema with Liquibase or Flyway switches VanillaBP's
  * table creation off. A missing table is then a deployment which forgot to apply the migration, and
  * that has to be said at startup - not at the first delivery, hours later.
+ * <p>
+ * Story 97 added a column to the table, which is the case the check of story 75 did not catch: a
+ * table created by an earlier version of VanillaBP exists, so the check passed and the missing
+ * column surfaced at the first delivery. The columns added later are therefore verified as well,
+ * whether the application hands the schema over or lets VanillaBP create it.
  */
 @ExtendWith(SuppressOutputExtension.class)
 public class JdbcTaskDeliverySchemaTest {
@@ -88,10 +93,66 @@ public class JdbcTaskDeliverySchemaTest {
                   BPMN_ERROR_CODE VARCHAR(255), \
                   BPMN_ERROR_NAME VARCHAR(255), \
                   RECORDED_AT TIMESTAMP NOT NULL, \
+                  LAST_SEEN_AT TIMESTAMP NOT NULL, \
                   CONSTRAINT PK_VANILLABP_TASK_DELIVERY PRIMARY KEY (DELIVERY_KEY))""");
     }
 
     assertDoesNotThrow(() -> storeOn("changelog").validateSchemaExists());
+
+  }
+
+  /**
+   * The table as VanillaBP created it before the second timestamp existed - the case a check
+   * looking at tables only cannot see.
+   */
+  private static void createTableOfAnEarlierVersion(
+      final String database) throws SQLException {
+
+    try (Connection connection = h2(database).acquire(); var statement = connection.createStatement()) {
+      statement
+          .executeUpdate(
+              """
+                  CREATE TABLE VANILLABP_TASK_DELIVERY (\
+                  DELIVERY_KEY VARCHAR(512) PRIMARY KEY, \
+                  WORKFLOW_MODULE_ID VARCHAR(255) NOT NULL, \
+                  BPMN_PROCESS_ID VARCHAR(255) NOT NULL, \
+                  AGGREGATE_ID VARCHAR(1024), \
+                  TASK_DEFINITION VARCHAR(255), \
+                  OUTCOME VARCHAR(32) NOT NULL, \
+                  BPMN_ERROR_CODE VARCHAR(255), \
+                  BPMN_ERROR_NAME VARCHAR(255), \
+                  RECORDED_AT TIMESTAMP NOT NULL)""");
+    }
+
+  }
+
+  @Test
+  @DisplayName("A table of an earlier version ends the startup naming the column and the way to add it")
+  public void aMissingColumnIsReportedAtStartup() throws SQLException {
+
+    createTableOfAnEarlierVersion("outdated");
+
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> storeOn("outdated").validateSchemaExists());
+
+    assertTrue(failure.getMessage().contains("LAST_SEEN_AT"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("ALTER TABLE VANILLABP_TASK_DELIVERY"), failure.getMessage());
+    assertTrue(failure.getMessage().contains("io.vanillabp:vanillabp-schema"), failure.getMessage());
+
+  }
+
+  @Test
+  @DisplayName("Even where VanillaBP creates the schema itself, a table of an earlier version is named")
+  public void aMissingColumnIsReportedWhereTheTableIsCreated() throws SQLException {
+
+    createTableOfAnEarlierVersion("outdated-created");
+
+    final var failure = assertThrows(
+        IllegalStateException.class,
+        () -> storeOn("outdated-created").createSchemaIfNotExists());
+
+    assertTrue(failure.getMessage().contains("LAST_SEEN_AT"), failure.getMessage());
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/JdbcTaskDeliverySchemaTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/JdbcTaskDeliverySchemaTest.java
@@ -1,6 +1,7 @@
 package io.vanillabp.migration.test.delivery;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -153,6 +154,91 @@ public class JdbcTaskDeliverySchemaTest {
         () -> storeOn("outdated-created").createSchemaIfNotExists());
 
     assertTrue(failure.getMessage().contains("LAST_SEEN_AT"), failure.getMessage());
+
+  }
+
+  /**
+   * A connection whose statements wait for the other thread. Both stores get past "the table is
+   * not there" before either of them runs the DDL, which is the race of two instances starting
+   * together - without a sleep and without a real race in the test.
+   */
+  private static JdbcConnectionAccess synchronizedAt(
+      final String database,
+      final java.util.concurrent.CyclicBarrier barrier) {
+
+    return () -> {
+      final var connection = h2(database).acquire();
+      return (Connection) java.lang.reflect.Proxy
+          .newProxyInstance(
+              Connection.class.getClassLoader(),
+              new Class<?>[]{
+                  Connection.class
+      },
+              (
+                  proxy,
+                  method,
+                  args) -> {
+                if ("createStatement".equals(method.getName())) {
+                  barrier.await(30, java.util.concurrent.TimeUnit.SECONDS);
+                }
+                try {
+                  return method.invoke(connection, args);
+                } catch (final java.lang.reflect.InvocationTargetException e) {
+                  throw e.getCause();
+                }
+              });
+    };
+
+  }
+
+  @Test
+  @DisplayName("Two instances creating the schema at the same moment both come through")
+  public void twoInstancesCreateTheSchemaAtOnce() throws Exception {
+
+    final var barrier = new java.util.concurrent.CyclicBarrier(2);
+    final var failures = new java.util.concurrent.CopyOnWriteArrayList<Throwable>();
+    final Runnable create = () -> {
+      try {
+        new JdbcTaskDeliveryStore(synchronizedAt("concurrent", barrier), "VANILLABP_TASK_DELIVERY")
+            .createSchemaIfNotExists();
+      } catch (final Throwable e) {
+        failures.add(e);
+      }
+    };
+
+    final var first = new Thread(create, "first-instance");
+    final var second = new Thread(create, "second-instance");
+    first.start();
+    second.start();
+    first.join(60000);
+    second.join(60000);
+
+    assertTrue(
+        failures.isEmpty(),
+        "the instance which lost the race has nothing left to do, it has not failed: "
+            + failures);
+
+    try (Connection connection = h2("concurrent").acquire(); var tables = connection.getMetaData().getTables(null, null,
+        "VANILLABP_TASK_DELIVERY", null)) {
+      assertTrue(tables.next(), "the table exists");
+      assertFalse(tables.next(), "exactly once");
+    }
+
+    assertDoesNotThrow(() -> storeOn("concurrent").validateSchemaExists());
+
+  }
+
+  @Test
+  @DisplayName("A metadata question which cannot be answered is a 'no', not an exception")
+  public void anUnanswerableMetadataQuestionIsANo() throws SQLException {
+
+    final Connection closed = h2("quiet").acquire();
+    closed.close();
+
+    assertFalse(
+        io.vanillabp.integration.adapter.migration.jdbc.JdbcSchema
+            .tableExistsQuietly(closed, "VANILLABP_TASK_DELIVERY"),
+        "the caller is on the failure path already - it must not fail there a second time");
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskAgeTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskAgeTest.java
@@ -154,6 +154,14 @@ public class OpenTaskAgeTest {
 
     final List<String> recorded = new ArrayList<>();
 
+    final List<String> stillOpen = new ArrayList<>();
+
+    @Override
+    public void stillOpen(
+        final String deliveryKey) {
+      stillOpen.add(deliveryKey);
+    }
+
     @Override
     public Optional<TaskDelivery> recordedDelivery(
         final String deliveryKey) {
@@ -509,6 +517,32 @@ public class OpenTaskAgeTest {
           .map(ch.qos.logback.classic.spi.ILoggingEvent::getFormattedMessage)
           .forEach(messages::add);
     }
+
+  }
+
+  @Test
+  @DisplayName("Story 97: every redelivery tells the store the record is still in use, and the age stays put")
+  public void aRedeliveryKeepsTheRecordAliveWithoutMovingTheAge() {
+
+    final var testee = registry(properties(Duration.ofHours(1), null, null, null));
+    storeAggregate("4715");
+
+    testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4715", "job-1"));
+    assertTrue(deliveryLog.stillOpen.isEmpty(), "the delivery which ran the handler is no redelivery");
+
+    deliveryLog.backdateBy(Duration.ofHours(3));
+    final var second = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4715", "job-1"));
+    final var third = testee.invokeWorkflowTask(MODULE, PROCESS, delivery("4715", "job-1"));
+
+    assertEquals(
+        2,
+        deliveryLog.stillOpen.size(),
+        "every redelivery of the open task reaches the store, which is what keeps its record");
+    assertEquals(deliveryLog.recorded.getFirst(), deliveryLog.stillOpen.getFirst(), "under the recorded key");
+    assertEquals(deliveryLog.recorded.getFirst(), deliveryLog.stillOpen.getLast());
+    assertTrue(second.openFor().toHours() >= 3, "and the age keeps counting from the moment the handler ran");
+    assertTrue(third.openFor().toHours() >= 3);
+    assertTrue(third.maxAgeExceeded(), "so the maximum age still fires");
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskRecordRetentionTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskRecordRetentionTest.java
@@ -1,0 +1,173 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.time.Duration;
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.delivery.JdbcConnectionAccess;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 97: the record of a task which is still open outlives the retention, the record of
+ * one nobody redelivers any more does not. Both are the JDBC store's business, which is
+ * shared by the two platforms, so this is where the SQL is pinned - on H2, with records
+ * backdated instead of waited for.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OpenTaskRecordRetentionTest {
+
+  private static final String TABLE = "VANILLABP_TASK_DELIVERY";
+
+  private static JdbcConnectionAccess h2(
+      final String name) {
+
+    return () -> DriverManager
+        .getConnection("jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1".formatted(name), "sa", "");
+
+  }
+
+  private final JdbcConnectionAccess connections;
+
+  private final JdbcTaskDeliveryStore testee;
+
+  public OpenTaskRecordRetentionTest() {
+
+    this.connections = h2("open-task-"
+        + java.util.UUID.randomUUID());
+    this.testee = new JdbcTaskDeliveryStore(connections, TABLE);
+    testee.createSchemaIfNotExists();
+
+  }
+
+  /**
+   * A record written the given time ago - both of its timestamps, exactly as the insert
+   * writes them.
+   */
+  private void record(
+      final String deliveryKey,
+      final String outcome,
+      final Duration age) {
+
+    testee.record(
+        new TaskDelivery(
+            deliveryKey, "test-module", "TestProcess", "4711", "awaitCompletion", outcome, null, null, Instant
+                .now()
+                .minus(age)));
+
+  }
+
+  private boolean exists(
+      final String deliveryKey) {
+
+    return testee.recordedDelivery(deliveryKey).isPresent();
+
+  }
+
+  /**
+   * The two timestamps of a record, read past the store - which maps only the one the
+   * core knows about.
+   */
+  private java.sql.Timestamp[] timestampsOf(
+      final String deliveryKey) throws SQLException {
+
+    try (var connection = connections.acquire(); var statement = connection
+        .prepareStatement("SELECT RECORDED_AT, LAST_SEEN_AT FROM %s WHERE DELIVERY_KEY = ?"
+            .formatted(TABLE))) {
+      statement.setString(1, deliveryKey);
+      try (var resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return new java.sql.Timestamp[]{
+            resultSet.getTimestamp(1), resultSet.getTimestamp(2)
+        };
+      }
+    }
+
+  }
+
+  @Test
+  @DisplayName("A record is written seen at the moment it was recorded")
+  public void aNewRecordWasSeenWhenItWasWritten() throws SQLException {
+
+    record("job-1", "COMPLETION_PENDING", Duration.ZERO);
+
+    final var timestamps = timestampsOf("job-1");
+    assertEquals(timestamps[0], timestamps[1], "nothing was redelivered yet");
+
+  }
+
+  @Test
+  @DisplayName("A redelivered open task keeps its record, one nobody redelivers loses it")
+  public void aRedeliveredOpenTaskKeepsItsRecord() throws SQLException {
+
+    record("job-open", "COMPLETION_PENDING", Duration.ofHours(2));
+    record("job-forgotten", "COMPLETION_PENDING", Duration.ofHours(2));
+    record("job-done", "COMPLETED", Duration.ofHours(2));
+
+    // the BPMS redelivered the open task, which is what the core reports to the store
+    testee.stillOpen("job-open");
+
+    final var deleted = testee.deleteExpired(Duration.ofHours(1));
+
+    assertEquals(2, deleted);
+    assertTrue(exists("job-open"), "a task which is still being redelivered keeps the record answering it");
+    assertFalse(exists("job-forgotten"), "a record nobody has seen for a whole retention expires");
+    assertFalse(exists("job-done"), "and so does the record of a task which is done");
+
+    final var timestamps = timestampsOf("job-open");
+    assertTrue(
+        timestamps[1].after(timestamps[0]),
+        "the moment it was last seen moved, the moment it was recorded did not");
+    assertTrue(
+        timestamps[0].toInstant().isBefore(Instant.now().minus(Duration.ofMinutes(90))),
+        "so the age of the open task is still measured from the moment the handler ran");
+
+  }
+
+  @Test
+  @DisplayName("An open task whose record expired anyway is recorded again on the next delivery")
+  public void anExpiredRecordIsWrittenAgain() {
+
+    record("job-lost", "COMPLETION_PENDING", Duration.ofHours(2));
+    assertEquals(1, testee.deleteExpired(Duration.ofHours(1)));
+
+    // the key of a record which is gone updates nothing, and that must not throw
+    testee.stillOpen("job-lost");
+    assertEquals(1, testee.refreshOpenTasks());
+    assertFalse(exists("job-lost"));
+
+  }
+
+  @Test
+  @DisplayName("More open tasks than one block are refreshed in blocks")
+  public void moreOpenTasksThanOneBlockAreRefreshed() throws SQLException {
+
+    final var tasks = OpenTaskTouches.BLOCK_SIZE + 100;
+    for (var i = 0; i < tasks; i++) {
+      record("job-"
+          + i, "COMPLETION_PENDING", Duration.ofHours(2));
+      testee.stillOpen("job-"
+          + i);
+    }
+
+    assertEquals(tasks, testee.refreshOpenTasks());
+    assertEquals(0, testee.deleteExpired(Duration.ofHours(1)), "every one of them survives");
+
+    final var timestamps = timestampsOf("job-"
+        + (tasks - 1));
+    assertTrue(timestamps[1].after(timestamps[0]), "the last key of the last block was written as well");
+
+  }
+
+}

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskTouchesTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/delivery/OpenTaskTouchesTest.java
@@ -1,0 +1,128 @@
+package io.vanillabp.migration.test.delivery;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+
+/**
+ * Story 97: how the keys of the open tasks a BPMS redelivered reach their store. The
+ * bundling itself is what is pinned here - that nothing is written while a delivery is
+ * being processed, that the store sees blocks of at most
+ * {@link OpenTaskTouches#BLOCK_SIZE} keys however many arrive, and that a failing block
+ * neither kills the flush nor the keys which come after it.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OpenTaskTouchesTest {
+
+  private final List<List<String>> blocks = new ArrayList<>();
+
+  private OpenTaskTouches testee() {
+
+    return new OpenTaskTouches("VANILLABP_TASK_DELIVERY", blocks::add);
+
+  }
+
+  @Test
+  @DisplayName("Remembering a key writes nothing - the flush does")
+  public void rememberingWritesNothing() {
+
+    final var testee = testee();
+
+    testee.remember("job-1");
+    testee.remember("job-2");
+    testee.remember("job-1");
+
+    assertTrue(blocks.isEmpty(), "a redelivery must not write in the transaction it runs in");
+    assertEquals(2, testee.size(), "the same task redelivered twice is one key");
+
+    assertEquals(2, testee.flush());
+    assertEquals(1, blocks.size());
+    assertEquals(List.of("job-1", "job-2"), blocks.getFirst().stream().sorted().toList());
+    assertEquals(0, testee.size(), "what was written is not written again");
+
+  }
+
+  @Test
+  @DisplayName("Nothing to write is no round trip at all")
+  public void anEmptyFlushDoesNothing() {
+
+    assertEquals(0, testee().flush());
+    assertTrue(blocks.isEmpty());
+
+  }
+
+  @Test
+  @DisplayName("More keys than the block size are written in blocks of at most that size")
+  public void moreKeysThanTheBlockSizeAreWrittenInBlocks() {
+
+    final var testee = testee();
+    final var keys = OpenTaskTouches.BLOCK_SIZE + (OpenTaskTouches.BLOCK_SIZE / 2);
+    for (var i = 0; i < keys; i++) {
+      testee.remember("job-"
+          + i);
+    }
+
+    assertEquals(keys, testee.flush());
+
+    assertEquals(2, blocks.size(), "one full block and the remainder");
+    assertEquals(OpenTaskTouches.BLOCK_SIZE, blocks.getFirst().size());
+    assertEquals(OpenTaskTouches.BLOCK_SIZE / 2, blocks.getLast().size());
+    assertEquals(
+        keys,
+        blocks.stream().flatMap(List::stream).distinct().count(),
+        "every key reached the store exactly once");
+
+  }
+
+  @Test
+  @DisplayName("A block the store refuses costs its own keys, not the ones after it")
+  public void aFailingBlockDoesNotSwallowTheRest() {
+
+    final var written = new ArrayList<String>();
+    final var testee = new OpenTaskTouches("VANILLABP_TASK_DELIVERY", block -> {
+      if (block.size() == OpenTaskTouches.BLOCK_SIZE) {
+        throw new IllegalStateException("the database was gone for a moment");
+      }
+      written.addAll(block);
+    });
+    for (var i = 0; i < (OpenTaskTouches.BLOCK_SIZE + 10); i++) {
+      testee.remember("job-"
+          + i);
+    }
+
+    // the first block throws, so the flush ends there - the keys it did not reach stay
+    assertEquals(0, testee.flush());
+    assertEquals(10, testee.size(), "what was not collected yet is still remembered");
+
+    assertEquals(10, testee.flush(), "and it is written by the next run");
+    assertEquals(10, written.size());
+
+  }
+
+  @Test
+  @DisplayName("The memory is bounded - a hint lost costs a record, never the application")
+  public void theMemoryIsBounded() {
+
+    final var testee = testee();
+    for (var i = 0; i < (OpenTaskTouches.MAX_REMEMBERED + 100); i++) {
+      testee.remember("job-"
+          + i);
+    }
+
+    assertEquals(OpenTaskTouches.MAX_REMEMBERED, testee.size());
+
+    testee.remember(null);
+    assertEquals(OpenTaskTouches.MAX_REMEMBERED, testee.size(), "and nothing without a key");
+
+  }
+
+}

--- a/quarkus-integration/README.md
+++ b/quarkus-integration/README.md
@@ -207,6 +207,9 @@ manages an aggregate.
   `vanillabp.outbox.create-schema` is disabled) and to start the core's
   `TaskDeliveryRetentionCleanup`, which calls `cleanUpExpiredRecords` per
   `vanillabp.outbox.retention`.
+- The same run refreshes the records of the tasks which are still open (story 97): the core
+  collects the keys the BPMS redelivered, `cleanUpExpiredRecords` writes them before it
+  deletes anything, and the JDBC store batches while the MongoDB one bulk-writes.
 
 ## What is published where (story 92)
 

--- a/quarkus-integration/README.md
+++ b/quarkus-integration/README.md
@@ -210,6 +210,10 @@ manages an aggregate.
 - The same run refreshes the records of the tasks which are still open (story 97): the core
   collects the keys the BPMS redelivered, `cleanUpExpiredRecords` writes them before it
   deletes anything, and the JDBC store batches while the MongoDB one bulk-writes.
+- `JdbcPhaseTwoOutboxDispatcher` creates its table the same way the core's delivery store does,
+  including the answer to two instances creating it at the same moment: a refused DDL asks the
+  metadata again through a connection of its own and stays quiet where the table is there now.
+  See the migration adapter's README for why this is not a question of SQL states.
 
 ## What is published where (story 92)
 

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryProcessWiringSource.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryProcessWiringSource.java
@@ -25,7 +25,8 @@ public class DeliveryProcessWiringSource implements DummyTaskWiringSource {
             new BpmnTaskSpec("Activity_Process", "processTask"),
             new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
             new BpmnTaskSpec("Activity_Fail", "failTask"),
-            new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+            new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"),
+            new BpmnTaskSpec("Activity_Await", "awaitCompletion"))
         : List.of();
 
   }

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/main/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
@@ -2,6 +2,7 @@ package io.vanillabp.integration.test.delivery;
 
 import io.vanillabp.spi.service.BpmnProcess;
 import io.vanillabp.spi.service.TaskException;
+import io.vanillabp.spi.service.TaskId;
 import io.vanillabp.spi.service.WorkflowService;
 import io.vanillabp.spi.service.WorkflowTask;
 import jakarta.enterprise.context.ApplicationScoped;
@@ -42,6 +43,21 @@ public class DeliveryWorkflowService {
     aggregate.setInvocations(aggregate.getInvocations() + 1);
     aggregate.setStatus("must-never-be-visible");
     throw new IllegalStateException("something broke");
+
+  }
+
+  /**
+   * A task the application completes later, so it stays open from the BPMS' point of view
+   * and is redelivered until somebody completes it - the record which answers those
+   * redeliveries is what story 97 keeps alive.
+   */
+  @WorkflowTask
+  public void awaitCompletion(
+      final DeliveryAggregate aggregate,
+      @TaskId final String taskId) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("awaiting-completion");
 
   }
 

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/OpenTaskRetentionTest.java
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/java/io/vanillabp/integration/it/OpenTaskRetentionTest.java
@@ -1,0 +1,234 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.adapter.dummy.runtime.DummyDeploymentService;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.spi.AdapterDeploymentService;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.runtime.delivery.JdbcTaskDeliveryLog;
+import io.vanillabp.integration.test.delivery.DeliveryAggregate;
+import io.vanillabp.integration.test.delivery.DeliveryAggregatePersistence;
+import io.vanillabp.integration.test.delivery.DeliveryProcessWiringSource;
+import io.vanillabp.integration.test.delivery.DeliveryWorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.enterprise.inject.Any;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Inject;
+
+/**
+ * Acceptance test of story 97 on Quarkus, with the default JDBC-based delivery log: the
+ * record which answers the redeliveries of an OPEN task outlives the retention as long as
+ * the BPMS keeps redelivering that task, while the record of a task nobody hands out any
+ * more expires as it always did. The age of the open task keeps being measured from the
+ * moment the handler ran, so <code>vanillabp.delivery.max-task-age</code> still fires.
+ * <p>
+ * An hour of retention and an hour of maximum age, with the records backdated by two -
+ * nothing here waits for a clock.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OpenTaskRetentionTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "DeliveryProcess";
+
+  private static final String ADAPTER = "demo1";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("open-task/application.yaml", "application.yaml")
+          .addClass(DeliveryAggregate.class)
+          .addClass(DeliveryAggregatePersistence.class)
+          .addClass(DeliveryWorkflowService.class)
+          .addClass(DeliveryProcessWiringSource.class)
+          .addAsResource("bpmn/first.bpmn", "processes/dummy/DeliveryProcess.bpmn")
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"));
+
+  @Inject
+  DeliveryAggregatePersistence persistence;
+
+  @Inject
+  DataSource dataSource;
+
+  @Inject
+  JdbcTaskDeliveryLog deliveryLog;
+
+  @Inject
+  @Any
+  Instance<List<AdapterDeploymentService<Object, Object>>> deploymentServices;
+
+  private DummyDeploymentService dummyAdapter() {
+
+    return deploymentServices
+        .stream()
+        .filter(java.util.Objects::nonNull)
+        .flatMap(List::stream)
+        .filter(java.util.Objects::nonNull)
+        .filter(DummyDeploymentService.class::isInstance)
+        .map(DummyDeploymentService.class::cast)
+        .filter(service -> ADAPTER.equals(service.getAdapterId()))
+        .findFirst()
+        .orElseThrow();
+
+  }
+
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getTaskId() {
+        return deliveryId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  private int recordCount(
+      final String aggregateId) throws SQLException {
+
+    try (var connection = dataSource.getConnection(); var statement = connection.prepareStatement(
+        "SELECT COUNT(*) FROM %s WHERE AGGREGATE_ID = ?".formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME))) {
+      statement.setString(1, aggregateId);
+      try (var resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getInt(1);
+      }
+    }
+
+  }
+
+  /**
+   * Moves every record of the table back in time, both of its timestamps - a database two
+   * hours older than the application which reads it.
+   */
+  private void backdateEveryRecordBy(
+      final Duration age) throws SQLException {
+
+    final var moment = Timestamp.from(Instant.now().minus(age));
+    try (var connection = dataSource.getConnection(); var statement = connection
+        .prepareStatement("UPDATE %s SET RECORDED_AT = ?, LAST_SEEN_AT = ?"
+            .formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME))) {
+      statement.setTimestamp(1, moment);
+      statement.setTimestamp(2, moment);
+      statement.executeUpdate();
+    }
+
+  }
+
+  private Timestamp lastSeenAt(
+      final String aggregateId) throws SQLException {
+
+    try (var connection = dataSource.getConnection(); var statement = connection
+        .prepareStatement("SELECT LAST_SEEN_AT FROM %s WHERE AGGREGATE_ID = ?"
+            .formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME))) {
+      statement.setString(1, aggregateId);
+      try (var resultSet = statement.executeQuery()) {
+        resultSet.next();
+        return resultSet.getTimestamp(1);
+      }
+    }
+
+  }
+
+  @Test
+  @DisplayName("The record of an open task survives the retention, the record of a finished one does not")
+  public void theRecordOfAnOpenTaskSurvivesTheRetention() throws SQLException {
+
+    final var dummyAdapter = dummyAdapter();
+
+    // an asynchronous task the application never completes, and an ordinary one which is
+    // done the moment its handler returns
+    persistence.store("4711");
+    persistence.store("4712");
+    final var opened = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4712", "job-2"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, opened.kind());
+    assertEquals(1, recordCount("4711"));
+    assertEquals(1, recordCount("4712"));
+
+    // two hours later, an hour past the retention and past the maximum age
+    backdateEveryRecordBy(Duration.ofHours(2));
+    final var backdated = lastSeenAt("4711");
+
+    // the BPMS renews the lock of the task nobody completed, which is a redelivery
+    final var redelivered = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+    assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, redelivered.kind());
+    assertEquals(
+        1,
+        persistence.get("4711").getInvocations(),
+        "the redelivery is answered from the record, the handler ran once");
+    assertTrue(
+        redelivered.openFor().compareTo(Duration.ofHours(2)) >= 0,
+        "the age is still measured from the moment the handler ran: "
+            + redelivered.openFor());
+    assertTrue(
+        redelivered.maxAgeExceeded(),
+        "so a task open longer than 'vanillabp.delivery.max-task-age' is still reported");
+
+    // the cleanup writes what the redelivery collected and then deletes what nobody saw
+    final var deleted = deliveryLog.cleanUpExpiredRecords();
+
+    assertEquals(1, deleted);
+    assertEquals(
+        1,
+        recordCount("4711"),
+        "the task is still being redelivered, so the record answering it stays");
+    assertEquals(
+        0,
+        recordCount("4712"),
+        "nobody redelivers a task which is done - its record expires as it always did");
+    assertTrue(lastSeenAt("4711").after(backdated), "the moment the record was last seen moved forward");
+
+    // and the record kept alive still does its job
+    dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+    assertEquals(
+        1,
+        persistence.get("4711").getInvocations(),
+        "which is the whole point: the handler of an open task must not run twice");
+
+  }
+
+}

--- a/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/open-task/application.yaml
+++ b/quarkus-integration/integration-tests/deployment-integration-tests/src/test/resources/open-task/application.yaml
@@ -1,0 +1,19 @@
+quarkus:
+  datasource:
+    db-kind: h2
+    jdbc:
+      url: jdbc:h2:mem:open-task;DB_CLOSE_DELAY=-1
+vanillabp:
+  outbox:
+    retention: PT1H
+  delivery:
+    max-task-age: PT1H
+  adapters:
+    demo1:
+      type: dummy
+      test: 1
+  workflow-modules:
+    test-module:
+      adapters:
+        demo1:
+          resources-location: classpath:processes/dummy

--- a/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoOpenTaskRetentionTest.java
+++ b/quarkus-integration/integration-tests/outbox-mongo-integration-tests/src/test/java/io/vanillabp/integration/it/MongoOpenTaskRetentionTest.java
@@ -1,0 +1,163 @@
+package io.vanillabp.integration.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.mongodb.client.MongoClient;
+
+import io.quarkus.test.QuarkusExtensionTest;
+import io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches;
+import io.vanillabp.integration.runtime.delivery.MongoTaskDeliveryLog;
+import io.vanillabp.integration.spi.TaskDelivery;
+import io.vanillabp.integration.test.Aggregate;
+import io.vanillabp.integration.test.AggregatePersistence;
+import io.vanillabp.integration.test.RecordingPhaseTwoListener;
+import io.vanillabp.integration.test.WorkflowService;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import jakarta.inject.Inject;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * Story 97 in the MongoDB store on Quarkus: the record which answers the redeliveries of an
+ * OPEN task outlives the retention as long as the BPMS keeps redelivering that task, and
+ * the record of a task nobody hands out any more expires as it always did. The moment the
+ * handler ran stays where it is, because the age of the open task is measured from it.
+ * <p>
+ * An hour of retention with records backdated by two, so nothing here waits for a clock -
+ * unlike {@link MongoTaskDeliveryLogTest}, whose retention of zero cannot tell a record
+ * kept from one deleted.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class MongoOpenTaskRetentionTest {
+
+  private static final String DATABASE = "open-task-it";
+
+  private static final String COLLECTION = "vanillabp-task-deliveries";
+
+  @RegisterExtension
+  static final QuarkusExtensionTest extensionTest = new QuarkusExtensionTest()
+      .withApplicationRoot(jar -> jar
+          .addAsResource("application.yaml")
+          .addClass(Aggregate.class)
+          .addClass(AggregatePersistence.class)
+          .addClass(WorkflowService.class)
+          .addClass(RecordingPhaseTwoListener.class)
+          .addAsResource("workflow-module-descriptor/workflow-module", "META-INF/workflow-module"))
+      .overrideConfigKey("quarkus.mongodb.database", DATABASE)
+      .overrideConfigKey("vanillabp.outbox.retention", "PT1H");
+
+  @Inject
+  MongoTaskDeliveryLog deliveryLog;
+
+  @Inject
+  UserTransaction userTransaction;
+
+  @Inject
+  MongoClient mongoClient;
+
+  @BeforeEach
+  public void clearRecords() {
+
+    mongoClient
+        .getDatabase(DATABASE)
+        .getCollection(COLLECTION)
+        .deleteMany(new Document());
+
+  }
+
+  /**
+   * A record written the given time ago - both of its timestamps, exactly as the insert
+   * writes them.
+   */
+  private TaskDelivery backdated(
+      final String deliveryKey,
+      final Duration age) {
+
+    return new TaskDelivery(
+        deliveryKey, "test-module", "TestProcess", "4711", "awaitCompletion", "COMPLETION_PENDING", null, null, Instant
+            .now()
+            .minus(age));
+
+  }
+
+  private Document documentOf(
+      final String deliveryKey) {
+
+    return mongoClient
+        .getDatabase(DATABASE)
+        .getCollection(COLLECTION)
+        .find(new Document("_id", deliveryKey))
+        .first();
+
+  }
+
+  @Test
+  @DisplayName("A redelivered open task keeps its record, one nobody redelivers loses it")
+  public void aRedeliveredOpenTaskKeepsItsRecord() throws Exception {
+
+    userTransaction.begin();
+    deliveryLog.record(backdated("job-open", Duration.ofHours(2)));
+    deliveryLog.record(backdated("job-forgotten", Duration.ofHours(2)));
+    userTransaction.commit();
+
+    // the BPMS redelivered the open task, which is what the core reports to the store
+    deliveryLog.stillOpen("job-open");
+
+    final var deleted = deliveryLog.cleanUpExpiredRecords();
+
+    assertEquals(1, deleted);
+    assertTrue(
+        deliveryLog.recordedDelivery("job-open").isPresent(),
+        "a task which is still being redelivered keeps the record answering it");
+    assertTrue(
+        deliveryLog.recordedDelivery("job-forgotten").isEmpty(),
+        "a record nobody has seen for a whole retention expires");
+
+    final var kept = documentOf("job-open");
+    assertTrue(
+        kept.getDate("lastSeenAt").after(kept.getDate("recordedAt")),
+        "the moment it was last seen moved, the moment it was recorded did not");
+    assertTrue(
+        kept.getDate("recordedAt").toInstant().isBefore(Instant.now().minus(Duration.ofMinutes(90))),
+        "so the age of the open task is still measured from the moment the handler ran");
+
+  }
+
+  @Test
+  @DisplayName("More open tasks than one block are refreshed in blocks")
+  public void moreOpenTasksThanOneBlockAreRefreshed() throws Exception {
+
+    final var tasks = OpenTaskTouches.BLOCK_SIZE + 100;
+
+    userTransaction.begin();
+    for (var i = 0; i < tasks; i++) {
+      deliveryLog.record(backdated("block-"
+          + i, Duration.ofHours(2)));
+    }
+    userTransaction.commit();
+    for (var i = 0; i < tasks; i++) {
+      deliveryLog.stillOpen("block-"
+          + i);
+    }
+
+    assertEquals(0, deliveryLog.cleanUpExpiredRecords(), "every one of them survives");
+    assertTrue(
+        documentOf("block-"
+            + (tasks - 1)).getDate("lastSeenAt")
+            .after(documentOf("block-"
+                + (tasks - 1)).getDate("recordedAt")),
+        "the last key of the last block was written as well");
+
+  }
+
+}

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/JdbcTaskDeliveryLog.java
@@ -127,14 +127,24 @@ public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAcces
   }
 
   /**
-   * Deletes the records whose retention period passed - run by the background cleanup and
-   * usable on demand (e.g. by tests).
+   * Refreshes the records of the open tasks redelivered since the last run and deletes the
+   * records whose retention period passed - run by the background cleanup and usable on
+   * demand (e.g. by tests). Both are the store's business and happen in that order (story
+   * 97).
    *
    * @return The number of records deleted
    */
   public int cleanUpExpiredRecords() {
 
     return getStore().deleteExpired(getProperties().getRetention());
+
+  }
+
+  @Override
+  public void stillOpen(
+      final String deliveryKey) {
+
+    getStore().stillOpen(deliveryKey);
 
   }
 

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
@@ -125,6 +125,8 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
       return;
     }
     if (getProperties().isCreateSchema()) {
+      // MongoDB answers a createIndex of an index which is already there with its name, so
+      // two instances starting at the same moment do not collide over it
       deliveryCollection().createIndex(Indexes.ascending("lastSeenAt"));
     }
     retentionCleanup = new TaskDeliveryRetentionCleanup(

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/delivery/MongoTaskDeliveryLog.java
@@ -9,11 +9,17 @@ import org.eclipse.microprofile.config.ConfigProvider;
 import com.mongodb.MongoWriteException;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.BulkWriteOptions;
+import com.mongodb.client.model.Filters;
 import com.mongodb.client.model.Indexes;
+import com.mongodb.client.model.UpdateOneModel;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.model.WriteModel;
 
 import io.quarkus.runtime.StartupEvent;
 import io.smallrye.config.SmallRyeConfig;
 import io.vanillabp.integration.adapter.migration.config.PhaseTwoOutboxProperties;
+import io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches;
 import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterProperties;
 import io.vanillabp.integration.runtime.config.QuarkusMigrationAdapterPropertiesMapper;
@@ -68,6 +74,9 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
 
   private volatile TaskDeliveryRetentionCleanup retentionCleanup;
 
+  private final OpenTaskTouches touches = new OpenTaskTouches(
+      DEFAULT_COLLECTION_NAME, this::refreshLastSeen);
+
   /**
    * Whether this default log is usable: the extension registers the bean at build time,
    * but without a MongoDB client it cannot store anything.
@@ -116,7 +125,7 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
       return;
     }
     if (getProperties().isCreateSchema()) {
-      deliveryCollection().createIndex(Indexes.ascending("recordedAt"));
+      deliveryCollection().createIndex(Indexes.ascending("lastSeenAt"));
     }
     retentionCleanup = new TaskDeliveryRetentionCleanup(
         DEFAULT_COLLECTION_NAME, getProperties().getRetention(), this::cleanUpExpiredRecords);
@@ -125,19 +134,53 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
   }
 
   /**
-   * Deletes the records whose retention period passed - run by the background cleanup and
-   * usable on demand (e.g. by tests).
+   * Refreshes the records of the open tasks redelivered since the last run and deletes the
+   * records nobody has seen for the retention period - run by the background cleanup and
+   * usable on demand (e.g. by tests). Refreshing first is what keeps the record of a task
+   * which is still being redelivered (story 97).
    *
    * @return The number of records deleted
    */
   public long cleanUpExpiredRecords() {
 
+    touches.flush();
+
     return deliveryCollection()
         .deleteMany(
             new Document(
-                "recordedAt", new Document("$lt", Date
+                "lastSeenAt", new Document("$lt", Date
                     .from(java.time.Instant.now().minus(getProperties().getRetention())))))
         .getDeletedCount();
+
+  }
+
+  @Override
+  public void stillOpen(
+      final String deliveryKey) {
+
+    touches.remember(deliveryKey);
+
+  }
+
+  /**
+   * Moves <code>lastSeenAt</code> of one block of records, in one round trip. A key whose
+   * record was deleted meanwhile matches nothing, which is the right answer: the record is
+   * gone and the next redelivery writes a new one.
+   *
+   * @param deliveryKeys The keys of one block
+   */
+  private void refreshLastSeen(
+      final java.util.List<String> deliveryKeys) {
+
+    final var now = new Date();
+    deliveryCollection()
+        .bulkWrite(
+            deliveryKeys
+                .stream()
+                .map(deliveryKey -> (WriteModel<Document>) new UpdateOneModel<Document>(
+                    Filters.eq("_id", deliveryKey), Updates.set("lastSeenAt", now)))
+                .toList(),
+            new BulkWriteOptions().ordered(false));
 
   }
 
@@ -189,6 +232,9 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
     // (story 70)
     final var session = io.vanillabp.integration.runtime.mongo.MongoSessions
         .activeSession(txRegistry);
+    final var recordedAt = Date.from(delivery.recordedAt() == null
+        ? java.time.Instant.now()
+        : delivery.recordedAt());
     final var record = new Document()
         .append("_id", delivery.deliveryKey())
         .append("workflowModuleId", delivery.workflowModuleId())
@@ -198,11 +244,10 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
         .append("outcome", delivery.outcome())
         .append("bpmnErrorCode", delivery.bpmnErrorCode())
         .append("bpmnErrorName", delivery.bpmnErrorName())
-        .append(
-            "recordedAt",
-            Date.from(delivery.recordedAt() == null
-                ? java.time.Instant.now()
-                : delivery.recordedAt()));
+        .append("recordedAt", recordedAt)
+        // the record was seen the moment it was written; a redelivery of a task which
+        // stays open moves lastSeenAt and leaves recordedAt where it is
+        .append("lastSeenAt", recordedAt);
     // a duplicate-key error inside a MongoDB transaction would abort it entirely, so the
     // common duplicate is read instead - the unique document ID stays the backstop
     if ((session != null) && (collection

--- a/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
+++ b/quarkus-integration/runtime/src/main/java/io/vanillabp/integration/runtime/outbox/JdbcPhaseTwoOutboxDispatcher.java
@@ -257,11 +257,38 @@ public class JdbcPhaseTwoOutboxDispatcher {
         statement.executeUpdate(buildCreateTable(connection, tableName));
       }
     } catch (SQLException e) {
+      if (createdConcurrently()) {
+        return;
+      }
       throw new IllegalStateException(
           """
               Could not create the phase-two outbox table '%s'! Set 'vanillabp.outbox.create-schema' \
               to 'false' and manage the schema manually if the DDL is not suitable for your database."""
               .formatted(tableName), e);
+    }
+
+  }
+
+  /**
+   * Whether the DDL failed because another instance created the table between the check and the
+   * statement. Two instances starting together (a rolling deployment, a scale-up from zero) both
+   * see no table and both create it, and the loser's boot must not end over it - it just has
+   * nothing left to do (see {@link JdbcSchema#tableExistsQuietly(Connection, String)}).
+   *
+   * @return Whether the table is there now
+   */
+  private boolean createdConcurrently() {
+
+    try (var connection = dataSource.get().getConnection()) {
+      if (!JdbcSchema.tableExistsQuietly(connection, tableName)) {
+        return false;
+      }
+      log.debug(
+          "The phase-two outbox table '{}' was created by another instance starting at the same moment",
+          tableName);
+      return true;
+    } catch (final SQLException e) {
+      return false;
     }
 
   }

--- a/schema/src/main/resources/vanillabp/schema/latest.xml
+++ b/schema/src/main/resources/vanillabp/schema/latest.xml
@@ -66,6 +66,9 @@
     <comment>
       The log of processed task deliveries: what a BPMS repeating a delivery is answered from. The
       delivery key is the BPMS' identity of the delivery, 512 characters for the same index reason.
+      RECORDED_AT is the moment the handler ran and never moves, because the age of a task left open
+      is measured from it; LAST_SEEN_AT is the moment the BPMS last redelivered that task, and the
+      retention deletes by it, so a task which is still being redelivered keeps its record.
     </comment>
     <createTable tableName="${vanillabp.delivery.table}">
       <column name="DELIVERY_KEY" type="VARCHAR(512)">
@@ -85,6 +88,9 @@
       <column name="BPMN_ERROR_CODE" type="VARCHAR(255)" />
       <column name="BPMN_ERROR_NAME" type="VARCHAR(255)" />
       <column name="RECORDED_AT" type="TIMESTAMP">
+        <constraints nullable="false" />
+      </column>
+      <column name="LAST_SEEN_AT" type="TIMESTAMP">
         <constraints nullable="false" />
       </column>
     </createTable>

--- a/schema/src/test/java/io/vanillabp/schema/ChangelogAppliesTest.java
+++ b/schema/src/test/java/io/vanillabp/schema/ChangelogAppliesTest.java
@@ -103,7 +103,8 @@ public class ChangelogAppliesTest {
           java.util.List
               .of(
                   "DELIVERY_KEY", "WORKFLOW_MODULE_ID", "BPMN_PROCESS_ID", "AGGREGATE_ID",
-                  "TASK_DEFINITION", "OUTCOME", "BPMN_ERROR_CODE", "BPMN_ERROR_NAME", "RECORDED_AT"),
+                  "TASK_DEFINITION", "OUTCOME", "BPMN_ERROR_CODE", "BPMN_ERROR_NAME", "RECORDED_AT",
+                  "LAST_SEEN_AT"),
           java.util.List.copyOf(delivery.keySet()));
 
     }

--- a/spring-boot-integration/README.md
+++ b/spring-boot-integration/README.md
@@ -96,6 +96,9 @@ aggregate is detected once in `SpringPersistenceTechnology`, shared by both reso
   `TaskDeliveryRetentionCleanup`). Table and index are created from a
   `SmartInitializingSingleton`, not while the bean is built - the DDL must not
   materialize the data source before the application's configuration is complete.
+- The same run refreshes the records of the tasks which are still open (story 97): the core
+  collects the keys the BPMS redelivered, `cleanUpExpiredRecords` writes them before it
+  deletes anything, and the JDBC store batches while the MongoDB one bulk-writes.
 
 ## What is published where (story 92)
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryRecordReleaseTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryRecordReleaseTest.java
@@ -152,7 +152,8 @@ public class DeliveryRecordReleaseTest {
                   new BpmnTaskSpec("Activity_Process", "processTask"),
                   new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
                   new BpmnTaskSpec("Activity_Fail", "failTask"),
-                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"),
+                  new BpmnTaskSpec("Activity_Await", "awaitCompletion"))
               : List.of();
 
     }

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/DeliveryWorkflowService.java
@@ -2,6 +2,7 @@ package io.vanillabp.integration.test.delivery;
 
 import io.vanillabp.spi.service.BpmnProcess;
 import io.vanillabp.spi.service.TaskException;
+import io.vanillabp.spi.service.TaskId;
 import io.vanillabp.spi.service.WorkflowService;
 import io.vanillabp.spi.service.WorkflowTask;
 
@@ -41,6 +42,21 @@ public class DeliveryWorkflowService {
     aggregate.setInvocations(aggregate.getInvocations() + 1);
     aggregate.setStatus("must-never-be-visible");
     throw new IllegalStateException("something broke");
+
+  }
+
+  /**
+   * A task the application completes later, so it stays open from the BPMS' point of view
+   * and is redelivered until somebody completes it - the record which answers those
+   * redeliveries is what story 97 keeps alive.
+   */
+  @WorkflowTask
+  public void awaitCompletion(
+      final DeliveryAggregate aggregate,
+      @TaskId final String taskId) {
+
+    aggregate.setInvocations(aggregate.getInvocations() + 1);
+    aggregate.setStatus("awaiting-completion");
 
   }
 

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/InboundIdempotencyTest.java
@@ -150,7 +150,8 @@ public class InboundIdempotencyTest {
                   new BpmnTaskSpec("Activity_Process", "processTask"),
                   new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
                   new BpmnTaskSpec("Activity_Fail", "failTask"),
-                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"))
+                  new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"),
+                  new BpmnTaskSpec("Activity_Await", "awaitCompletion"))
               : List.of();
 
     }

--- a/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/OpenTaskRetentionTest.java
+++ b/spring-boot-integration/integration-tests/main-integration-test/src/test/java/io/vanillabp/integration/test/delivery/OpenTaskRetentionTest.java
@@ -1,0 +1,371 @@
+package io.vanillabp.integration.test.delivery;
+
+import java.io.IOException;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
+import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
+import org.springframework.transaction.PlatformTransactionManager;
+
+import io.vanillabp.adapter.dummy.springboot.DummyAdapterConfiguration;
+import io.vanillabp.adapter.dummy.springboot.deployment.DeploymentService;
+import io.vanillabp.adapter.dummy.springboot.deployment.DummyTaskWiringSource;
+import io.vanillabp.adapter.dummy.springboot.processservice.DummyAdapterProcessServiceConfiguration;
+import io.vanillabp.integration.adapter.migration.delivery.JdbcTaskDeliveryStore;
+import io.vanillabp.integration.adapter.spi.workflowtask.BpmnTaskSpec;
+import io.vanillabp.integration.adapter.spi.workflowtask.TaskInvocationContext;
+import io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskOutcome;
+import io.vanillabp.integration.delivery.JdbcTaskDeliveryLog;
+import io.vanillabp.integration.delivery.JdbcTaskDeliveryLogAutoConfiguration;
+import io.vanillabp.integration.processservice.SpringBootMigrationAdapterAutoConfiguration;
+import io.vanillabp.integration.spi.AggregatePersistenceAware;
+import io.vanillabp.integration.test.TestPersistenceConfiguration;
+import io.vanillabp.integration.test.WorkflowModuleConfiguration;
+import io.vanillabp.integration.test.deployment.DeploymentTest;
+import io.vanillabp.integration.test.utils.SuppressOutputExtension;
+import io.vanillabp.integration.test.utils.springboot.SpringBootTestApplication;
+import io.vanillabp.integration.workflowmodule.WorkflowModuleAutoConfiguration;
+
+/**
+ * Acceptance test of story 97 on Spring Boot, with the default JDBC-based delivery log: the
+ * record which answers the redeliveries of an OPEN task outlives the retention as long as
+ * the BPMS keeps redelivering that task, while the record of a task nobody hands out any
+ * more expires as it always did.
+ * <p>
+ * The second half of the story is that nothing of this moves the age of the open task: it
+ * keeps being measured from the moment the handler ran, so
+ * <code>vanillabp.delivery.max-task-age</code> still fires. Both are asserted on records
+ * backdated in the database rather than waited for.
+ */
+@ExtendWith(SuppressOutputExtension.class)
+public class OpenTaskRetentionTest {
+
+  private static final String MODULE = "test-module";
+
+  private static final String PROCESS = "DeliveryProcess";
+
+  private static final String ADAPTER = "test";
+
+  /**
+   * In-memory persistence of the test aggregate plus the H2 database the delivery log
+   * writes its records into - the same shape the inbound-idempotency test uses.
+   */
+  @Configuration
+  static class OpenTaskConfiguration {
+
+    static final Map<String, DeliveryAggregate> AGGREGATES = new ConcurrentHashMap<>();
+
+    @Bean
+    AggregatePersistenceAware<DeliveryAggregate> deliveryPersistence() {
+
+      return new AggregatePersistenceAware<>() {
+
+        @Override
+        public Class<DeliveryAggregate> getAggregateClass() {
+          return DeliveryAggregate.class;
+        }
+
+        @Override
+        public DeliveryAggregate save(
+            final DeliveryAggregate aggregate) {
+          AGGREGATES.put(aggregate.getId(), aggregate);
+          return aggregate;
+        }
+
+        @Override
+        public Object getAggregateId(
+            final DeliveryAggregate aggregate) {
+          return aggregate.getId();
+        }
+
+        @Override
+        public Class<?> getAggregateIdType() {
+          return String.class;
+        }
+
+        @Override
+        public DeliveryAggregate loadById(
+            final Object aggregateId) {
+          return AGGREGATES.get(aggregateId);
+        }
+
+      };
+
+    }
+
+    @Bean
+    DataSource deliveryDataSource() {
+
+      return new EmbeddedDatabaseBuilder()
+          .setType(EmbeddedDatabaseType.H2)
+          .generateUniqueName(true)
+          .build();
+
+    }
+
+    @Bean
+    PlatformTransactionManager transactionManager(
+        final DataSource deliveryDataSource) {
+
+      return new DataSourceTransactionManager(deliveryDataSource);
+
+    }
+
+    @Bean
+    DummyTaskWiringSource deliveryTaskWiringSource() {
+
+      return (
+          adapterId,
+          workflowModuleId,
+          bpmnProcessId) -> PROCESS.equals(bpmnProcessId)
+              ? List
+                  .of(
+                      new BpmnTaskSpec("Activity_Process", "processTask"),
+                      new BpmnTaskSpec("Activity_Error", "raiseBpmnError"),
+                      new BpmnTaskSpec("Activity_Fail", "failTask"),
+                      new BpmnTaskSpec("Activity_Undeduplicated", "undeduplicatedTask"),
+                      new BpmnTaskSpec("Activity_Await", "awaitCompletion"))
+              : List.of();
+
+    }
+
+  }
+
+  /**
+   * An hour of retention and an hour of maximum age: the records are backdated by two, so
+   * both boundaries are crossed without waiting for anything.
+   */
+  private static final String APPLICATION_YAML = """
+      vanillabp:
+        outbox:
+          retention: PT1H
+        delivery:
+          max-task-age: PT1H
+        adapters:
+          test:
+            type: dummy
+            test: 1
+        workflow-modules:
+          test-module:
+            adapters:
+              test:
+                resources-location: classpath*:test-module/processes/delivery
+      """;
+
+  private ConfigurableApplicationContext runTestApplication(
+      final SpringBootTestApplication testApp) {
+
+    return testApp
+        .applicationBuilder(
+            DummyAdapterConfiguration.class,
+            DummyAdapterProcessServiceConfiguration.class,
+            WorkflowModuleAutoConfiguration.class,
+            SpringBootMigrationAdapterAutoConfiguration.class,
+            TestPersistenceConfiguration.class,
+            DeliveryWorkflowService.class,
+            WorkflowModuleConfiguration.class,
+            OpenTaskConfiguration.class,
+            JdbcTaskDeliveryLogAutoConfiguration.class,
+            DeploymentTest.TestConfig.class)
+        .run();
+
+  }
+
+  private SpringBootTestApplication buildTestApp() throws IOException {
+
+    return SpringBootTestApplication.builder()
+        .addResource("META-INF/workflow-module")
+        .addResource("application.yaml", APPLICATION_YAML)
+        .hideResource("META-INF/workflow-module")
+        .hideResource("application.yaml")
+        .build();
+
+  }
+
+  private TaskInvocationContext delivery(
+      final String taskDefinition,
+      final String aggregateId,
+      final String deliveryId) {
+
+    return new TaskInvocationContext() {
+
+      @Override
+      public String getAdapterId() {
+        return ADAPTER;
+      }
+
+      @Override
+      public String getTaskDefinition() {
+        return taskDefinition;
+      }
+
+      @Override
+      public String getWorkflowAggregateId() {
+        return aggregateId;
+      }
+
+      @Override
+      public String getTaskId() {
+        return deliveryId;
+      }
+
+      @Override
+      public String getDeliveryId() {
+        return deliveryId;
+      }
+
+    };
+
+  }
+
+  private void storeAggregate(
+      final String id) {
+
+    final var aggregate = new DeliveryAggregate();
+    aggregate.setId(id);
+    aggregate.setStatus("new");
+    OpenTaskConfiguration.AGGREGATES.put(id, aggregate);
+
+  }
+
+  private JdbcTemplate jdbc(
+      final ConfigurableApplicationContext context) {
+
+    return new JdbcTemplate(context.getBean(DataSource.class));
+
+  }
+
+  private int recordCount(
+      final ConfigurableApplicationContext context,
+      final String aggregateId) {
+
+    return jdbc(context)
+        .queryForObject(
+            "SELECT COUNT(*) FROM %s WHERE AGGREGATE_ID = ?".formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME),
+            Integer.class,
+            aggregateId);
+
+  }
+
+  /**
+   * Moves every record of the table back in time, both of its timestamps - a database two
+   * hours older than the application which reads it.
+   */
+  private void backdateEveryRecordBy(
+      final ConfigurableApplicationContext context,
+      final Duration age) {
+
+    final var moment = Timestamp.from(Instant.now().minus(age));
+    jdbc(context)
+        .update(
+            "UPDATE %s SET RECORDED_AT = ?, LAST_SEEN_AT = ?"
+                .formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME),
+            moment,
+            moment);
+
+  }
+
+  private Timestamp lastSeenAt(
+      final ConfigurableApplicationContext context,
+      final String aggregateId) {
+
+    return jdbc(context)
+        .queryForObject(
+            "SELECT LAST_SEEN_AT FROM %s WHERE AGGREGATE_ID = ?"
+                .formatted(JdbcTaskDeliveryStore.DEFAULT_TABLE_NAME),
+            Timestamp.class,
+            aggregateId);
+
+  }
+
+  @Test
+  @DisplayName("The record of an open task survives the retention, the record of a finished one does not")
+  public void theRecordOfAnOpenTaskSurvivesTheRetention() throws IOException {
+
+    OpenTaskConfiguration.AGGREGATES.clear();
+
+    try (var testApp = buildTestApp(); var context = runTestApplication(testApp)) {
+
+      final var dummyAdapter = context.getBean("DummyAdapter_DeploymentService_test", DeploymentService.class);
+      final var deliveryLog = context.getBean(JdbcTaskDeliveryLog.class);
+
+      // an asynchronous task the application never completes, and an ordinary one which is
+      // done the moment its handler returns
+      storeAggregate("4711");
+      storeAggregate("4712");
+      final var opened = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("processTask", "4712", "job-2"));
+      Assertions.assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, opened.kind());
+      Assertions.assertEquals(1, recordCount(context, "4711"));
+      Assertions.assertEquals(1, recordCount(context, "4712"));
+
+      // two hours later, an hour past the retention and past the maximum age
+      backdateEveryRecordBy(context, Duration.ofHours(2));
+      final var backdated = lastSeenAt(context, "4711");
+
+      // the BPMS renews the lock of the task nobody completed, which is a redelivery
+      final var redelivered = dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+      Assertions.assertEquals(WorkflowTaskOutcome.Kind.COMPLETION_PENDING, redelivered.kind());
+      Assertions
+          .assertEquals(
+              1,
+              OpenTaskConfiguration.AGGREGATES.get("4711").getInvocations(),
+              "the redelivery is answered from the record, the handler ran once");
+      Assertions
+          .assertTrue(
+              redelivered.openFor().compareTo(Duration.ofHours(2)) >= 0,
+              "the age is still measured from the moment the handler ran: "
+                  + redelivered.openFor());
+      Assertions
+          .assertTrue(
+              redelivered.maxAgeExceeded(),
+              "so a task open longer than 'vanillabp.delivery.max-task-age' is still reported");
+
+      // the cleanup writes what the redelivery collected and then deletes what nobody saw
+      final var deleted = deliveryLog.cleanUpExpiredRecords();
+
+      Assertions.assertEquals(1, deleted);
+      Assertions
+          .assertEquals(
+              1,
+              recordCount(context, "4711"),
+              "the task is still being redelivered, so the record answering it stays");
+      Assertions
+          .assertEquals(
+              0,
+              recordCount(context, "4712"),
+              "nobody redelivers a task which is done - its record expires as it always did");
+      Assertions
+          .assertTrue(
+              lastSeenAt(context, "4711").after(backdated),
+              "the moment the record was last seen moved forward");
+
+      // and the record kept alive still does its job
+      dummyAdapter.invokeTask(MODULE, PROCESS, delivery("awaitCompletion", "4711", "job-1"));
+      Assertions
+          .assertEquals(
+              1,
+              OpenTaskConfiguration.AGGREGATES.get("4711").getInvocations(),
+              "which is the whole point: the handler of an open task must not run twice");
+
+    }
+
+  }
+
+}

--- a/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
+++ b/spring-boot-integration/integration-tests/outbox-mongo-integration-test/src/test/java/io/vanillabp/integration/test/outbox/MongoTaskDeliveryLogTest.java
@@ -222,4 +222,80 @@ public class MongoTaskDeliveryLogTest {
 
   }
 
+  /**
+   * A record written the given time ago - both of its timestamps, exactly as the insert
+   * writes them.
+   */
+  private TaskDelivery backdated(
+      final String deliveryKey,
+      final java.time.Duration age) {
+
+    return new TaskDelivery(
+        deliveryKey, "test-module", "TestProcess", "4711", "awaitCompletion", "COMPLETION_PENDING", null, null, java.time.Instant
+            .now()
+            .minus(age));
+
+  }
+
+  @Test
+  @DisplayName("Story 97: the record of a task which is still redelivered survives the retention")
+  public void theRecordOfAnOpenTaskSurvivesTheRetention() {
+
+    // this context runs with a retention of zero, which cannot tell a record kept from one
+    // deleted - a log of its own on the same collection brings the hour this needs
+    final var anHourOfRetention = new MongoTaskDeliveryLog(
+        mongoTemplate, COLLECTION, java.time.Duration.ofHours(1));
+
+    transactionTemplate.executeWithoutResult(status -> {
+      deliveryLog.record(backdated("job-open", java.time.Duration.ofHours(2)));
+      deliveryLog.record(backdated("job-forgotten", java.time.Duration.ofHours(2)));
+    });
+
+    // the BPMS redelivered the open task, which is what the core reports to the store
+    anHourOfRetention.stillOpen("job-open");
+    final var deleted = anHourOfRetention.cleanUpExpiredRecords();
+
+    assertEquals(1, deleted);
+    assertTrue(
+        deliveryLog.recordedDelivery("job-open").isPresent(),
+        "a task which is still being redelivered keeps the record answering it");
+    assertTrue(
+        deliveryLog.recordedDelivery("job-forgotten").isEmpty(),
+        "a record nobody has seen for a whole retention expires");
+
+    final var kept = mongoTemplate
+        .findById("job-open", io.vanillabp.integration.delivery.TaskDeliveryDocument.class, COLLECTION);
+    assertTrue(
+        kept.getLastSeenAt().isAfter(kept.getRecordedAt()),
+        "the moment it was last seen moved, the moment it was recorded did not");
+    assertTrue(
+        kept.getRecordedAt().isBefore(java.time.Instant.now().minus(java.time.Duration.ofMinutes(90))),
+        "so the age of the open task is still measured from the moment the handler ran");
+
+  }
+
+  @Test
+  @DisplayName("Story 97: more open tasks than one block are refreshed in blocks")
+  public void moreOpenTasksThanOneBlockAreRefreshed() {
+
+    final var anHourOfRetention = new MongoTaskDeliveryLog(
+        mongoTemplate, COLLECTION, java.time.Duration.ofHours(1));
+    final var tasks = io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches.BLOCK_SIZE + 100;
+
+    transactionTemplate.executeWithoutResult(status -> {
+      for (var i = 0; i < tasks; i++) {
+        deliveryLog.record(backdated("job-"
+            + i, java.time.Duration.ofHours(2)));
+      }
+    });
+    for (var i = 0; i < tasks; i++) {
+      anHourOfRetention.stillOpen("job-"
+          + i);
+    }
+
+    assertEquals(0, anHourOfRetention.cleanUpExpiredRecords(), "every one of them survives");
+    assertEquals(tasks, mongoTemplate.getCollection(COLLECTION).countDocuments());
+
+  }
+
 }

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/JdbcTaskDeliveryLog.java
@@ -71,14 +71,24 @@ public class JdbcTaskDeliveryLog implements TaskDeliveryLog, JdbcConnectionAcces
   }
 
   /**
-   * Deletes the records whose retention period passed - run by the background cleanup and
-   * usable on demand (e.g. by tests).
+   * Refreshes the records of the open tasks redelivered since the last run and deletes the
+   * records whose retention period passed - run by the background cleanup and usable on
+   * demand (e.g. by tests). Both are the store's business and happen in that order (story
+   * 97).
    *
    * @return The number of records deleted
    */
   public int cleanUpExpiredRecords() {
 
     return store.deleteExpired(retention);
+
+  }
+
+  @Override
+  public void stillOpen(
+      final String deliveryKey) {
+
+    store.stillOpen(deliveryKey);
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLog.java
@@ -5,12 +5,17 @@ import java.time.Instant;
 import java.util.Optional;
 
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.mongodb.core.BulkOperations;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.data.mongodb.core.query.UpdateDefinition;
+import org.springframework.data.util.Pair;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
+import io.vanillabp.integration.adapter.migration.delivery.OpenTaskTouches;
 import io.vanillabp.integration.adapter.migration.delivery.TaskDeliveryRetentionCleanup;
 import io.vanillabp.integration.spi.TaskDelivery;
 import io.vanillabp.integration.spi.TaskDeliveryLog;
@@ -47,6 +52,8 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
 
   private final TaskDeliveryRetentionCleanup retentionCleanup;
 
+  private final OpenTaskTouches touches;
+
   public MongoTaskDeliveryLog(
       final MongoTemplate mongoTemplate,
       final String collection,
@@ -57,6 +64,7 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
     this.retention = retention;
     this.retentionCleanup = new TaskDeliveryRetentionCleanup(
         collection, retention, this::cleanUpExpiredRecords);
+    this.touches = new OpenTaskTouches(collection, this::refreshLastSeen);
 
   }
 
@@ -112,13 +120,17 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
     }
 
     try {
+      // the record was seen the moment it was written; a redelivery of a task which stays
+      // open moves lastSeenAt and leaves recordedAt where it is
+      final var recordedAt = delivery.recordedAt() == null
+          ? Instant.now()
+          : delivery.recordedAt();
       mongoTemplate.insert(
           new TaskDeliveryDocument(
               delivery.deliveryKey(), delivery.workflowModuleId(), delivery.bpmnProcessId(), delivery
                   .workflowAggregateId(), delivery.taskDefinition(), delivery
-                      .outcome(), delivery.bpmnErrorCode(), delivery.bpmnErrorName(), delivery.recordedAt() == null
-                          ? Instant.now()
-                          : delivery.recordedAt()),
+                      .outcome(), delivery.bpmnErrorCode(), delivery
+                          .bpmnErrorName(), recordedAt, recordedAt),
           collection);
       compensateUnlessCommitted(delivery);
       return true;
@@ -215,19 +227,56 @@ public class MongoTaskDeliveryLog implements TaskDeliveryLog {
   }
 
   /**
-   * Deletes the records whose retention period passed - run by the background cleanup and
-   * usable on demand (e.g. by tests).
+   * Refreshes the records of the open tasks redelivered since the last run and deletes the
+   * records nobody has seen for the retention period - run by the background cleanup and
+   * usable on demand (e.g. by tests). Refreshing first is what keeps the record of a task
+   * which is still being redelivered (story 97).
    *
    * @return The number of records deleted
    */
   public long cleanUpExpiredRecords() {
 
+    touches.flush();
+
     return mongoTemplate
         .remove(
-            Query.query(Criteria.where("recordedAt").lt(Instant.now().minus(retention))),
+            Query.query(Criteria.where("lastSeenAt").lt(Instant.now().minus(retention))),
             TaskDeliveryDocument.class,
             collection)
         .getDeletedCount();
+
+  }
+
+  @Override
+  public void stillOpen(
+      final String deliveryKey) {
+
+    touches.remember(deliveryKey);
+
+  }
+
+  /**
+   * Moves <code>lastSeenAt</code> of one block of records, in one unordered bulk write. A
+   * key whose record was deleted meanwhile matches nothing, which is the right answer: the
+   * record is gone and the next redelivery writes a new one.
+   *
+   * @param deliveryKeys The keys of one block
+   */
+  private void refreshLastSeen(
+      final java.util.List<String> deliveryKeys) {
+
+    final var now = Instant.now();
+    mongoTemplate
+        .bulkOps(BulkOperations.BulkMode.UNORDERED, TaskDeliveryDocument.class, collection)
+        .updateOne(
+            deliveryKeys
+                .stream()
+                .map(deliveryKey -> Pair
+                    .of(
+                        Query.query(Criteria.where("_id").is(deliveryKey)),
+                        (UpdateDefinition) Update.update("lastSeenAt", now)))
+                .toList())
+        .execute();
 
   }
 

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
@@ -82,7 +82,8 @@ public class MongoTaskDeliveryLogAutoConfiguration {
     return () -> {
       if (vanillaBpProperties.getOutbox().isCreateSchema()) {
         // the retention deletes by the moment a record was last seen (story 97), so that is
-        // the field the cleanup scans
+        // the field the cleanup scans; MongoDB answers a createIndex of an index which is
+        // already there with its name, so two instances starting together do not collide
         mongoTemplate
             .indexOps(MongoTaskDeliveryLog.DEFAULT_COLLECTION_NAME)
             .createIndex(new Index()

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/MongoTaskDeliveryLogAutoConfiguration.java
@@ -81,10 +81,12 @@ public class MongoTaskDeliveryLogAutoConfiguration {
 
     return () -> {
       if (vanillaBpProperties.getOutbox().isCreateSchema()) {
+        // the retention deletes by the moment a record was last seen (story 97), so that is
+        // the field the cleanup scans
         mongoTemplate
             .indexOps(MongoTaskDeliveryLog.DEFAULT_COLLECTION_NAME)
             .createIndex(new Index()
-                .on("recordedAt", Sort.Direction.ASC));
+                .on("lastSeenAt", Sort.Direction.ASC));
       }
       deliveryLog.start();
     };

--- a/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/TaskDeliveryDocument.java
+++ b/spring-boot-integration/runtime/src/main/java/io/vanillabp/integration/delivery/TaskDeliveryDocument.java
@@ -46,8 +46,16 @@ public class TaskDeliveryDocument {
   private String bpmnErrorName;
 
   /**
-   * When the delivery was processed - the retention cleanup deletes by this field.
+   * When the delivery was processed. The age of an open task is measured from here, so
+   * this value never moves.
    */
   private Instant recordedAt;
+
+  /**
+   * When the BPMS last redelivered the task this record answers, which is what the
+   * retention cleanup deletes by (story 97). Written together with
+   * {@link #recordedAt} and moved forward while an open task keeps being redelivered.
+   */
+  private Instant lastSeenAt;
 
 }


### PR DESCRIPTION
Story 97, stacked on `story/92-adapter-observability` (PR #60) because both touch `MigrationProcessService` and the delivery stores.

## The defect

A task left open by a `@TaskId` handler is answered from the record VanillaBP wrote when the handler ran. That record was deleted once `vanillabp.outbox.retention` passed, seven days by default, and a task open for longer lost it: the next redelivery reached the handler a second time. Story 89 shrank the exposure from fourteen days to the retention, it did not remove it.

## What was built

The record carries a second timestamp. `RECORDED_AT` keeps meaning the moment the handler ran, which is what the age of an open task is measured from, and `LAST_SEEN_AT` carries the moment the BPMS last redelivered that task. The retention deletes by the second one, so a task which is still being redelivered keeps the record answering it while the record of a task nobody hands out any more expires as it always did.

- The trigger belongs to the core, not to an adapter: `MigrationProcessService.stillOpen` runs on every redelivery whose recorded outcome is `COMPLETION_PENDING`, whichever BPMS redelivered, and reports the key through the new `TaskDeliveryLog.stillOpen` default method. A store written by an application inherits a no-op and stays valid.
- Nothing is written there. The redelivery runs in the transaction of the workflow aggregate, so the key lands in `OpenTaskTouches` and the timer which already runs the retention cleanup writes what accumulated. Losing that memory to a crash costs one interval, because a record only expires when a whole retention passes without a single refresh. The memory is bounded for the same reason.
- Writing goes in blocks of 500: one `UPDATE ... SET LAST_SEEN_AT = ? WHERE DELIVERY_KEY = ?` as a JDBC batch instead of an `IN` list, whose length Oracle caps at 1000 expressions and SQL Server at about 2100 parameters. The MongoDB stores of both platforms do the same with an unordered bulk write per block.
- Both rejected alternatives are named in the code for the reason they were rejected: a cleanup skipping `COMPLETION_PENDING` and one collective `UPDATE ... WHERE OUTCOME = 'COMPLETION_PENDING'` would keep the record of a task which never completes alive for good.

## Schema artifact and the startup check

The column is part of `io.vanillabp:vanillabp-schema`: the 2.0.0 changeset of `latest.xml` (still unreleased, so no second changeset) plus the SQL generated from it for all seven databases. The startup check of story 75 looked at the TABLE only, which is exactly the case a new column slips through: a table created by an earlier version exists, the check passed, and the missing column would have surfaced at the first delivery. `validateSchemaExists` and `createSchemaIfNotExists` now verify the columns added later as well, through `JdbcSchema.columnExists`, and the message names the `ALTER TABLE` which repairs such a table.

## Second commit: two instances creating the same table

Found while reading the DDL path. `createSchemaIfNotExists` and the Quarkus outbox' `createTableIfNotExists` ask the metadata and then run the DDL, because `CREATE TABLE IF NOT EXISTS` is not portable. Two instances starting together (a rolling deployment, a scale-up from zero) both see no table and both create it, and the loser got a "table already exists" which ended its boot on Quarkus. A refused DDL now asks the metadata once more, through a connection of its own, and stays quiet where the table is there now. No SQL state is guessed, every database reports that collision differently. The MongoDB stores need nothing: MongoDB answers a `createIndex` of an index which is already there with its name.

## Tests

- Core, JDBC store on H2: the record of a redelivered open task survives while an untouched one expires, both timestamps are asserted, and more keys than one block are refreshed.
- `OpenTaskTouches` as a unit: nothing is written while a delivery runs, blocks of at most 500, a failing block costs only its own keys, the bound holds.
- Startup: the missing column in both paths, and the DDL race with two threads meeting at a barrier between the check and the statement (verified to fail without the fix).
- Acceptance test per platform with the dummy adapter: an open task redelivered after its record was backdated past the retention keeps the record, the task which is done loses it, `openFor` still reports two hours and `max-task-age` still fires.
- MongoDB store of both platforms: the same survival, plus a block beyond 500.

Full build green (`./mvnw -o install verify`, 28:20 min). Coverage: Spring Boot 90.0 %, Quarkus 87.5 % overall; `OpenTaskTouches` 100 %.

The Camunda 8 adapter needs nothing, checked in its code rather than assumed: `Camunda8JobHandler` reads `openFor` and `maxAgeExceeded` of the outcome, and both keep being measured from `RECORDED_AT`. Camunda 7 and the Process-Engine-API do not touch delivery records at all.

Wiki: `11df8e6` on `feature/finalize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
