### PR TITLE
feat(workflowtask): report the @TaskParam names of a task to the adapters

### DIFF
--- a/migration-adapter/README.md
+++ b/migration-adapter/README.md
@@ -363,6 +363,36 @@ and that adapter does not process workflows). A failure of the first-priority ad
 always fails the boot, regardless of the policy, because new workflows could not be
 started otherwise.
 
+#### The variables a handler reads (`taskParameterNames`, story 99)
+
+A `@TaskParam` takes what the BPMS GENERATED on this path through the model: the target of
+an input or output mapping, the result of a script or a decision, a value the model
+computed rather than the workflow aggregate holds. Most applications need none of it, and
+it can never be ruled out, because a model may produce a value the application has to see.
+
+Those names exist in exactly one place, and it is here. `WorkflowTaskScanner` reads them
+off the annotations while it builds the parameter binders, `WorkflowTaskHandler` keeps them
+and `WorkflowTaskRegistry#taskParameterNames(module, process, taskDefinitionOrActivityId)`
+reports the union over every handler serving that element - a union, because methods
+serving different process versions share one BPMN element and whichever of them runs has to
+find its variable. The list is sorted and duplicate-free, which a subscription comparing
+itself across restarts needs (a Camunda 8 job stream is equivalent to another one only when
+the fetched variables match).
+
+Why the core has to say it: at runtime an adapter pulls the values one name at a time
+through `TaskInvocationContext#getTaskParameter(name)`, and by then the delivery has already
+happened. A BPMS which ships a variable payload with every delivery has to know the names
+BEFORE it subscribes, and the only other place it could look is the BPMN model - which is a
+guess, since the model may declare names nobody reads and a handler may read a name no model
+declares. Camunda 8 derived the list that way between stories 93 and 99; the model scan is
+gone with this story rather than kept as a second source for one answer.
+
+The method is a `default` returning an empty collection, so an adapter which never heard of
+it keeps the behaviour it had. BPMS-initiated starts deliberately have no counterpart: the
+core copies EVERY variable such a start carries into the workflow aggregate it builds
+(`BpmsInitiatedStartExecution#writeVariables`), so a start worker has to ask for all of them
+regardless of what any `@TaskParam` names.
+
 #### Deliveries VanillaBP already processed (`TaskDeliveryLog` SPI, story 51)
 
 The inbound counterpart of the outbox. A remote BPMS reports the outcome AFTER the

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskHandler.java
@@ -66,6 +66,14 @@ public class WorkflowTaskHandler {
   private final java.util.Set<io.vanillabp.spi.service.TaskEvent.Event> subscribedEvents;
 
   /**
+   * The process variables the method reads with <code>&#64;TaskParam</code>, sorted and
+   * duplicate-free (story 99). The core reports them to the adapters through
+   * {@link io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker#taskParameterNames},
+   * so a BPMS delivering a variable payload knows what to put into it.
+   */
+  private final List<String> taskParameters;
+
+  /**
    * Whether some BPMN task matched this handler during wiring validation - input
    * for the per-module unwired-methods check (a handler registered under several
    * BPMN processes via {@code secondaryBpmnProcesses} legitimately matches in only
@@ -82,7 +90,8 @@ public class WorkflowTaskHandler {
       final String activityId,
       final List<VersionRange> versions,
       final boolean asynchronousTask,
-      final java.util.Set<io.vanillabp.spi.service.TaskEvent.Event> subscribedEvents) {
+      final java.util.Set<io.vanillabp.spi.service.TaskEvent.Event> subscribedEvents,
+      final List<String> taskParameters) {
 
     this.workflowServiceClass = workflowServiceClass;
     this.method = method;
@@ -93,6 +102,16 @@ public class WorkflowTaskHandler {
     this.versions = versions;
     this.asynchronousTask = asynchronousTask;
     this.subscribedEvents = subscribedEvents;
+    this.taskParameters = taskParameters;
+
+  }
+
+  /**
+   * @return The process variables the method reads with <code>&#64;TaskParam</code>
+   */
+  List<String> getTaskParameters() {
+
+    return taskParameters;
 
   }
 

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskRegistry.java
@@ -788,6 +788,32 @@ public class WorkflowTaskRegistry implements WorkflowTaskInvoker, BpmsInitiatedS
 
   }
 
+  @Override
+  public Collection<String> taskParameterNames(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinitionOrActivityId) {
+
+    final var entry = entries.get(new RegistryKey(workflowModuleId, bpmnProcessId));
+    if (entry == null) {
+      return List.of();
+    }
+    // the UNION over every method serving this element: methods wired to one BPMN
+    // element differ in the process version they serve (story 48), and the delivery
+    // has to satisfy whichever of them runs. Sorted, because a subscription which
+    // names variables is compared to itself across restarts
+    return entry.handlers
+        .stream()
+        .filter(candidate -> sameWiring(candidate.getTaskDefinition(),
+            taskDefinitionOrActivityId) || sameWiring(candidate.getActivityId(), taskDefinitionOrActivityId))
+        .map(WorkflowTaskHandler::getTaskParameters)
+        .flatMap(List::stream)
+        .distinct()
+        .sorted()
+        .toList();
+
+  }
+
   /**
    * The sentence a delivery from an OUTFADED version deserves - without it the
    * developer reads "no method matches" and looks for a wiring defect, while the

--- a/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
+++ b/migration-adapter/runtime/src/main/java/io/vanillabp/integration/adapter/migration/workflowtask/WorkflowTaskScanner.java
@@ -87,6 +87,17 @@ class WorkflowTaskScanner {
       if (subscribedEvents.isEmpty()) {
         subscribedEvents.add(TaskEvent.Event.CREATED);
       }
+      // story 99: the process variables the method reads - the core is the only place
+      // these names exist, and an adapter whose BPMS ships a variable payload with
+      // every delivery needs them to keep that payload at what is read
+      final var taskParameters = Arrays
+          .stream(method.getParameters())
+          .map(parameter -> parameter.getAnnotation(TaskParam.class))
+          .filter(java.util.Objects::nonNull)
+          .map(TaskParam::value)
+          .distinct()
+          .sorted()
+          .toList();
       for (final var annotation : annotations) {
         handlers.add(buildHandler(
             workflowServiceClass,
@@ -95,7 +106,8 @@ class WorkflowTaskScanner {
             binders,
             annotation,
             asynchronousTask,
-            subscribedEvents));
+            subscribedEvents,
+            taskParameters));
       }
     }
     if (!transactionDefects.isEmpty()) {
@@ -148,7 +160,8 @@ class WorkflowTaskScanner {
       final List<ParameterBinder> binders,
       final WorkflowTask annotation,
       final boolean asynchronousTask,
-      final java.util.Set<TaskEvent.Event> subscribedEvents) {
+      final java.util.Set<TaskEvent.Event> subscribedEvents,
+      final List<String> taskParameters) {
 
     final var location = "%s#%s".formatted(workflowServiceClass.getName(), method.getName());
     // a public method of a package-private bean class is not accessible through
@@ -176,7 +189,7 @@ class WorkflowTaskScanner {
         .map(version -> VersionRange.parse(version, location))
         .toList();
     return new WorkflowTaskHandler(
-        workflowServiceClass, method, workflowServiceBean, binders, taskDefinition, activityId, versions, asynchronousTask, subscribedEvents);
+        workflowServiceClass, method, workflowServiceBean, binders, taskDefinition, activityId, versions, asynchronousTask, subscribedEvents, taskParameters);
 
   }
 

--- a/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
+++ b/migration-adapter/runtime/src/test/java/io/vanillabp/migration/test/workflowtask/WorkflowTaskRegistryTest.java
@@ -1029,6 +1029,175 @@ public class WorkflowTaskRegistryTest {
 
   }
 
+  /**
+   * Two methods serving ONE BPMN element in different process versions, each reading a
+   * variable of its own - what a subscription serving that element has to bring along.
+   */
+  static class ParameterizedVersionsService {
+
+    @WorkflowTask(taskDefinition = "parameterized", version = "1")
+    public void firstVersion(
+        final Aggregate aggregate,
+        @TaskParam("ratingProvider") final String ratingProvider) {
+
+      aggregate.parameterValue = ratingProvider;
+
+    }
+
+    @WorkflowTask(taskDefinition = "parameterized", version = ">1")
+    public void laterVersions(
+        final Aggregate aggregate,
+        @TaskParam("rating") final String rating,
+        @TaskParam("ratingProvider") final String ratingProvider) {
+
+      aggregate.parameterValue = rating + ratingProvider;
+
+    }
+
+  }
+
+  @Nested
+  @DisplayName("Declared task parameters (story 99)")
+  class DeclaredTaskParameters {
+
+    @Test
+    @DisplayName("The names of a method's @TaskParam parameters are reported to the adapter")
+    public void theDeclaredNamesAreReported() {
+
+      assertEquals(
+          List.of("status"),
+          List.copyOf(registry.taskParameterNames(MODULE, PROCESS, "withBindings")),
+          "the adapter cannot see what a method reads - the core scanned it while wiring");
+
+    }
+
+    @Test
+    @DisplayName("A method reading nothing but its aggregate declares no parameter")
+    public void aMethodWithoutTaskParamDeclaresNothing() {
+
+      assertTrue(registry.taskParameterNames(MODULE, PROCESS, "doSomething").isEmpty());
+
+    }
+
+    @Test
+    @DisplayName("A method wired by activity ID is found by that ID")
+    public void anActivityIdWiringIsAnsweredToo() {
+
+      assertTrue(registry.taskParameterNames(MODULE, PROCESS, "Activity_4711").isEmpty());
+      assertTrue(registry.taskParameterNames(MODULE, PROCESS, "unknownTask").isEmpty());
+      assertTrue(registry.taskParameterNames(MODULE, "UnknownProcess", "withBindings").isEmpty());
+
+    }
+
+    @Test
+    @DisplayName("Several methods serving one element contribute the UNION of their parameters")
+    public void theUnionOfEveryMethodServingTheElement() {
+
+      registry.registerWorkflowService(
+          MODULE,
+          "ParameterizedProcess",
+          ParameterizedVersionsService.class,
+          ParameterizedVersionsService::new,
+          beans::get,
+          createProcessService());
+
+      assertEquals(
+          List.of("rating", "ratingProvider"),
+          List.copyOf(registry.taskParameterNames(MODULE, "ParameterizedProcess", "parameterized")),
+          "whichever version is delivered has to find its variable, and the list is sorted so a "
+              + "subscription naming it stays the same across restarts");
+
+    }
+
+    @Test
+    @DisplayName("An adapter not implementing the SPI method sees the previous behaviour")
+    public void theDefaultAnswersNothing() {
+
+      final var untouched = new io.vanillabp.integration.adapter.spi.workflowtask.WorkflowTaskInvoker() {
+
+        @Override
+        public void validateTaskWiring(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final java.util.Collection<BpmnTaskSpec> tasks) {
+        }
+
+        @Override
+        public void validateNoUnwiredWorkflowTaskMethods(
+            final String workflowModuleId) {
+        }
+
+        @Override
+        public WorkflowTaskOutcome invokeWorkflowTask(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final TaskInvocationContext context) {
+
+          return null;
+
+        }
+
+        @Override
+        public boolean workflowAggregateHasProperty(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final String propertyName) {
+
+          return false;
+
+        }
+
+        @Override
+        public Object resolveWorkflowAggregateProperty(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final String workflowAggregateId,
+            final String propertyName) {
+
+          return null;
+
+        }
+
+        @Override
+        public boolean workflowTaskHandlerExists(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final String taskDefinitionOrActivityId) {
+
+          return false;
+
+        }
+
+        @Override
+        public Map<String, Object> syncedWorkflowAggregateValues(
+            final String workflowModuleId,
+            final String bpmnProcessId,
+            final String workflowAggregateId,
+            final io.vanillabp.integration.adapter.spi.AggregateSyncMode adapterDefault) {
+
+          return Map.of();
+
+        }
+
+        @Override
+        public String resolveWorkflowAggregateIdName(
+            final String workflowModuleId,
+            final String bpmnProcessId) {
+
+          return "id";
+
+        }
+
+      };
+
+      assertTrue(
+          untouched.taskParameterNames(MODULE, PROCESS, "withBindings").isEmpty(),
+          "the SPI method is additive: an adapter which never heard of it keeps the behaviour it had");
+
+    }
+
+  }
+
   @Nested
   @DisplayName("Wiring validation")
   class WiringValidation {

--- a/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
+++ b/migration-adapter/spi/src/main/java/io/vanillabp/integration/adapter/spi/workflowtask/WorkflowTaskInvoker.java
@@ -236,6 +236,44 @@ public interface WorkflowTaskInvoker {
       String taskDefinitionOrActivityId);
 
   /**
+   * The process variables the <code>&#64;WorkflowTask</code> method(s) serving the
+   * given task definition (or BPMN activity ID) read with
+   * <code>&#64;TaskParam</code> - the names as the annotation spells them.
+   * <p>
+   * A <code>&#64;TaskParam</code> is how the application reads what the BPMS
+   * GENERATED on this path: a value an input or output mapping produced, the result
+   * of a script or a decision, something the model computed rather than the
+   * workflow aggregate holds. A BPMS which hands its worker a variable payload has
+   * to know these names to keep that payload down to what is actually read, and the
+   * core is the only place they exist - the adapter sees a
+   * {@link TaskInvocationContext#getTaskParameter(String)} call one name at a time,
+   * and only once the delivery is already there.
+   * <p>
+   * Several methods may serve one element (different process versions, story 48), so
+   * the answer is the UNION of their parameters: the delivery has to satisfy
+   * whichever of them runs. The names are sorted and duplicate-free, which is what a
+   * subscription comparing itself across restarts needs (a Camunda 8 job stream is
+   * equivalent to another one only if the fetched variables match).
+   * <p>
+   * The default answers nothing, which switches the derivation off rather than
+   * making an adapter fetch an incomplete list.
+   *
+   * @param workflowModuleId The workflow module ID
+   * @param bpmnProcessId The BPMN process ID
+   * @param taskDefinitionOrActivityId The task definition or BPMN activity ID
+   * @return The declared parameter names, sorted; empty if no method is registered
+   *         or none of them declares a <code>&#64;TaskParam</code>
+   */
+  default Collection<String> taskParameterNames(
+      final String workflowModuleId,
+      final String bpmnProcessId,
+      final String taskDefinitionOrActivityId) {
+
+    return java.util.List.of();
+
+  }
+
+  /**
    * Whether two BPMN processes of one workflow module work on the SAME workflow
    * aggregate - which is what the declaration says: one class declares the process
    * to be started as its {@code bpmnProcess} and the others as


### PR DESCRIPTION
Story 99. The core knows which process variables a handler asks for, and until now it told no adapter.

## Why

A `@TaskParam` takes what the BPMS GENERATED on an execution path: the target of a mapping, the result of a script or a decision, a value the model computed rather than the workflow aggregate holds. Rare, because the aggregate is the source of truth, and never to be ruled out, because a BPMS may produce a value the application has to see.

A BPMS which ships a variable payload with every delivery has to know those names before it subscribes. Nobody told it: at runtime the adapter pulls values one name at a time through `TaskInvocationContext#getTaskParameter`, long after the delivery happened. Camunda 8 therefore derived the list from the deployed models (story 93), which is a guess in both directions - a model declares names nobody reads, and a handler may read a name no model declares.

## What

`WorkflowTaskScanner` already reads `@TaskParam#value()` while it builds the parameter binders. `WorkflowTaskHandler` keeps the names now, and the new SPI method

```java
default Collection<String> taskParameterNames(
    String workflowModuleId, String bpmnProcessId, String taskDefinitionOrActivityId)
```

reports the union over every handler serving that element - a union, because methods serving different process versions share one BPMN element and whichever of them runs has to find its variable. Sorted and duplicate-free, which a subscription comparing itself across restarts needs (a Camunda 8 job stream is equivalent to another one only when the fetched variables match).

Additive, with a default answering nothing: an adapter which never heard of the method behaves exactly as before.

## What deliberately did not happen

BPMS-initiated starts get no counterpart. The core copies EVERY variable such a start carries into the workflow aggregate it builds (`BpmsInitiatedStartExecution#writeVariables`), so a start worker has to ask for all of them regardless of what any `@TaskParam` names - the method would be dead code.

## Tests

`WorkflowTaskRegistryTest`, nested class `Declared task parameters (story 99)`: the declared names, a method reading nothing, wiring by activity id, the union over two methods serving one element in different versions, and the default of an SPI implementation which does not override it. `mvn test -pl migration-adapter/runtime` green (452 tests).

## Merge order

The two adapter PRs consume this method and compile against the platform snapshot, so they need this merged and the snapshot published from `main` first:

- vanillabp/camunda8-adapter (drops the model scan of story 93)
- vanillabp/process-engine-api-adapter (stops subscribing with an empty payload set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7HLKaJvVpdCiSYxhwHJTc